### PR TITLE
docs: dokumentiere UI-Umlaut-Prüfung

### DIFF
--- a/docs/design-system/ui-umlaut-korrekturen-2026-04-10.md
+++ b/docs/design-system/ui-umlaut-korrekturen-2026-04-10.md
@@ -1,0 +1,42 @@
+# UI-Umlaut-Korrekturen und Sichtprüfung vom 2026-04-10
+
+## Zweck
+
+Dieses Dokument hält die am 2026-04-10 vorgenommenen **Umlaut-Korrekturen in sichtbaren UI-Texten** sowie die anschliessende **visuelle Prüfung der gerenderten Darstellung** fest. Es ersetzt lose Arbeitsnotizen durch eine nachvollziehbare, versionierbare Projekt-Dokumentation im Repository.
+
+## Umfang der inhaltlichen Korrekturen
+
+Die Bereinigung bezog sich gezielt auf **sichtbar gerenderte deutsche Website-Texte**. Technische Bezeichner, Hash-Namen, URLs sowie bewusst nicht freigegebene Download-Textvorlagen wurden nicht pauschal umgeschrieben, damit keine unbeabsichtigten Seiteneffekte in Routing, Verlinkungen oder Dateinamen entstehen.
+
+| Bereich | Betroffene Dateien | Dokumentierter Zweck |
+|---|---|---|
+| Shell / Footer | `src/data/appShellContent.js`, `src/components/Footer.jsx` | Korrektur sichtbarer Navigations- und Footer-Texte |
+| Glossar | `src/data/glossaryContent.js` | Korrektur sichtbarer Glossar-Begriffe und Definitionen |
+| Grundlagen | `src/data/grundlagenContent.js`, `src/sections/GrundlagenSection.jsx` | Korrektur sichtbarer Einordnungs- und Bereichstexte |
+| Lernmodule | `src/sections/ElearningSection.jsx`, `src/templates/LearningPageTemplate.jsx` | Korrektur sichtbarer Lernmodul- und Rückmeldungstexte |
+| Netzwerk | `src/sections/NetworkSection.jsx`, `src/templates/NetworkPageTemplate.jsx` | Korrektur sichtbarer Netzwerk- und Hilfetexte |
+| Vignetten | `src/sections/VignettenSection.jsx` | Korrektur sichtbarer Fall- und Auswahltexte |
+
+## Beispiele der bereinigten Schreibungen
+
+Im Zuge der Bereinigung wurden typische Umschreibungen wie `fuer`, `naechste`, `ueber`, `Angehoerige`, `Gespraech`, `Zurueck`, `Luecken`, `Ergaenzungen`, `Einschaetzung` oder `waere` in korrekte deutsche Schreibungen mit Umlauten überführt, soweit sie in **sichtbaren UI-Texten** erschienen.
+
+## Ergebnis der visuellen Prüfung
+
+Die gerenderte Website wurde nach den Korrekturen in mehreren Bereichen visuell geprüft. Die Darstellung war dabei konsistent und unauffällig.
+
+| Geprüfter Bereich | Ergebnis der Sichtprüfung |
+|---|---|
+| Startseite | Umlaute werden korrekt dargestellt, unter anderem in `für`, `psychischer Belastung`, `Angehörigenberatung`, `Nächste Schritte konkret machen` sowie in Shell-Kacheln wie `Kurzformate für Fachpraxis` |
+| Lernmodule | Korrekte Darstellung unter anderem in `Gesprächsführung`, `führt`, `Zuletzt geprüft` und `für ruhige fachliche Reflexion` |
+| Glossar | Korrekte Darstellung unter anderem in `Einträge`, `für Praxis`, `Teamgespräch`, `Versorgungsalltag`, `Kinderschutz`, `Angehörigenarbeit` und `Gespräch` |
+| Footer | Korrekte Darstellung unter anderem in `Kurzformate für Fachpraxis`, `Triage, Schutz, nächste Schritte`, `Hilfen, Stellen, Weitervermittlung` sowie in begleitendem Fliesstext |
+| Netzwerk | Korrekte Darstellung unter anderem in `Zürich`, `mehrsprachig`, `Lücken`, `nächste Schritte` und `schweizweite Ergänzungen` |
+
+## Abgrenzung
+
+Die Prüfung ergab zuletzt, dass verbleibende Treffer mit Zeichenfolgen wie `ae`, `oe` oder `ue` überwiegend auf **technische IDs**, **URLs**, **Hash-Namen** wie `zuerich` oder auf bewusst nicht angepasste **Download-Textvorlagen** zurückgingen. Diese Stellen wurden nicht automatisch verändert.
+
+## Git-Bezug
+
+Die eigentlichen inhaltlichen UI-Korrekturen wurden unter der Commit-Nachricht `fix(content): korrigiere Umlaute in sichtbaren UI-Texten` in den Projektverlauf übernommen. Dieses Dokument ergänzt die inhaltliche Änderung um eine kompakte, dauerhafte Nachvollziehbarkeits- und Prüfspur.


### PR DESCRIPTION
## Zusammenfassung
- überführt die lokalen Arbeitsnotizen zur Umlaut-Kontrolle in eine bereinigte Repository-Dokumentation
- dokumentiert Umfang, Abgrenzung und Sichtprüfung der UI-Umlaut-Korrekturen vom 2026-04-10
- ergänzt die bereits gemergten Inhaltskorrekturen um eine dauerhafte Prüfspur

## Hinweise
- technische IDs, URLs und bewusst ausgenommene Download-Textvorlagen bleiben unverändert
- die eigentlichen UI-Korrekturen wurden bereits zuvor über PR #1 in  übernommen