### PR TITLE
fix(security): sanitize dangerouslySetInnerHTML with DOMPurify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "relational-recovery",
       "version": "0.1.0",
       "dependencies": {
+        "dompurify": "^3.3.3",
         "lucide-react": "^0.542.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -1476,6 +1477,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
@@ -1598,6 +1606,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "dompurify": "^3.3.3",
     "lucide-react": "^0.542.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 // Design note: This file preserves the application's information architecture while the visual language is shifted toward a warm editorial interface with calmer surfaces, serif-led hierarchy and lower-arousal accents.
 import React, { lazy, Suspense, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import DOMPurify from 'dompurify';
 import './styles/app-global.css';
 import { AlertTriangle, ShieldCheck } from 'lucide-react';
 import Header from './components/Header';
@@ -135,7 +136,7 @@ function ToolboxPrintPage() {
 
   return (
     <div className="min-h-screen bg-white text-slate-900">
-      <main className="print-shell" dangerouslySetInnerHTML={{ __html: payload.html }} />
+      <main className="print-shell" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(payload.html) }} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **P0 Security Fix**: Die Toolbox-Print-View renderte HTML aus `localStorage` via `dangerouslySetInnerHTML` ohne Sanitization — ein XSS-Vektor.
- `dompurify` als Dependency hinzugefügt und `DOMPurify.sanitize()` vor dem Rendering angewendet.
- Minimale Änderung (3 Zeilen), kein Funktionalitätsverlust.

## Test plan
- [ ] Toolbox öffnen, Arbeitsansicht drucken → Print-View rendert korrekt
- [ ] `npm run build` läuft fehlerfrei durch

https://claude.ai/code/session_01YKq9W9S6WmYrvGXvM3Hn5q