### PR TITLE
chore: add ESLint + Prettier, remove dead code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 output
 tmp/
 pnpm-lock.yaml
+test-results/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 120,
+  "tabWidth": 2,
+  "semi": true
+}

--- a/e2e/assessment-score.spec.js
+++ b/e2e/assessment-score.spec.js
@@ -29,9 +29,7 @@ test.describe('Assessment Score', () => {
     await checkboxFor(page, ITEMS[0].label).check({ force: true });
 
     await expect(page.locator('.ui-toolbox-score')).toHaveText(String(ITEMS[0].val));
-    await expect(page.locator('#assessment-score-status')).toContainText(
-      `Aktueller Assessment-Score: ${ITEMS[0].val}`
-    );
+    await expect(page.locator('#assessment-score-status')).toContainText(`Aktueller Assessment-Score: ${ITEMS[0].val}`);
   });
 
   test('unchecking an item decreases the score', async ({ page }) => {
@@ -39,9 +37,7 @@ test.describe('Assessment Score', () => {
     await expect(page.locator('.ui-toolbox-score')).toHaveText(String(ITEMS[0].val));
 
     await checkboxFor(page, ITEMS[0].label).uncheck({ force: true });
-    await expect(page.locator('#assessment-score-status')).toContainText(
-      'Aktueller Assessment-Score: 0'
-    );
+    await expect(page.locator('#assessment-score-status')).toContainText('Aktueller Assessment-Score: 0');
   });
 
   test('risk band transitions: supportive → caution → danger', async ({ page }) => {
@@ -72,9 +68,7 @@ test.describe('Assessment Score', () => {
     }
 
     await expect(page.locator('.ui-toolbox-score')).toHaveText('10');
-    await expect(page.locator('#assessment-score-status')).toContainText(
-      'Hinweis auf Schutzabklärung'
-    );
+    await expect(page.locator('#assessment-score-status')).toContainText('Hinweis auf Schutzabklärung');
   });
 
   test('reset button clears score and unchecks all items', async ({ page }) => {
@@ -85,9 +79,7 @@ test.describe('Assessment Score', () => {
 
     await page.locator('button', { hasText: 'Assessment zurücksetzen' }).click();
 
-    await expect(page.locator('#assessment-score-status')).toContainText(
-      'Aktueller Assessment-Score: 0'
-    );
+    await expect(page.locator('#assessment-score-status')).toContainText('Aktueller Assessment-Score: 0');
 
     const checkboxes = page.locator('fieldset.ui-toolbox-checklist input[type="checkbox"]');
     const count = await checkboxes.count();
@@ -113,10 +105,14 @@ test.describe('Assessment Score', () => {
     await expect(page.locator('.ui-toolbox-score')).toHaveText('5');
 
     // Navigate away and back using hash (reliable, layout-independent)
-    await page.evaluate(() => { window.location.hash = '#start'; });
+    await page.evaluate(() => {
+      window.location.hash = '#start';
+    });
     await expect(page.locator('#page-heading-start')).toBeVisible();
 
-    await page.evaluate(() => { window.location.hash = '#toolbox'; });
+    await page.evaluate(() => {
+      window.location.hash = '#toolbox';
+    });
     await page.waitForSelector('fieldset.ui-toolbox-checklist');
 
     await expect(page.locator('.ui-toolbox-score')).toHaveText('5');

--- a/e2e/navigation.spec.js
+++ b/e2e/navigation.spec.js
@@ -18,7 +18,9 @@ const TABS = [
 // and verify the handler wiring separately.
 
 async function navigateViaHash(page, tabId) {
-  await page.evaluate((id) => { window.location.hash = `#${id}`; }, tabId);
+  await page.evaluate((id) => {
+    window.location.hash = `#${id}`;
+  }, tabId);
 }
 
 test.describe('Tab Navigation', () => {
@@ -45,12 +47,15 @@ test.describe('Tab Navigation', () => {
   test('active tab button has aria-current="page"', async ({ page }) => {
     await navigateViaHash(page, 'toolbox');
 
-    await expect(
-      page.locator('nav.ui-nav--desktop button', { hasText: 'Toolbox' })
-    ).toHaveAttribute('aria-current', 'page');
+    await expect(page.locator('nav.ui-nav--desktop button', { hasText: 'Toolbox' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
 
     // Inactive tab should NOT have aria-current attribute
-    const ariaCurrent = await page.locator('nav.ui-nav--desktop button', { hasText: 'Start' }).getAttribute('aria-current');
+    const ariaCurrent = await page
+      .locator('nav.ui-nav--desktop button', { hasText: 'Start' })
+      .getAttribute('aria-current');
     expect(ariaCurrent).toBeNull();
   });
 
@@ -81,8 +86,8 @@ test.describe('Tab Navigation', () => {
     // Verify each nav button has a React onClick that calls navigateToTab
     const result = await page.evaluate(() => {
       const buttons = document.querySelectorAll('nav.ui-nav--desktop button');
-      return Array.from(buttons).map(btn => {
-        const propsKey = Object.keys(btn).find(k => k.startsWith('__reactProps$'));
+      return Array.from(buttons).map((btn) => {
+        const propsKey = Object.keys(btn).find((k) => k.startsWith('__reactProps$'));
         return {
           text: btn.textContent.trim(),
           hasOnClick: propsKey ? typeof btn[propsKey].onClick === 'function' : false,
@@ -138,7 +143,9 @@ test.describe('Hash Routing', () => {
 
   test('hashchange event triggers tab switch', async ({ page }) => {
     await page.goto('/');
-    await page.evaluate(() => { window.location.hash = '#glossar'; });
+    await page.evaluate(() => {
+      window.location.hash = '#glossar';
+    });
     const activeBtn = page.locator('nav.ui-nav--desktop button.is-active');
     await expect(activeBtn).toContainText('Glossar');
   });
@@ -151,8 +158,8 @@ test.describe('Logo / Home Navigation', () => {
     await expect(page).toHaveURL(/#glossar/);
 
     // Verify logo button has correct onClick wired, then navigate via hash
-    const hasHandler = await page.locator('button.ui-brand').evaluate(btn => {
-      const propsKey = Object.keys(btn).find(k => k.startsWith('__reactProps$'));
+    const hasHandler = await page.locator('button.ui-brand').evaluate((btn) => {
+      const propsKey = Object.keys(btn).find((k) => k.startsWith('__reactProps$'));
       return propsKey ? typeof btn[propsKey].onClick === 'function' : false;
     });
     expect(hasHandler).toBe(true);
@@ -175,8 +182,8 @@ test.describe('Emergency Access', () => {
     await expect(emergencyBtn).toBeVisible();
 
     // Verify it has a click handler
-    const hasHandler = await emergencyBtn.evaluate(btn => {
-      const propsKey = Object.keys(btn).find(k => k.startsWith('__reactProps$'));
+    const hasHandler = await emergencyBtn.evaluate((btn) => {
+      const propsKey = Object.keys(btn).find((k) => k.startsWith('__reactProps$'));
       return propsKey ? typeof btn[propsKey].onClick === 'function' : false;
     });
     expect(hasHandler).toBe(true);
@@ -194,7 +201,10 @@ test.describe('Session Reset', () => {
     await page.waitForSelector('fieldset.ui-toolbox-checklist');
 
     // Check an assessment item
-    const checkbox = page.locator('label').filter({ hasText: 'Ungeplanter Eintritt / Krise' }).locator('input[type="checkbox"]');
+    const checkbox = page
+      .locator('label')
+      .filter({ hasText: 'Ungeplanter Eintritt / Krise' })
+      .locator('input[type="checkbox"]');
     await checkbox.check({ force: true });
     await expect(page.locator('.ui-toolbox-score')).toHaveText('2');
 
@@ -210,9 +220,7 @@ test.describe('Session Reset', () => {
     await navigateViaHash(page, 'toolbox');
     await page.waitForSelector('fieldset.ui-toolbox-checklist');
 
-    await expect(page.locator('#assessment-score-status')).toContainText(
-      'Aktueller Assessment-Score: 0'
-    );
+    await expect(page.locator('#assessment-score-status')).toContainText('Aktueller Assessment-Score: 0');
   });
 });
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,44 @@
+import js from '@eslint/js';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import prettier from 'eslint-config-prettier';
+
+export default [
+  { ignores: ['dist/', 'node_modules/', 'qa/', 'qa-artifacts/', 'scripts/'] },
+  js.configs.recommended,
+  {
+    files: ['**/*.{js,jsx}'],
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      globals: {
+        window: 'readonly',
+        document: 'readonly',
+        localStorage: 'readonly',
+        console: 'readonly',
+        crypto: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        URL: 'readonly',
+        URLSearchParams: 'readonly',
+        Blob: 'readonly',
+        BroadcastChannel: 'readonly',
+        MutationObserver: 'readonly',
+        navigator: 'readonly',
+      },
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-hooks/refs': 'off',
+      'react-hooks/preserve-manual-memoization': 'off',
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+    },
+  },
+  prettier,
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,17 +8,22 @@
       "name": "relational-recovery",
       "version": "0.1.0",
       "dependencies": {
-        "dompurify": "^3.3.3",
         "lucide-react": "^0.542.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.52.0",
         "@tailwindcss/vite": "^4.1.0",
         "@vitejs/plugin-react": "^5.0.2",
+        "eslint": "^10.2.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-refresh": "^0.5.2",
         "playwright-core": "^1.59.1",
+        "prettier": "^3.8.2",
         "tailwindcss": "^4.1.0",
         "vite": "^7.1.4"
       }
@@ -745,6 +750,186 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1487,6 +1672,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1494,12 +1686,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -1522,6 +1714,56 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.13",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
@@ -1533,6 +1775,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1597,6 +1852,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1615,6 +1885,13 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1623,15 +1900,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1707,6 +1975,238 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
+      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.4",
+        "@eslint/config-helpers": "^0.5.4",
+        "@eslint/core": "^1.2.0",
+        "@eslint/plugin-kit": "^0.7.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz",
+      "integrity": "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1724,6 +2224,57 @@
           "optional": true
         }
       }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1750,10 +2301,90 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
@@ -1787,6 +2418,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1798,6 +2450,30 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -2061,6 +2737,22 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2090,6 +2782,22 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2116,12 +2824,89 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2232,6 +3017,42 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -2324,6 +3145,29 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2381,6 +3225,19 @@
         "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -2410,6 +3267,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/vite": {
@@ -2487,12 +3354,74 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,20 +7,29 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test:e2e": "npx playwright test"
+    "test:e2e": "npx playwright test",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write \"src/**/*.{js,jsx,css}\" \"e2e/**/*.js\"",
+    "format:check": "prettier --check \"src/**/*.{js,jsx,css}\" \"e2e/**/*.js\""
   },
   "dependencies": {
-    "dompurify": "^3.3.3",
     "lucide-react": "^0.542.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.52.0",
     "@tailwindcss/vite": "^4.1.0",
     "@vitejs/plugin-react": "^5.0.2",
+    "eslint": "^10.2.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.5.2",
     "playwright-core": "^1.59.1",
+    "prettier": "^3.8.2",
     "tailwindcss": "^4.1.0",
     "vite": "^7.1.4"
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 // Design note: This file preserves the application's information architecture while the visual language is shifted toward a warm editorial interface with calmer surfaces, serif-led hierarchy and lower-arousal accents.
-import React, { lazy, Suspense, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import DOMPurify from 'dompurify';
+import { lazy, Suspense, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import './styles/app-global.css';
 import { AlertTriangle, ShieldCheck } from 'lucide-react';
 import Header from './components/Header';
@@ -24,7 +23,6 @@ import {
   normalizeAppStateData,
   normalizeHashToTab,
   safeLocalStorageSet,
-  safeParse,
 } from './utils/appHelpers';
 
 const ElearningSection = lazy(() => import('./sections/ElearningSection'));
@@ -35,122 +33,12 @@ const ToolboxSection = lazy(() => import('./sections/ToolboxSection'));
 const NetworkSection = lazy(() => import('./sections/NetworkSection'));
 const EvidenceSection = lazy(() => import('./sections/EvidenceSection'));
 
-const TOOLBOX_PRINT_STORAGE_KEY = 'rr-toolbox-print-payload';
-
 const SECTION_ALIAS_MAP = {
   'network-map': 'netzwerk-karte',
   'network-directory': 'netzwerk-fachstellen',
   'netzwerk-karte': 'netzwerk-karte',
   'netzwerk-fachstellen': 'netzwerk-fachstellen',
 };
-
-function getToolboxPrintMode() {
-  if (typeof window === 'undefined') return false;
-  return new URLSearchParams(window.location.search).get('print') === 'toolbox';
-}
-
-function readToolboxPrintPayload() {
-  if (typeof window === 'undefined') return null;
-
-  try {
-    const raw = window.localStorage.getItem(TOOLBOX_PRINT_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed.html !== 'string' || !parsed.html.trim()) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-
-function storeToolboxPrintPayload(payload) {
-  if (typeof window === 'undefined') return false;
-
-  try {
-    window.localStorage.setItem(
-      TOOLBOX_PRINT_STORAGE_KEY,
-      JSON.stringify({
-        title: payload.title,
-        html: payload.html,
-        updatedAt: Date.now(),
-      })
-    );
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function openIsolatedPrintView({ contentSelector, title }) {
-  if (typeof window === 'undefined' || typeof document === 'undefined') return false;
-
-  const printNode = document.querySelector(contentSelector);
-  if (!printNode) return false;
-
-  const stored = storeToolboxPrintPayload({
-    title,
-    html: printNode.outerHTML,
-  });
-  if (!stored) return false;
-
-  const printUrl = new URL(window.location.href);
-  printUrl.searchParams.set('print', 'toolbox');
-  printUrl.searchParams.set('ts', String(Date.now()));
-
-  const printWindow = window.open(printUrl.toString(), '_blank');
-  if (!printWindow) return false;
-
-  if (typeof printWindow.focus === 'function') {
-    window.setTimeout(() => printWindow.focus(), 150);
-  }
-
-  return true;
-}
-
-function ToolboxPrintPage() {
-  const payload = useMemo(() => readToolboxPrintPayload(), []);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return undefined;
-
-    const timer = window.setTimeout(() => {
-      window.focus();
-      window.print();
-    }, 400);
-
-    return () => window.clearTimeout(timer);
-  }, []);
-
-  if (!payload?.html) {
-    return (
-      <div className="min-h-screen bg-white px-6 py-10 text-slate-900">
-        <main className="mx-auto max-w-3xl">
-          <h1 className="text-2xl font-semibold">Druckansicht konnte nicht geladen werden</h1>
-          <p className="mt-4 text-base leading-relaxed text-slate-700">
-            Bitte dieses Fenster schliessen und die Arbeitsansicht noch einmal direkt aus der Toolbox starten.
-          </p>
-        </main>
-      </div>
-    );
-  }
-
-  return (
-    <div className="min-h-screen bg-white text-slate-900">
-      <main className="print-shell" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(payload.html) }} />
-    </div>
-  );
-}
-
-function handleToolboxPrint() {
-  const opened = openIsolatedPrintView({
-    contentSelector: '#toolbox-next-steps .print-only',
-    title: 'Relational Recovery – Toolbox Arbeitsansicht',
-  });
-
-  if (!opened) {
-    window.print();
-  }
-}
 
 const SectionLoadingFallback = memo(function SectionLoadingFallback() {
   return (
@@ -172,7 +60,12 @@ function getFocusableElements(container) {
     container.querySelectorAll(
       'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), summary, [tabindex]:not([tabindex="-1"])'
     )
-  ).filter((element) => !element.hasAttribute('disabled') && element.getAttribute('aria-hidden') !== 'true' && element.offsetParent !== null);
+  ).filter(
+    (element) =>
+      !element.hasAttribute('disabled') &&
+      element.getAttribute('aria-hidden') !== 'true' &&
+      element.offsetParent !== null
+  );
 }
 
 export default function App() {
@@ -196,7 +89,10 @@ export default function App() {
   const [pendingPriorityFocus, setPendingPriorityFocus] = useState(null);
   const [pendingSectionHash, setPendingSectionHash] = useState(() => {
     if (typeof window === 'undefined') return null;
-    const rawHash = String(window.location.hash || '').replace(/^#/, '').trim().toLowerCase();
+    const rawHash = String(window.location.hash || '')
+      .replace(/^#/, '')
+      .trim()
+      .toLowerCase();
     return SECTION_ALIAS_MAP[rawHash] ?? null;
   });
   const mainContentRef = useRef(null);
@@ -212,7 +108,9 @@ export default function App() {
   const firstMobileNavItemRef = useRef(null);
   const mobileMenuContainerRef = useRef(null);
   const tabInstanceIdRef = useRef(
-    typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `tab-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    typeof crypto !== 'undefined' && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `tab-${Date.now()}-${Math.random().toString(16).slice(2)}`
   );
   const latestAppliedTimestampRef = useRef(null);
   if (latestAppliedTimestampRef.current === null) {
@@ -287,7 +185,10 @@ export default function App() {
   };
 
   const getSectionHashTarget = (hashValue) => {
-    const cleaned = String(hashValue || '').replace(/^#/, '').trim().toLowerCase();
+    const cleaned = String(hashValue || '')
+      .replace(/^#/, '')
+      .trim()
+      .toLowerCase();
     return SECTION_ALIAS_MAP[cleaned] ?? null;
   };
 
@@ -306,9 +207,13 @@ export default function App() {
         return undefined;
       }
 
-      const rawHash = String(window.location.hash || '').replace(/^#/, '').trim().toLowerCase();
+      const rawHash = String(window.location.hash || '')
+        .replace(/^#/, '')
+        .trim()
+        .toLowerCase();
       const currentHashTab = rawHash ? normalizeHashToTab(rawHash) : null;
-      const shouldPreserveSectionHash = rawHash && rawHash !== activeTab && currentHashTab === activeTab && getSectionHashTarget(rawHash);
+      const shouldPreserveSectionHash =
+        rawHash && rawHash !== activeTab && currentHashTab === activeTab && getSectionHashTarget(rawHash);
 
       const nextHash = `#${activeTab}`;
       if (!shouldPreserveSectionHash && window.location.hash !== nextHash) {
@@ -375,7 +280,6 @@ export default function App() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-
 
     const handleHashChange = () => {
       const rawHash = String(window.location.hash || '').replace(/^#/, '');
@@ -527,7 +431,17 @@ export default function App() {
       score,
       completedModules,
     }),
-    [activeTab, currentVignette, selectedOption, searchTerm, activeResourceFilter, quizState, showSafeNote, score, completedModules]
+    [
+      activeTab,
+      currentVignette,
+      selectedOption,
+      searchTerm,
+      activeResourceFilter,
+      quizState,
+      showSafeNote,
+      score,
+      completedModules,
+    ]
   );
 
   useEffect(() => {
@@ -619,15 +533,21 @@ export default function App() {
         ? prev.checked.filter((entry) => entry !== itemId)
         : [...prev.checked, itemId];
 
-      const risk = ASSESSMENT_ITEMS.filter((item) => checked.includes(item.id)).reduce((sum, item) => sum + item.val, 0);
+      const risk = ASSESSMENT_ITEMS.filter((item) => checked.includes(item.id)).reduce(
+        (sum, item) => sum + item.val,
+        0
+      );
       return { risk, checked };
     });
   }, []);
 
-  const openPriorityToolboxSection = useCallback((section) => {
-    navigateToTab('toolbox', { focusTarget: 'heading' });
-    setPendingPriorityFocus(section);
-  }, [navigateToTab]);
+  const openPriorityToolboxSection = useCallback(
+    (section) => {
+      navigateToTab('toolbox', { focusTarget: 'heading' });
+      setPendingPriorityFocus(section);
+    },
+    [navigateToTab]
+  );
 
   const handleEmergencyAccess = useCallback(() => {
     openPriorityToolboxSection('acute-crisis');
@@ -874,21 +794,24 @@ Aktueller Assessment-Score: ${score.risk}
   const downloadResources = [
     {
       title: 'Gesprächsleitfaden für Fachpersonen',
-      description: 'Kurzblatt für Erstgespräch, Verlaufsgespräch oder Supervision mit Fokus auf Elternrolle, Versorgung, Netzwerk und nächsten Schritt.',
+      description:
+        'Kurzblatt für Erstgespräch, Verlaufsgespräch oder Supervision mit Fokus auf Elternrolle, Versorgung, Netzwerk und nächsten Schritt.',
       meta: ['TXT editierbar', 'Gespräch / Supervision'],
       actionLabel: 'Leitfaden herunterladen',
       onDownload: handleDownloadConversationGuide,
     },
     {
       title: 'Netzwerkkarte als Arbeitsvorlage',
-      description: 'Strukturierte Vorlage für private Kontakte, Alltagsstützen, Fachstellen, Mitwissende und Versorgungslücken.',
+      description:
+        'Strukturierte Vorlage für private Kontakte, Alltagsstützen, Fachstellen, Mitwissende und Versorgungslücken.',
       meta: ['TXT editierbar', 'Vernetzung / Mapping'],
       actionLabel: 'Netzwerkkarte herunterladen',
       onDownload: handleDownloadNetworkMap,
     },
     {
       title: 'Psychoedukations-Hilfe',
-      description: 'Kurzhilfe für Fachpersonen zum Sprechen mit Kindern über die psychische Erkrankung eines Elternteils.',
+      description:
+        'Kurzhilfe für Fachpersonen zum Sprechen mit Kindern über die psychische Erkrankung eines Elternteils.',
       meta: ['TXT editierbar', 'Gespräch mit Kindern'],
       actionLabel: 'Kurzhilfe herunterladen',
       onDownload: handleDownloadPsychoeducationGuide,
@@ -957,7 +880,10 @@ Aktueller Assessment-Score: ${score.risk}
           <div className="mx-auto flex max-w-[86rem] flex-col items-start justify-between gap-3 px-2 md:flex-row md:items-center md:px-6">
             <div className="flex items-center gap-3 text-[10px] font-extrabold uppercase tracking-[0.24em] text-[#eadfce]">
               <ShieldCheck size={16} className="shrink-0 text-[#f0c786]" />
-              <span>Lokale Speicherung im Browser • auf gemeinsam genutzten Geräten nach der Nutzung zurücksetzen • keine serverseitige Falldokumentation in dieser Ansicht</span>
+              <span>
+                Lokale Speicherung im Browser • auf gemeinsam genutzten Geräten nach der Nutzung zurücksetzen • keine
+                serverseitige Falldokumentation in dieser Ansicht
+              </span>
             </div>
             <button
               type="button"
@@ -973,9 +899,13 @@ Aktueller Assessment-Score: ${score.risk}
       <div className="no-print border-b border-[#e4cbbb] bg-[linear-gradient(180deg,#fff6ee,#f4e4d6)]">
         <div className="mx-auto flex max-w-[86rem] flex-col items-start justify-between gap-3 px-4 py-3 md:flex-row md:items-center md:px-6">
           <div className="text-sm leading-relaxed text-[#6d342c]">
-            <span className="mr-3 text-[10px] font-extrabold uppercase tracking-[0.18em] text-[#9a4b3c]">Akute Krise</span>
-            Bei akuter Lebensgefahr: <span className="font-extrabold">144</span>. Im Kanton Zürich bei nicht lebensbedrohlichen Situationen:
-            <span className="font-extrabold"> AERZTEFON 0800 33 66 55</span>. Für Jugendliche ist <span className="font-extrabold">147 telefonisch</span> der schnellste Weg.
+            <span className="mr-3 text-[10px] font-extrabold uppercase tracking-[0.18em] text-[#9a4b3c]">
+              Akute Krise
+            </span>
+            Bei akuter Lebensgefahr: <span className="font-extrabold">144</span>. Im Kanton Zürich bei nicht
+            lebensbedrohlichen Situationen:
+            <span className="font-extrabold"> AERZTEFON 0800 33 66 55</span>. Für Jugendliche ist{' '}
+            <span className="font-extrabold">147 telefonisch</span> der schnellste Weg.
           </div>
           <button
             type="button"
@@ -1034,10 +964,7 @@ Aktueller Assessment-Score: ${score.risk}
           {activeTab === 'glossar' && <GlossarSection />}
 
           {activeTab === 'grundlagen' && (
-            <GrundlagenSection
-              sharedDownloadResources={downloadResources}
-              onNavigateToTab={navigateToTab}
-            />
+            <GrundlagenSection sharedDownloadResources={downloadResources} onNavigateToTab={navigateToTab} />
           )}
 
           {activeTab === 'toolbox' && (

--- a/src/components/closing/ClosingSection.jsx
+++ b/src/components/closing/ClosingSection.jsx
@@ -20,8 +20,7 @@ function RichCopy({ description, paragraphs = [] }) {
 function MetaTags({ items = [], tone = 'default' }) {
   if (!items.length) return null;
 
-  const className =
-    tone === 'accent' ? 'ui-closing-tag ui-closing-tag--accent' : 'ui-closing-tag';
+  const className = tone === 'accent' ? 'ui-closing-tag ui-closing-tag--accent' : 'ui-closing-tag';
 
   return (
     <div className="ui-badge-row ui-closing-tags">
@@ -89,12 +88,14 @@ function ClosingPrimaryActions({ items = [] }) {
   return (
     <div className="ui-closing-actions-grid no-print">
       {items.map((item) => (
-        <button key={item.title} type="button" className="ui-closing-action" onClick={item.onClick} aria-label={item.ariaLabel || item.title}>
-          <div
-            className={`ui-closing-action__preview ${item.previewClassName || ''}`}
-          >
-            {item.preview}
-          </div>
+        <button
+          key={item.title}
+          type="button"
+          className="ui-closing-action"
+          onClick={item.onClick}
+          aria-label={item.ariaLabel || item.title}
+        >
+          <div className={`ui-closing-action__preview ${item.previewClassName || ''}`}>{item.preview}</div>
           <h3 className="ui-closing-action__title">{item.title}</h3>
           {item.description ? <p className="ui-closing-action__copy">{item.description}</p> : null}
           {item.meta?.length ? (
@@ -120,7 +121,16 @@ function ClosingPrimaryActions({ items = [] }) {
 function ClosingActionButton({ item, defaultLabel }) {
   if (item.href) {
     return (
-      <Button as="a" href={item.href} className="ui-editorial-card__action" variant="secondary" target={item.target} rel={item.rel} download={item.kind === 'download'} aria-label={item.ariaLabel || item.actionLabel || defaultLabel}>
+      <Button
+        as="a"
+        href={item.href}
+        className="ui-editorial-card__action"
+        variant="secondary"
+        target={item.target}
+        rel={item.rel}
+        download={item.kind === 'download'}
+        aria-label={item.ariaLabel || item.actionLabel || defaultLabel}
+      >
         {item.actionLabel || defaultLabel}
       </Button>
     );
@@ -128,7 +138,12 @@ function ClosingActionButton({ item, defaultLabel }) {
 
   if (item.onClick) {
     return (
-      <Button className="ui-editorial-card__action" variant="secondary" onClick={item.onClick} aria-label={item.ariaLabel || item.actionLabel || defaultLabel}>
+      <Button
+        className="ui-editorial-card__action"
+        variant="secondary"
+        onClick={item.onClick}
+        aria-label={item.ariaLabel || item.actionLabel || defaultLabel}
+      >
         {item.actionLabel || defaultLabel}
       </Button>
     );
@@ -138,7 +153,9 @@ function ClosingActionButton({ item, defaultLabel }) {
 }
 
 function normalizeSearchText(value) {
-  return String(value || '').trim().toLowerCase();
+  return String(value || '')
+    .trim()
+    .toLowerCase();
 }
 
 function getActionSearchText(item = {}) {
@@ -193,14 +210,17 @@ function ClosingNavigator({ entries = [], query, setQuery, totalCount, resultCou
                 <strong>Materialien und Anschlusswege gezielt scannen.</strong>
               </p>
               <p>
-                Die Abschlusszone lässt sich jetzt über einen kleinen Index und eine inhaltsnahe Suche schneller lesen. Die Suche prüft Materialtitel,
-                Beschreibungen, Metadaten und Aktionslabels über alle sichtbaren Sammlungen hinweg.
+                Die Abschlusszone lässt sich jetzt über einen kleinen Index und eine inhaltsnahe Suche schneller lesen.
+                Die Suche prüft Materialtitel, Beschreibungen, Metadaten und Aktionslabels über alle sichtbaren
+                Sammlungen hinweg.
               </p>
             </div>
           </div>
           <div className="ui-closing-navigator__stat">
             <div className="ui-closing-navigator__stat-label">Treffer</div>
-            <div className="ui-closing-navigator__stat-value">{resultCount}/{totalCount}</div>
+            <div className="ui-closing-navigator__stat-value">
+              {resultCount}/{totalCount}
+            </div>
           </div>
         </div>
 
@@ -218,11 +238,7 @@ function ClosingNavigator({ entries = [], query, setQuery, totalCount, resultCou
         {entries.length ? (
           <div className="ui-chip-row ui-closing-navigator__entries">
             {entries.map((entry) => (
-              <a
-                key={entry.href}
-                href={entry.href}
-                className="ui-closing-navigator__entry"
-              >
+              <a key={entry.href} href={entry.href} className="ui-closing-navigator__entry">
                 {entry.label}
                 <span className="ui-closing-navigator__entry-count">{entry.count}</span>
               </a>
@@ -238,7 +254,11 @@ function ClosingCollections({ collections = [] }) {
   if (!collections.length) return null;
 
   return collections.map((collection, index) => (
-    <div key={collection.id || collection.eyebrow || collection.title} id={getCollectionAnchorId(collection, index)} className="ui-stack ui-stack--tight no-print ui-anchor-offset-target">
+    <div
+      key={collection.id || collection.eyebrow || collection.title}
+      id={getCollectionAnchorId(collection, index)}
+      className="ui-stack ui-stack--tight no-print ui-anchor-offset-target"
+    >
       {collection.eyebrow ? <Eyebrow>{collection.eyebrow}</Eyebrow> : null}
       {collection.title || collection.description ? (
         <div className="ui-copy">
@@ -246,9 +266,7 @@ function ClosingCollections({ collections = [] }) {
             <p>
               <strong>{collection.title}</strong>
               {collection.items?.length ? (
-                <span className="ui-closing-collection__count">
-                  {collection.items.length} Elemente
-                </span>
+                <span className="ui-closing-collection__count">{collection.items.length} Elemente</span>
               ) : null}
             </p>
           ) : null}
@@ -257,7 +275,11 @@ function ClosingCollections({ collections = [] }) {
       ) : null}
       <div className="ui-closing-collection-grid">
         {collection.items.map((item, itemIndex) => (
-          <SurfaceCard key={getActionItemKey(item, itemIndex)} tone={collection.collectionKind === 'books' ? 'soft' : 'default'} className="ui-closing-collection-card">
+          <SurfaceCard
+            key={getActionItemKey(item, itemIndex)}
+            tone={collection.collectionKind === 'books' ? 'soft' : 'default'}
+            className="ui-closing-collection-card"
+          >
             <MetaTags items={item.meta} />
             {item.age || item.type ? <p className="ui-fact-card__label">{item.age || item.type}</p> : null}
             <h3 className="ui-card__title">{item.title}</h3>
@@ -265,7 +287,10 @@ function ClosingCollections({ collections = [] }) {
             {item.provider ? <p className="ui-card__copy">{item.provider}</p> : null}
             {item.description ? <p className="ui-card__copy">{item.description}</p> : null}
             {item.assetMeta ? <p className="ui-closing-item__meta">{item.assetMeta}</p> : null}
-            <ClosingActionButton item={item} defaultLabel={item.kind === 'download' ? 'Material herunterladen' : 'Ressource öffnen'} />
+            <ClosingActionButton
+              item={item}
+              defaultLabel={item.kind === 'download' ? 'Material herunterladen' : 'Ressource öffnen'}
+            />
           </SurfaceCard>
         ))}
       </div>
@@ -283,9 +308,7 @@ function ClosingRelatedLinks({ relatedLinks, relatedLinksId }) {
         {relatedLinks.title ? (
           <p>
             <strong>{relatedLinks.title}</strong>
-            <span className="ui-closing-related-links__count">
-              {relatedLinks.items.length} Anschlusswege
-            </span>
+            <span className="ui-closing-related-links__count">{relatedLinks.items.length} Anschlusswege</span>
           </p>
         ) : null}
         {relatedLinks.description ? <p>{relatedLinks.description}</p> : null}
@@ -330,9 +353,7 @@ function ClosingReferences({ references }) {
       <div className="ui-stack ui-stack--loose">
         <div className="ui-stack ui-stack--tight">
           {references.eyebrow ? <Eyebrow>{references.eyebrow}</Eyebrow> : null}
-          <h2 className="ui-hero__title ui-closing-references__title">
-            {references.title}
-          </h2>
+          <h2 className="ui-hero__title ui-closing-references__title">{references.title}</h2>
           <RichCopy paragraphs={references.paragraphs} />
         </div>
 
@@ -427,15 +448,22 @@ export default function ClosingSection({ section, sectionId, surface = 'plain', 
         <div className={hasPrintView ? 'ui-stack ui-stack--loose no-print' : 'ui-stack ui-stack--loose'}>
           <ClosingHeader section={section} />
           <ClosingPrimaryActions items={section.primaryActions} />
-          {(totalCount || navigatorEntries.length) ? (
-            <ClosingNavigator entries={navigatorEntries} query={query} setQuery={setQuery} totalCount={totalCount} resultCount={resultCount} />
+          {totalCount || navigatorEntries.length ? (
+            <ClosingNavigator
+              entries={navigatorEntries}
+              query={query}
+              setQuery={setQuery}
+              totalCount={totalCount}
+              resultCount={resultCount}
+            />
           ) : null}
           <ClosingCollections collections={filteredCollections} />
           <ClosingRelatedLinks relatedLinks={filteredRelatedLinks} relatedLinksId={relatedLinksId} />
           {normalizedQuery && resultCount === 0 ? (
             <div className="ui-closing-empty-state no-print">
               <p className="ui-closing-empty-state__copy">
-                Für <strong>{query}</strong> wurden in den aktuellen Materialien und Anschlusswegen keine Treffer gefunden. Versuchen Sie einen allgemeineren Begriff.
+                Für <strong>{query}</strong> wurden in den aktuellen Materialien und Anschlusswegen keine Treffer
+                gefunden. Versuchen Sie einen allgemeineren Begriff.
               </p>
             </div>
           ) : null}

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -7,15 +7,7 @@ const VARIANT_CLASSES = {
   emergency: 'ui-button ui-button--emergency',
 };
 
-export default function Button({
-  as,
-  href,
-  variant = 'primary',
-  className = '',
-  children,
-  type = 'button',
-  ...props
-}) {
+export default function Button({ as, href, variant = 'primary', className = '', children, type = 'button', ...props }) {
   const variantClass = VARIANT_CLASSES[variant] ?? VARIANT_CLASSES.primary;
 
   const classes = [variantClass, className].filter(Boolean).join(' ');

--- a/src/components/ui/EditorialIntro.jsx
+++ b/src/components/ui/EditorialIntro.jsx
@@ -11,11 +11,7 @@ export default function EditorialIntro({ intro }) {
         <div className="ui-split">
           <div className="ui-stack ui-stack--tight">
             {intro.eyebrow ? <Eyebrow>{intro.eyebrow}</Eyebrow> : null}
-            {intro.title ? (
-              <h2 className="ui-hero__title ui-section-title">
-                {intro.title}
-              </h2>
-            ) : null}
+            {intro.title ? <h2 className="ui-hero__title ui-section-title">{intro.title}</h2> : null}
             {intro.description ? (
               <div className="ui-copy">
                 <p>{intro.description}</p>

--- a/src/data/appShellContent.js
+++ b/src/data/appShellContent.js
@@ -1,4 +1,13 @@
-import { Activity, BookOpenText, CircleHelp, ClipboardCheck, GraduationCap, HeartHandshake, LayoutDashboard, MapPin } from 'lucide-react';
+import {
+  Activity,
+  BookOpenText,
+  CircleHelp,
+  ClipboardCheck,
+  GraduationCap,
+  HeartHandshake,
+  LayoutDashboard,
+  MapPin,
+} from 'lucide-react';
 import { E_MODULES, VIGNETTEN } from './learningContent';
 import { RESOURCE_DATA } from './networkContent';
 import { LITERATUR, MEDIA_BOOKS, MEDIA_DIGITAL, SUPPORT_OFFERS } from './evidenceContent';
@@ -71,4 +80,5 @@ export const DEFAULT_QUIZ_STATE = {};
 export const E_MODULE_COUNT = E_MODULES.length;
 export const VIGNETTE_COUNT = VIGNETTEN.length;
 export const NETWORK_RESOURCE_COUNT = RESOURCE_DATA.length;
-export const HOME_REFERENCE_COUNT = LITERATUR.length + MEDIA_BOOKS.length + MEDIA_DIGITAL.length + SUPPORT_OFFERS.length;
+export const HOME_REFERENCE_COUNT =
+  LITERATUR.length + MEDIA_BOOKS.length + MEDIA_DIGITAL.length + SUPPORT_OFFERS.length;

--- a/src/data/evidenceContent.js
+++ b/src/data/evidenceContent.js
@@ -105,23 +105,19 @@ export const RELEVANCE_POINTS = [
 export const PARENT_EXPERIENCE_PANELS = [
   {
     title: 'Elternschaft als Kraftquelle',
-    text:
-      'Für viele betroffene Eltern ist die Beziehung zum Kind nicht nur Belastung, sondern auch Sinnquelle, Motivation und ein wichtiger Grund, Hilfe anzunehmen und dranzubleiben.',
+    text: 'Für viele betroffene Eltern ist die Beziehung zum Kind nicht nur Belastung, sondern auch Sinnquelle, Motivation und ein wichtiger Grund, Hilfe anzunehmen und dranzubleiben.',
   },
   {
     title: 'Elternschaft als Belastungsquelle',
-    text:
-      'Gleichzeitig können Symptome wie Erschöpfung, Angst, Reizbarkeit oder innere Leere dazu führen, dass selbst einfache Alltagsaufgaben kaum noch zu bewältigen sind.',
+    text: 'Gleichzeitig können Symptome wie Erschöpfung, Angst, Reizbarkeit oder innere Leere dazu führen, dass selbst einfache Alltagsaufgaben kaum noch zu bewältigen sind.',
   },
   {
     title: 'Schuld und Scham',
-    text:
-      'Viele Eltern leiden unter der Diskrepanz zwischen dem eigenen Anspruch, eine gute Mutter oder ein guter Vater zu sein, und dem Erleben, den Kindern aktuell nicht gerecht zu werden.',
+    text: 'Viele Eltern leiden unter der Diskrepanz zwischen dem eigenen Anspruch, eine gute Mutter oder ein guter Vater zu sein, und dem Erleben, den Kindern aktuell nicht gerecht zu werden.',
   },
   {
     title: 'Überforderung im Alltag',
-    text:
-      'Besonders belastend sind Übergänge: Aufstehen, Schule, Hausaufgaben, Konflikte, Trennungssituationen, Reizüberflutung, Termine und die Organisation von Entlastung.',
+    text: 'Besonders belastend sind Übergänge: Aufstehen, Schule, Hausaufgaben, Konflikte, Trennungssituationen, Reizüberflutung, Termine und die Organisation von Entlastung.',
   },
 ];
 
@@ -148,23 +144,19 @@ export const PARENT_PRACTICE_POINTS = [
 export const COLLABORATION_PANELS = [
   {
     title: 'Information und Transparenz',
-    text:
-      'Fachpersonen sollen ihre Beobachtungen, Einschätzungen und nächsten Schritte nachvollziehbar machen. Transparenz senkt Kontrollängste und erleichtert Kooperation.',
+    text: 'Fachpersonen sollen ihre Beobachtungen, Einschätzungen und nächsten Schritte nachvollziehbar machen. Transparenz senkt Kontrollängste und erleichtert Kooperation.',
   },
   {
     title: 'Anhörung und Mitsprache',
-    text:
-      'Eltern erleben Zusammenarbeit eher als tragfähig, wenn ihre Sicht ernst genommen wird und sie nicht nur Empfängerinnen und Empfänger von Vorgaben bleiben.',
+    text: 'Eltern erleben Zusammenarbeit eher als tragfähig, wenn ihre Sicht ernst genommen wird und sie nicht nur Empfängerinnen und Empfänger von Vorgaben bleiben.',
   },
   {
     title: 'Mitbestimmung',
-    text:
-      'Gerade bei Scham, Hilflosigkeit oder Misstrauen ist es wichtig, Ziele und Vorgehen gemeinsam zu entwickeln. Das stärkt Selbstwirksamkeit und reduziert erlebte Ohnmacht.',
+    text: 'Gerade bei Scham, Hilflosigkeit oder Misstrauen ist es wichtig, Ziele und Vorgehen gemeinsam zu entwickeln. Das stärkt Selbstwirksamkeit und reduziert erlebte Ohnmacht.',
   },
   {
     title: 'Auf Augenhöhe',
-    text:
-      'Eltern sind Expertinnen und Experten ihrer Lebenssituation. Gute Zusammenarbeit verbindet fachliche Verantwortung mit Respekt vor ihrem Wissen über Alltag, Beziehung und Belastungsgrenzen.',
+    text: 'Eltern sind Expertinnen und Experten ihrer Lebenssituation. Gute Zusammenarbeit verbindet fachliche Verantwortung mit Respekt vor ihrem Wissen über Alltag, Beziehung und Belastungsgrenzen.',
   },
 ];
 
@@ -178,13 +170,11 @@ export const COLLABORATION_FOUR_AS = [
 export const FAMILY_WISHES_PANELS = [
   {
     title: 'Was Eltern häufig wünschen',
-    text:
-      'Viele Eltern suchen Unterstützung beim Erklären der Erkrankung gegenüber den Kindern, bei Erziehungsfragen, bei der Reduktion elterlicher Belastung, bei Betreuungsorganisation und bei Austausch mit anderen Betroffenen.',
+    text: 'Viele Eltern suchen Unterstützung beim Erklären der Erkrankung gegenüber den Kindern, bei Erziehungsfragen, bei der Reduktion elterlicher Belastung, bei Betreuungsorganisation und bei Austausch mit anderen Betroffenen.',
   },
   {
     title: 'Was Kinder häufig wünschen',
-    text:
-      'Kinder wünschen sich vor allem verständliche Informationen über die Erkrankung, einen Ort für Sorgen und Fragen, mehr Normalität im Alltag und eine Reduktion von Stigma und Geheimhaltung.',
+    text: 'Kinder wünschen sich vor allem verständliche Informationen über die Erkrankung, einen Ort für Sorgen und Fragen, mehr Normalität im Alltag und eine Reduktion von Stigma und Geheimhaltung.',
   },
 ];
 
@@ -197,23 +187,19 @@ export const FAMILY_WISHES_POINTS = [
 export const PARENT_SELF_HELP_PANELS = [
   {
     title: 'Weniger, aber verlässlich',
-    text:
-      'Kinder brauchen nicht perfekte Eltern, sondern möglichst verlässliche Orientierung. Wenn gerade wenig Kraft da ist, helfen kleine, wiedererkennbare Dinge oft mehr als grosse Vorhaben: ein kurzer Gruss am Morgen, ein gemeinsames Abendritual oder eine klare Absprache für den Nachmittag.',
+    text: 'Kinder brauchen nicht perfekte Eltern, sondern möglichst verlässliche Orientierung. Wenn gerade wenig Kraft da ist, helfen kleine, wiedererkennbare Dinge oft mehr als grosse Vorhaben: ein kurzer Gruss am Morgen, ein gemeinsames Abendritual oder eine klare Absprache für den Nachmittag.',
   },
   {
     title: 'Kurz und ehrlich sprechen',
-    text:
-      'Kinder spüren meist, dass etwas anders ist. Eine kurze, einfache Erklärung ist oft entlastender als Schweigen: zum Beispiel, dass Mama oder Papa gerade krank, erschöpft oder schneller gereizt ist und dass andere Erwachsene mithelfen.',
+    text: 'Kinder spüren meist, dass etwas anders ist. Eine kurze, einfache Erklärung ist oft entlastender als Schweigen: zum Beispiel, dass Mama oder Papa gerade krank, erschöpft oder schneller gereizt ist und dass andere Erwachsene mithelfen.',
   },
   {
     title: 'Hilfe früh organisieren',
-    text:
-      'Unterstützung ist kein Zeichen von Versagen. Wenn Einkaufen, Aufstehen, Übergaben, Hausaufgaben oder Termine zu viel werden, ist es oft sinnvoll, früh eine Bezugsperson, Familienhilfe, Beratung oder Entlastung einzubeziehen.',
+    text: 'Unterstützung ist kein Zeichen von Versagen. Wenn Einkaufen, Aufstehen, Übergaben, Hausaufgaben oder Termine zu viel werden, ist es oft sinnvoll, früh eine Bezugsperson, Familienhilfe, Beratung oder Entlastung einzubeziehen.',
   },
   {
     title: 'Krisen vorher absprechen',
-    text:
-      'Besonders entlastend ist ein einfacher Plan für belastete Phasen: Wer übernimmt die Kinder? Wen rufe ich zuerst an? Was sage ich der Schule oder Kita? Was muss sicher versorgt werden? Solche Absprachen helfen, bevor es akut wird.',
+    text: 'Besonders entlastend ist ein einfacher Plan für belastete Phasen: Wer übernimmt die Kinder? Wen rufe ich zuerst an? Was sage ich der Schule oder Kita? Was muss sicher versorgt werden? Solche Absprachen helfen, bevor es akut wird.',
   },
 ];
 
@@ -229,46 +215,38 @@ export const PARENT_SELF_HELP_POINTS = [
 export const PARENT_EVERYDAY_SUPPORT_PANELS = [
   {
     title: 'Wenn ein Kind viel weint oder Nähe sucht',
-    text:
-      'Gerade unter Stress kann kindliches Schreien oder Klammern schnell überfordernd wirken. Hilfreich ist, diese Belastung offen anzusprechen, Beruhigungsstrategien zu üben und Entlastung früh mitzudenken, statt sich dafür zu verurteilen.',
+    text: 'Gerade unter Stress kann kindliches Schreien oder Klammern schnell überfordernd wirken. Hilfreich ist, diese Belastung offen anzusprechen, Beruhigungsstrategien zu üben und Entlastung früh mitzudenken, statt sich dafür zu verurteilen.',
   },
   {
     title: 'Lob, Anerkennung und kleine positive Signale',
-    text:
-      'Kinder profitieren von kleinen Momenten der Bestärkung. Ein ehrliches Lob, richtiges Zuhören oder das Ernstnehmen ihrer Meinung kann im Alltag oft mehr stabilisieren als grosse Erziehungspläne.',
+    text: 'Kinder profitieren von kleinen Momenten der Bestärkung. Ein ehrliches Lob, richtiges Zuhören oder das Ernstnehmen ihrer Meinung kann im Alltag oft mehr stabilisieren als grosse Erziehungspläne.',
   },
   {
     title: 'Probleme in kleinen Schritten lösen',
-    text:
-      'Kinder brauchen Unterstützung, wenn Sorgen oder Alltagsprobleme zu gross werden. Hilfreich ist, gemeinsam ein Problem auszuwählen, Lösungsideen zu sammeln, Vor- und Nachteile zu besprechen und den nächsten kleinen Schritt zu planen.',
+    text: 'Kinder brauchen Unterstützung, wenn Sorgen oder Alltagsprobleme zu gross werden. Hilfreich ist, gemeinsam ein Problem auszuwählen, Lösungsideen zu sammeln, Vor- und Nachteile zu besprechen und den nächsten kleinen Schritt zu planen.',
   },
   {
     title: 'Soziale Kontakte ausdrücklich erlauben',
-    text:
-      'Kinder psychisch belasteter Eltern brauchen oft verlässliche Beziehungen ausserhalb der Kernfamilie. Entscheidend ist, dass Eltern diese Kontakte innerlich erlauben, fördern und mit dem Kind besprechen, wem es was erzählen möchte.',
+    text: 'Kinder psychisch belasteter Eltern brauchen oft verlässliche Beziehungen ausserhalb der Kernfamilie. Entscheidend ist, dass Eltern diese Kontakte innerlich erlauben, fördern und mit dem Kind besprechen, wem es was erzählen möchte.',
   },
 ];
 
 export const FAMILY_SYSTEM_PANELS = [
   {
     title: 'Alltag und Routinen',
-    text:
-      'Wenn ein Elternteil psychisch erkrankt, wird der Familienalltag oft unberechenbarer. Gewohnte Abläufe kippen leichter, Zuständigkeiten werden unsicher und viele Entscheidungen richten sich zunehmend nach dem aktuellen Befinden des erkrankten Elternteils.',
+    text: 'Wenn ein Elternteil psychisch erkrankt, wird der Familienalltag oft unberechenbarer. Gewohnte Abläufe kippen leichter, Zuständigkeiten werden unsicher und viele Entscheidungen richten sich zunehmend nach dem aktuellen Befinden des erkrankten Elternteils.',
   },
   {
     title: 'Rollen und Verantwortung',
-    text:
-      'In belasteten Phasen verschieben sich Rollen innerhalb der Familie. Kinder übernehmen manchmal mehr Verantwortung, Partnerinnen oder Partner tragen dauerhaft Ausgleichsarbeit, und Grosseltern oder andere Bezugspersonen werden zu zentralen Stützen des Systems.',
+    text: 'In belasteten Phasen verschieben sich Rollen innerhalb der Familie. Kinder übernehmen manchmal mehr Verantwortung, Partnerinnen oder Partner tragen dauerhaft Ausgleichsarbeit, und Grosseltern oder andere Bezugspersonen werden zu zentralen Stützen des Systems.',
   },
   {
     title: 'Kommunikation und Schweigen',
-    text:
-      'Viele Familien versuchen, Belastung nach aussen zu verbergen. Dann entstehen Missverständnisse, Loyalitätskonflikte und ein Klima, in dem Sorgen zwar stark gespürt, aber nicht gut besprochen werden können.',
+    text: 'Viele Familien versuchen, Belastung nach aussen zu verbergen. Dann entstehen Missverständnisse, Loyalitätskonflikte und ein Klima, in dem Sorgen zwar stark gespürt, aber nicht gut besprochen werden können.',
   },
   {
     title: 'Isolation und Rückzug',
-    text:
-      'Scham, Erschöpfung und Angst vor Bewertung können dazu führen, dass sich Familien sozial zurückziehen. Dadurch fehlen oft genau jene entlastenden Kontakte, die in Krisenzeiten stabilisierend wirken würden.',
+    text: 'Scham, Erschöpfung und Angst vor Bewertung können dazu führen, dass sich Familien sozial zurückziehen. Dadurch fehlen oft genau jene entlastenden Kontakte, die in Krisenzeiten stabilisierend wirken würden.',
   },
 ];
 
@@ -289,23 +267,19 @@ export const FAMILY_SYSTEM_PRACTICE_POINTS = [
 export const CHILD_EXPERIENCE_PANELS = [
   {
     title: 'Kinder als Hochrisikogruppe',
-    text:
-      'Kinder psychisch erkrankter Eltern tragen ein deutlich erhöhtes Risiko für emotionale Belastungen und spätere psychische Auffälligkeiten. Entscheidend ist aber nicht nur die Diagnose, sondern wie stark Alltag, Beziehung, Sprache und Schutzfaktoren beeinträchtigt sind.',
+    text: 'Kinder psychisch erkrankter Eltern tragen ein deutlich erhöhtes Risiko für emotionale Belastungen und spätere psychische Auffälligkeiten. Entscheidend ist aber nicht nur die Diagnose, sondern wie stark Alltag, Beziehung, Sprache und Schutzfaktoren beeinträchtigt sind.',
   },
   {
     title: 'Parentifizierung',
-    text:
-      'Manche Kinder übernehmen Aufgaben, die eigentlich Erwachsene tragen sollten: Sie trösten den Elternteil, achten auf Stimmungsschwankungen, kümmern sich um Geschwister oder halten den Haushalt mit. Das kann nach aussen kompetent wirken, ist innerlich aber oft überfordernd.',
+    text: 'Manche Kinder übernehmen Aufgaben, die eigentlich Erwachsene tragen sollten: Sie trösten den Elternteil, achten auf Stimmungsschwankungen, kümmern sich um Geschwister oder halten den Haushalt mit. Das kann nach aussen kompetent wirken, ist innerlich aber oft überfordernd.',
   },
   {
     title: 'Loyalitätskonflikte',
-    text:
-      'Viele Kinder wollen den erkrankten Elternteil schützen und gleichzeitig ihre eigene Not ausdrücken. Hilfe zu suchen kann sich dann wie Verrat anfühlen. Diese innere Zerrissenheit bindet viel Energie und macht offene Gespräche schwer.',
+    text: 'Viele Kinder wollen den erkrankten Elternteil schützen und gleichzeitig ihre eigene Not ausdrücken. Hilfe zu suchen kann sich dann wie Verrat anfühlen. Diese innere Zerrissenheit bindet viel Energie und macht offene Gespräche schwer.',
   },
   {
     title: 'Tabuisierung und Familiengeheimnis',
-    text:
-      'Wenn über die Erkrankung kaum gesprochen werden kann, entstehen leicht Schuldgefühle, Verunsicherung und falsche Erklärungen. Kinder spüren, dass etwas nicht stimmt, haben aber oft zu wenig Worte und zu wenig entlastende Informationen.',
+    text: 'Wenn über die Erkrankung kaum gesprochen werden kann, entstehen leicht Schuldgefühle, Verunsicherung und falsche Erklärungen. Kinder spüren, dass etwas nicht stimmt, haben aber oft zu wenig Worte und zu wenig entlastende Informationen.',
   },
 ];
 
@@ -326,23 +300,19 @@ export const CHILD_EXPERIENCE_PRACTICE_POINTS = [
 export const FAMILY_RESILIENCE_PANELS = [
   {
     title: 'Verlässliche Bezugspersonen',
-    text:
-      'Eine stabile, emotional sichere Bindung zu mindestens einer verlässlichen erwachsenen Bezugsperson wirkt im Familiensystem oft wie ein Schutzanker. Das kann der andere Elternteil sein, aber auch eine Grossmutter, ein Grossvater, ein Pate oder eine andere tragfähige Person im nahen Umfeld.',
+    text: 'Eine stabile, emotional sichere Bindung zu mindestens einer verlässlichen erwachsenen Bezugsperson wirkt im Familiensystem oft wie ein Schutzanker. Das kann der andere Elternteil sein, aber auch eine Grossmutter, ein Grossvater, ein Pate oder eine andere tragfähige Person im nahen Umfeld.',
   },
   {
     title: 'Regeln, Rituale und Alltag',
-    text:
-      'Klare Abläufe, wiederkehrende Rituale und ein möglichst vorhersehbarer Alltag geben Familien Halt. Gerade bei psychischer Belastung helfen überschaubare Routinen, Verlässlichkeit zu spüren und Spannungen im Zusammenleben zu reduzieren.',
+    text: 'Klare Abläufe, wiederkehrende Rituale und ein möglichst vorhersehbarer Alltag geben Familien Halt. Gerade bei psychischer Belastung helfen überschaubare Routinen, Verlässlichkeit zu spüren und Spannungen im Zusammenleben zu reduzieren.',
   },
   {
     title: 'Offene, altersgerechte Kommunikation',
-    text:
-      'Wenn in der Familie benannt werden darf, dass es einem Elternteil psychisch schlecht geht, sinken Verunsicherung und falsche Selbstzuschreibungen. Ehrliche, kindgerechte Gespräche schaffen Orientierung und entlasten Beziehungen.',
+    text: 'Wenn in der Familie benannt werden darf, dass es einem Elternteil psychisch schlecht geht, sinken Verunsicherung und falsche Selbstzuschreibungen. Ehrliche, kindgerechte Gespräche schaffen Orientierung und entlasten Beziehungen.',
   },
   {
     title: 'Erlaubnis, Hilfe anzunehmen',
-    text:
-      'Familiäre Resilienz entsteht auch dort, wo Eltern ihren Kindern und sich selbst erlauben, Unterstützung von aussen anzunehmen. Das mindert Isolation, erweitert das Netz und entlastet die Familie als Ganzes.',
+    text: 'Familiäre Resilienz entsteht auch dort, wo Eltern ihren Kindern und sich selbst erlauben, Unterstützung von aussen anzunehmen. Das mindert Isolation, erweitert das Netz und entlastet die Familie als Ganzes.',
   },
 ];
 
@@ -355,23 +325,19 @@ export const FAMILY_RESILIENCE_POINTS = [
 export const CHILD_PROTECTION_PANELS = [
   {
     title: 'Selbstwirksamkeit und Problemlösen',
-    text:
-      'Kinder profitieren, wenn sie erleben, dass sie schwierige Situationen nicht allein tragen müssen, aber dennoch handlungsfähig sind. Ein positives Selbstkonzept und realistische Selbstwirksamkeit helfen, Belastungen besser einzuordnen.',
+    text: 'Kinder profitieren, wenn sie erleben, dass sie schwierige Situationen nicht allein tragen müssen, aber dennoch handlungsfähig sind. Ein positives Selbstkonzept und realistische Selbstwirksamkeit helfen, Belastungen besser einzuordnen.',
   },
   {
     title: 'Temperament und Flexibilität',
-    text:
-      'Ein zugängliches Temperament, soziale Offenheit und emotionale Flexibilität können helfen, Belastungen abzufedern. Diese Eigenschaften ersetzen jedoch keine Schutzbeziehungen, sondern entfalten ihre Wirkung erst im Zusammenspiel mit einem tragfähigen Umfeld.',
+    text: 'Ein zugängliches Temperament, soziale Offenheit und emotionale Flexibilität können helfen, Belastungen abzufedern. Diese Eigenschaften ersetzen jedoch keine Schutzbeziehungen, sondern entfalten ihre Wirkung erst im Zusammenspiel mit einem tragfähigen Umfeld.',
   },
   {
     title: 'Kognitive und sprachliche Ressourcen',
-    text:
-      'Gute Problemlösefähigkeit, altersangemessenes Verstehen und die Möglichkeit, innere Zustände in Worte zu fassen, erleichtern die Verarbeitung belastender Erfahrungen. Wissen und Sprache können Angst, Schuld und Ohnmacht deutlich reduzieren.',
+    text: 'Gute Problemlösefähigkeit, altersangemessenes Verstehen und die Möglichkeit, innere Zustände in Worte zu fassen, erleichtern die Verarbeitung belastender Erfahrungen. Wissen und Sprache können Angst, Schuld und Ohnmacht deutlich reduzieren.',
   },
   {
     title: 'Aktive Bewältigung',
-    text:
-      'Kinder werden gestärkt, wenn sie Unterstützung suchen dürfen, positive Beziehungen ausserhalb der Kernfamilie erleben und in Schule oder Freizeit Zugehörigkeit finden. Schutz entsteht oft aus mehreren kleinen, tragenden Erfahrungen.',
+    text: 'Kinder werden gestärkt, wenn sie Unterstützung suchen dürfen, positive Beziehungen ausserhalb der Kernfamilie erleben und in Schule oder Freizeit Zugehörigkeit finden. Schutz entsteht oft aus mehreren kleinen, tragenden Erfahrungen.',
   },
 ];
 
@@ -392,49 +358,41 @@ export const PSYCHOEDUCATION_AGE_GROUPS = [
   {
     title: 'Kleinkinder bis etwa 3 Jahre',
     shortLabel: 'Sicherheit vor Erklärung',
-    text:
-      'In diesem Alter zählt vor allem die Atmosphäre. Kinder brauchen einfache, beruhigende Sätze wie: „Mama geht es heute nicht gut“ oder „Papa ist gerade sehr müde“. Entscheidend sind Verlässlichkeit, Nähe und wiederkehrende Abläufe.',
+    text: 'In diesem Alter zählt vor allem die Atmosphäre. Kinder brauchen einfache, beruhigende Sätze wie: „Mama geht es heute nicht gut“ oder „Papa ist gerade sehr müde“. Entscheidend sind Verlässlichkeit, Nähe und wiederkehrende Abläufe.',
   },
   {
     title: 'Vorschulkinder etwa 3 bis 6 Jahre',
     shortLabel: 'Schuld entlasten',
-    text:
-      'Vorschulkinder denken oft magisch und beziehen vieles auf sich. Deshalb ist wichtig zu sagen, dass sie die Krankheit weder verursacht haben noch heilen müssen. Bilder, Metaphern und kurze Wiederholungen helfen mehr als lange Erklärungen.',
+    text: 'Vorschulkinder denken oft magisch und beziehen vieles auf sich. Deshalb ist wichtig zu sagen, dass sie die Krankheit weder verursacht haben noch heilen müssen. Bilder, Metaphern und kurze Wiederholungen helfen mehr als lange Erklärungen.',
   },
   {
     title: 'Schulkinder etwa 6 bis 12 Jahre',
     shortLabel: 'Konkrete Informationen',
-    text:
-      'Schulkinder bemerken Unterschiede zu anderen Familien deutlicher. Sie profitieren von klaren Informationen über Namen der Erkrankung, typische Symptome und Hilfewege. Gleichzeitig brauchen sie Raum für Fragen und ambivalente Gefühle.',
+    text: 'Schulkinder bemerken Unterschiede zu anderen Familien deutlicher. Sie profitieren von klaren Informationen über Namen der Erkrankung, typische Symptome und Hilfewege. Gleichzeitig brauchen sie Raum für Fragen und ambivalente Gefühle.',
   },
   {
     title: 'Jugendliche ab etwa 13 Jahren',
     shortLabel: 'Einordnen statt beschönigen',
-    text:
-      'Jugendliche möchten meist genauer verstehen, was los ist, und fragen häufiger nach Vererbbarkeit, Verantwortung und eigener Abgrenzung. Hier helfen ehrliche Gespräche auf Augenhöhe, ohne die Jugendlichen zu Erwachsenenrollen zu drängen.',
+    text: 'Jugendliche möchten meist genauer verstehen, was los ist, und fragen häufiger nach Vererbbarkeit, Verantwortung und eigener Abgrenzung. Hier helfen ehrliche Gespräche auf Augenhöhe, ohne die Jugendlichen zu Erwachsenenrollen zu drängen.',
   },
 ];
 
 export const PHRASE_GUIDES = [
   {
     title: 'Depression',
-    text:
-      '„Mama oder Papa ist im Moment nicht einfach nur traurig, sondern krank. Diese Krankheit nimmt Energie, macht vieles schwer und verändert, wie jemand fühlt oder reagiert. Du bist daran nicht schuld.“',
+    text: '„Mama oder Papa ist im Moment nicht einfach nur traurig, sondern krank. Diese Krankheit nimmt Energie, macht vieles schwer und verändert, wie jemand fühlt oder reagiert. Du bist daran nicht schuld.“',
   },
   {
     title: 'Angststörung',
-    text:
-      '„Die Angst ist bei Mama oder Papa gerade so gross, dass sich vieles gefährlicher anfühlt, als es von aussen aussieht. Das ist eine Krankheit und nicht deine Aufgabe, sie wegzumachen.“',
+    text: '„Die Angst ist bei Mama oder Papa gerade so gross, dass sich vieles gefährlicher anfühlt, als es von aussen aussieht. Das ist eine Krankheit und nicht deine Aufgabe, sie wegzumachen.“',
   },
   {
     title: 'Psychose / Schizophrenie',
-    text:
-      '„Manchmal nimmt Mama oder Papa Dinge wahr oder deutet sie anders, als andere Menschen es tun. Das kann sehr verwirrend sein. Dafür gibt es Hilfe, und Erwachsene kümmern sich darum.“',
+    text: '„Manchmal nimmt Mama oder Papa Dinge wahr oder deutet sie anders, als andere Menschen es tun. Das kann sehr verwirrend sein. Dafür gibt es Hilfe, und Erwachsene kümmern sich darum.“',
   },
   {
     title: 'Manie',
-    text:
-      '„Manchmal ist Mama oder Papa so voller Energie und Gedanken, dass fast alles gleichzeitig passiert. Dann wirkt vieles sehr schnell, laut oder durcheinander. Auch das gehört zu einer Krankheit.“',
+    text: '„Manchmal ist Mama oder Papa so voller Energie und Gedanken, dass fast alles gleichzeitig passiert. Dann wirkt vieles sehr schnell, laut oder durcheinander. Auch das gehört zu einer Krankheit.“',
   },
 ];
 
@@ -455,59 +413,49 @@ export const PSYCHOEDUCATION_PREPARATION_POINTS = [
 export const PSYCHOEDUCATION_SETTINGS = [
   {
     title: 'Eltern sprechen selbst mit Unterstützung',
-    text:
-      'Wenn Eltern grundsätzlich gesprächsbereit sind, kann es sinnvoll sein, dass sie das Gespräch selbst führen und von einer Fachperson nur in Vorbereitung, Struktur und Sprache unterstützt werden.',
+    text: 'Wenn Eltern grundsätzlich gesprächsbereit sind, kann es sinnvoll sein, dass sie das Gespräch selbst führen und von einer Fachperson nur in Vorbereitung, Struktur und Sprache unterstützt werden.',
   },
   {
     title: 'Begleitetes Familiengespräch',
-    text:
-      'Bei Tabuisierung, Sprachlosigkeit oder grosser Unsicherheit kann ein professionell moderiertes Familiengespräch entlasten. Die Fachperson unterstützt Offenheit, die Eltern bleiben aber zentrale Gesprächspersonen.',
+    text: 'Bei Tabuisierung, Sprachlosigkeit oder grosser Unsicherheit kann ein professionell moderiertes Familiengespräch entlasten. Die Fachperson unterstützt Offenheit, die Eltern bleiben aber zentrale Gesprächspersonen.',
   },
   {
     title: 'Vorgespräch mit dem Kind',
-    text:
-      'Wenn ein Kind ängstlich, zurückhaltend oder jahrelang an Schweigen gewöhnt ist, kann ein geschütztes Einzelgespräch vor einem Familiengespräch sinnvoll sein. Dort lassen sich Sorgen, Fragen und der bisherige Wissensstand besser erfassen.',
+    text: 'Wenn ein Kind ängstlich, zurückhaltend oder jahrelang an Schweigen gewöhnt ist, kann ein geschütztes Einzelgespräch vor einem Familiengespräch sinnvoll sein. Dort lassen sich Sorgen, Fragen und der bisherige Wissensstand besser erfassen.',
   },
 ];
 
 export const PSYCHOEDUCATION_DIFFICULTIES = [
   {
     title: 'Das Kind will scheinbar nicht sprechen',
-    text:
-      'Rückzug oder Abwehr bedeuten nicht automatisch Desinteresse. Dahinter können Angst vor schlimmen Informationen, alte Sprachlosigkeit oder Loyalitätskonflikte stehen.',
+    text: 'Rückzug oder Abwehr bedeuten nicht automatisch Desinteresse. Dahinter können Angst vor schlimmen Informationen, alte Sprachlosigkeit oder Loyalitätskonflikte stehen.',
   },
   {
     title: 'Das Gespräch bricht ab',
-    text:
-      'Ein Abbruch kann ein gesunder Schutzmechanismus sein, wenn Aufmerksamkeit oder emotionale Aufnahmekapazität erschöpft sind. Dann hilft eher ein späteres Wiederanknüpfen als Drängen.',
+    text: 'Ein Abbruch kann ein gesunder Schutzmechanismus sein, wenn Aufmerksamkeit oder emotionale Aufnahmekapazität erschöpft sind. Dann hilft eher ein späteres Wiederanknüpfen als Drängen.',
   },
   {
     title: 'Das Kind stellt sehr viele Fragen',
-    text:
-      'Viele Fragen können Ausdruck von Neugier, Angst, Verunsicherung oder Misstrauen sein. Dann ist nicht nur Sachinformation, sondern auch das Nachfragen nach Gefühlen und Sorgen wichtig.',
+    text: 'Viele Fragen können Ausdruck von Neugier, Angst, Verunsicherung oder Misstrauen sein. Dann ist nicht nur Sachinformation, sondern auch das Nachfragen nach Gefühlen und Sorgen wichtig.',
   },
 ];
 
 export const HELP_BARRIER_PANELS = [
   {
     title: 'Scham und Stigmatisierung',
-    text:
-      'Viele Eltern befürchten, als ungenügend oder unfähig wahrgenommen zu werden, wenn sie offen über psychische Belastungen in der Familie sprechen. Diese Scham kann dazu führen, dass Probleme lange verborgen bleiben.',
+    text: 'Viele Eltern befürchten, als ungenügend oder unfähig wahrgenommen zu werden, wenn sie offen über psychische Belastungen in der Familie sprechen. Diese Scham kann dazu führen, dass Probleme lange verborgen bleiben.',
   },
   {
     title: 'Angst vor Eingriffen',
-    text:
-      'Eine zentrale Hürde ist die Sorge, Hilfe könnte automatisch zu Kontrolle, Meldungen oder zum Verlust von Einfluss auf die Kinder führen. Gerade die Angst vor behördlichen Eingriffen kann Familien davon abhalten, früh Unterstützung anzunehmen.',
+    text: 'Eine zentrale Hürde ist die Sorge, Hilfe könnte automatisch zu Kontrolle, Meldungen oder zum Verlust von Einfluss auf die Kinder führen. Gerade die Angst vor behördlichen Eingriffen kann Familien davon abhalten, früh Unterstützung anzunehmen.',
   },
   {
     title: 'Symptome erschweren Hilfe',
-    text:
-      'Depression, Angst, Erschöpfung, Antriebsmangel oder chaotische Krisenverläufe rauben oft genau die Kraft, die es bräuchte, um Angebote zu suchen, Termine zu organisieren oder Unterstützung verlässlich wahrzunehmen.',
+    text: 'Depression, Angst, Erschöpfung, Antriebsmangel oder chaotische Krisenverläufe rauben oft genau die Kraft, die es bräuchte, um Angebote zu suchen, Termine zu organisieren oder Unterstützung verlässlich wahrzunehmen.',
   },
   {
     title: 'Informationslücken',
-    text:
-      'Viele Familien wissen nicht, welche spezifischen Angebote es gibt, wer wofür zuständig ist oder wie niedrigschwellig erste Hilfe aussehen kann. Ohne Orientierung bleibt selbst vorhandene Unterstützung oft ungenutzt.',
+    text: 'Viele Familien wissen nicht, welche spezifischen Angebote es gibt, wer wofür zuständig ist oder wie niedrigschwellig erste Hilfe aussehen kann. Ohne Orientierung bleibt selbst vorhandene Unterstützung oft ungenutzt.',
   },
 ];
 
@@ -527,28 +475,23 @@ export const HELP_BARRIER_PRACTICE_POINTS = [
 export const CLINICAL_PRACTICE_PANELS = [
   {
     title: 'Netzwerkkarte',
-    text:
-      'Eine Netzwerkkarte hilft sichtbar zu machen, welche Personen und Stellen im Alltag tatsächlich tragen können: Kernfamilie, Verwandte, Schule, Betreuung, Nachbarschaft, Fachstellen. So wird Unterstützung konkreter und weniger abstrakt.',
+    text: 'Eine Netzwerkkarte hilft sichtbar zu machen, welche Personen und Stellen im Alltag tatsächlich tragen können: Kernfamilie, Verwandte, Schule, Betreuung, Nachbarschaft, Fachstellen. So wird Unterstützung konkreter und weniger abstrakt.',
   },
   {
     title: 'Krisenplan / Notfallplan',
-    text:
-      'Ein schriftlicher Krisenplan entlastet Familien in akuten Phasen. Er klärt vorab, wer die Kinder betreut, wo sie schlafen können, wie wichtige Informationen weitergegeben werden und wie der Kontakt zum Elternteil gehalten wird.',
+    text: 'Ein schriftlicher Krisenplan entlastet Familien in akuten Phasen. Er klärt vorab, wer die Kinder betreut, wo sie schlafen können, wie wichtige Informationen weitergegeben werden und wie der Kontakt zum Elternteil gehalten wird.',
   },
   {
     title: 'Parentifizierte Beziehungen',
-    text:
-      'Wenn Kinder zu viel Verantwortung übernehmen, braucht es eine sensible therapeutische Arbeit an Rollenumkehr und innerer Erlaubnis. Ziel ist nicht Schuldzuweisung, sondern eine schrittweise Rückgabe von Verantwortung an Erwachsene.',
+    text: 'Wenn Kinder zu viel Verantwortung übernehmen, braucht es eine sensible therapeutische Arbeit an Rollenumkehr und innerer Erlaubnis. Ziel ist nicht Schuldzuweisung, sondern eine schrittweise Rückgabe von Verantwortung an Erwachsene.',
   },
   {
     title: 'Stationärer Aufenthalt',
-    text:
-      'Bei einer Aufnahme sollten Elternschaft, Sorgearrangements und Kontaktmöglichkeiten systematisch geklärt werden. Kindgerechte Besuchsregelungen, Telefonate oder Videoanrufe können helfen, Beziehung und Orientierung zu erhalten.',
+    text: 'Bei einer Aufnahme sollten Elternschaft, Sorgearrangements und Kontaktmöglichkeiten systematisch geklärt werden. Kindgerechte Besuchsregelungen, Telefonate oder Videoanrufe können helfen, Beziehung und Orientierung zu erhalten.',
   },
   {
     title: 'Übergangsmanagement',
-    text:
-      'Die Zeit rund um Austritt und Rückkehr in den Alltag ist oft besonders sensibel. Gute Übergänge brauchen klare Absprachen, aktivierte Bezugspersonen und eine realistische Planung der ersten Tage zuhause.',
+    text: 'Die Zeit rund um Austritt und Rückkehr in den Alltag ist oft besonders sensibel. Gute Übergänge brauchen klare Absprachen, aktivierte Bezugspersonen und eine realistische Planung der ersten Tage zuhause.',
   },
 ];
 
@@ -568,18 +511,15 @@ export const CLINICAL_PRACTICE_STEPS = [
 export const MENTALIZATION_PANELS = [
   {
     title: 'Mentalisieren als Kernprozess',
-    text:
-      'Mentalisieren meint, über eigene und fremde Gedanken, Gefühle, Bedürfnisse und Absichten nachdenken zu können. Gerade in belasteten Familien unterstützt diese Fähigkeit dabei, Verhalten weniger vorschnell und mehr verstehend einzuordnen.',
+    text: 'Mentalisieren meint, über eigene und fremde Gedanken, Gefühle, Bedürfnisse und Absichten nachdenken zu können. Gerade in belasteten Familien unterstützt diese Fähigkeit dabei, Verhalten weniger vorschnell und mehr verstehend einzuordnen.',
   },
   {
     title: 'Haltung der Fachperson',
-    text:
-      'Eine mentalisierende Haltung nimmt die Realität des Gegenübers empathisch ernst, arbeitet mit einer Haltung des Nicht-Wissens und bleibt neugierig statt vorschnell sicher.',
+    text: 'Eine mentalisierende Haltung nimmt die Realität des Gegenübers empathisch ernst, arbeitet mit einer Haltung des Nicht-Wissens und bleibt neugierig statt vorschnell sicher.',
   },
   {
     title: 'Familienorientierte Interventionen',
-    text:
-      'Neben Psychoedukation gehören begleitende Familientherapie, bindungsbezogene Interventionen, Förderung familiärer Kommunikation und Aktivierung sozialer Ressourcen zu den zentralen evidenzbasierten Basisinterventionen.',
+    text: 'Neben Psychoedukation gehören begleitende Familientherapie, bindungsbezogene Interventionen, Förderung familiärer Kommunikation und Aktivierung sozialer Ressourcen zu den zentralen evidenzbasierten Basisinterventionen.',
   },
 ];
 

--- a/src/data/glossaryContent.js
+++ b/src/data/glossaryContent.js
@@ -2,8 +2,7 @@ export const GLOSSARY_HERO = {
   eyebrow: 'Redaktioneller Wissensbereich',
   title: 'Begriffe für',
   accent: 'ruhige fachliche Orientierung.',
-  lead:
-    'Das Glossar sammelt zentrale Begriffe aus relationaler Recovery, Kindesschutz, Angehörigenarbeit und Netzwerkpraxis in einer einheitlichen Sprache. Es soll Fachpersonen helfen, schneller zwischen Einordnung, Gespräch und Weitervermittlung zu wechseln.',
+  lead: 'Das Glossar sammelt zentrale Begriffe aus relationaler Recovery, Kindesschutz, Angehörigenarbeit und Netzwerkpraxis in einer einheitlichen Sprache. Es soll Fachpersonen helfen, schneller zwischen Einordnung, Gespräch und Weitervermittlung zu wechseln.',
   asideTitle: 'Nutzungshinweis',
   asideCopy:
     'Die Einträge sind als knappe Arbeitsdefinitionen für Praxis, Teamgespräch und Orientierung im Versorgungsalltag formuliert. Sie ersetzen keine institutionellen Richtlinien oder juristische Fachberatung.',
@@ -34,8 +33,7 @@ export const GLOSSARY_INTRO = {
   aside: {
     label: 'Ziel',
     title: 'Gemeinsame Sprache entlastet',
-    copy:
-      'Wenn Teams dieselben Kernbegriffe ähnlich verwenden, werden Fallbesprechungen ruhiger, Rückfragen klarer und Überleitungen zwischen Fachstellen verständlicher.',
+    copy: 'Wenn Teams dieselben Kernbegriffe ähnlich verwenden, werden Fallbesprechungen ruhiger, Rückfragen klarer und Überleitungen zwischen Fachstellen verständlicher.',
     tone: 'soft',
   },
   cards: [

--- a/src/data/grundlagenContent.js
+++ b/src/data/grundlagenContent.js
@@ -2,8 +2,7 @@ export const GRUNDLAGEN_HERO = {
   eyebrow: 'Redaktioneller Wissensbereich',
   title: 'Häufige Fragen für',
   accent: 'ruhigere Orientierung im Alltag.',
-  lead:
-    'Der Grundlagenbereich beantwortet typische Fragen von Angehörigen und Fachpersonen in einer klaren, entlastenden Sprache. Er soll Unsicherheit reduzieren, Begriffe in Alltagssituationen übersetzen und den Blick auf nächste Schritte öffnen.',
+  lead: 'Der Grundlagenbereich beantwortet typische Fragen von Angehörigen und Fachpersonen in einer klaren, entlastenden Sprache. Er soll Unsicherheit reduzieren, Begriffe in Alltagssituationen übersetzen und den Blick auf nächste Schritte öffnen.',
   asideTitle: 'Einordnung',
   asideCopy:
     'Die Antworten ersetzen keine individuelle klinische, rechtliche oder kindesschutzbezogene Beurteilung. Sie dienen als tragfähige Erstorientierung für Gespräch, Reflexion und Weitervermittlung.',
@@ -34,8 +33,7 @@ export const GRUNDLAGEN_INTRO = {
   aside: {
     label: 'Warum das hilft',
     title: 'Fragen sind oft der erste Zugang zu Orientierung',
-    copy:
-      'Viele Angehörige suchen nicht zuerst nach Theorie, sondern nach einer Antwort auf das, was sie im Moment beschäftigt. Ein FAQ-orientierter Grundlagenbereich holt genau dort ab und führt dann weiter in Sprache, Einordnung und Handlungsoptionen.',
+    copy: 'Viele Angehörige suchen nicht zuerst nach Theorie, sondern nach einer Antwort auf das, was sie im Moment beschäftigt. Ein FAQ-orientierter Grundlagenbereich holt genau dort ab und führt dann weiter in Sprache, Einordnung und Handlungsoptionen.',
     tone: 'soft',
   },
   cards: [
@@ -70,8 +68,7 @@ export const GRUNDLAGEN_CLUSTERS = [
     aside: {
       label: 'Merksatz',
       title: 'Verstehen entlastet, ohne Probleme kleinzureden',
-      copy:
-        'Eine ruhigere Einordnung bedeutet nicht, dass Belastung unwichtig ist. Sie schafft vielmehr die Voraussetzung dafür, wieder handlungsfähig zu werden.',
+      copy: 'Eine ruhigere Einordnung bedeutet nicht, dass Belastung unwichtig ist. Sie schafft vielmehr die Voraussetzung dafür, wieder handlungsfähig zu werden.',
       tone: 'soft',
     },
     faqs: [
@@ -106,8 +103,7 @@ export const GRUNDLAGEN_CLUSTERS = [
     aside: {
       label: 'Merksatz',
       title: 'Grenzen sind kein Beziehungsabbruch',
-      copy:
-        'Eine Grenze kann Beziehung schützen, wenn sie Klarheit schafft, Überforderung vermindert und Verantwortung wieder nachvollziehbar verteilt.',
+      copy: 'Eine Grenze kann Beziehung schützen, wenn sie Klarheit schafft, Überforderung vermindert und Verantwortung wieder nachvollziehbar verteilt.',
       tone: 'soft',
     },
     faqs: [
@@ -142,8 +138,7 @@ export const GRUNDLAGEN_CLUSTERS = [
     aside: {
       label: 'Merksatz',
       title: 'Nicht alles lösen, aber den nächsten Schritt klären',
-      copy:
-        'In komplexen Situationen entsteht Orientierung oft nicht durch die perfekte Gesamtlösung, sondern durch einen realistischen nächsten Kontakt, eine benannte Fachstelle oder eine klarere gemeinsame Sprache.',
+      copy: 'In komplexen Situationen entsteht Orientierung oft nicht durch die perfekte Gesamtlösung, sondern durch einen realistischen nächsten Kontakt, eine benannte Fachstelle oder eine klarere gemeinsame Sprache.',
       tone: 'soft',
     },
     faqs: [

--- a/src/data/learningContent.js
+++ b/src/data/learningContent.js
@@ -63,7 +63,11 @@ export const E_MODULES = [
     duration: '4 Min.',
     storyboard: 'Mit kindgerechter Sprache Schuldgefühle entlasten und Gesprächsfähigkeit stärken.',
     quiz: 'Warum können Metaphern hilfreich sein?',
-    quizOptions: ['Um die Wahrheit zu verbergen', 'Um altersgerechte Sprache zu schaffen', 'Um den Klinikaufenthalt zu verlängern'],
+    quizOptions: [
+      'Um die Wahrheit zu verbergen',
+      'Um altersgerechte Sprache zu schaffen',
+      'Um den Klinikaufenthalt zu verlängern',
+    ],
     correctQuizIdx: 1,
   },
 ];

--- a/src/data/toolboxContent.js
+++ b/src/data/toolboxContent.js
@@ -77,18 +77,15 @@ export const SAFETY_PLAN_TEMPLATE_FIELDS = [
 export const CHILD_PROTECTION_THRESHOLDS = [
   {
     title: 'Freiwillige Hilfe zuerst',
-    text:
-      'Wenn Sicherheit und Grundversorgung aktuell gewährleistet sind, ist freiwillige Unterstützung oft der erste sinnvolle Schritt – zum Beispiel über das kjz, Familienberatung oder konkrete Entlastung im Alltag.',
+    text: 'Wenn Sicherheit und Grundversorgung aktuell gewährleistet sind, ist freiwillige Unterstützung oft der erste sinnvolle Schritt – zum Beispiel über das kjz, Familienberatung oder konkrete Entlastung im Alltag.',
   },
   {
     title: 'Wann es enger wird',
-    text:
-      'Wenn Nahrung, Aufsicht, medizinische Versorgung, Sicherheit oder Schutz vor Gewalt nicht verlässlich gewährleistet sind, braucht es eine vertiefte Kindesschutzabklärung.',
+    text: 'Wenn Nahrung, Aufsicht, medizinische Versorgung, Sicherheit oder Schutz vor Gewalt nicht verlässlich gewährleistet sind, braucht es eine vertiefte Kindesschutzabklärung.',
   },
   {
     title: 'Was eine Meldung bedeutet',
-    text:
-      'Eine besorgte Person muss eine Gefährdung nicht beweisen. Die Prüfung und Kindeswohlabklärung ist Aufgabe der KESB oder der beauftragten Fachstellen.',
+    text: 'Eine besorgte Person muss eine Gefährdung nicht beweisen. Die Prüfung und Kindeswohlabklärung ist Aufgabe der KESB oder der beauftragten Fachstellen.',
   },
 ];
 
@@ -102,18 +99,15 @@ export const CHILD_PROTECTION_TIPS = [
 export const ADDICTION_PANELS = [
   {
     title: 'Psychische Erkrankung und Substanzkonsum zusammen denken',
-    text:
-      'Alkohol, Medikamente, Cannabis oder andere Substanzen können psychische Symptome verstärken, Krisen verschärfen und Behandlung erschweren. Für Familien ist wichtig, Moral und Sicherheit auseinanderzuhalten.',
+    text: 'Alkohol, Medikamente, Cannabis oder andere Substanzen können psychische Symptome verstärken, Krisen verschärfen und Behandlung erschweren. Für Familien ist wichtig, Moral und Sicherheit auseinanderzuhalten.',
   },
   {
     title: 'Grenzen ohne Beschämung',
-    text:
-      'Hilfreich sind klare Sicherheitsregeln: keine Kinderbetreuung unter starkem Einfluss, kein Fahren unter Einfluss, keine Beschaffung von Substanzen. Gleichzeitig sollten Hilfewege offen bleiben.',
+    text: 'Hilfreich sind klare Sicherheitsregeln: keine Kinderbetreuung unter starkem Einfluss, kein Fahren unter Einfluss, keine Beschaffung von Substanzen. Gleichzeitig sollten Hilfewege offen bleiben.',
   },
   {
     title: 'Niederschwelliger Einstieg',
-    text:
-      'Gerade bei Scham, Rückzug oder Ambivalenz kann anonyme Online-Beratung ein realistischer erster Schritt sein – auch für Angehörige und Nahestehende.',
+    text: 'Gerade bei Scham, Rückzug oder Ambivalenz kann anonyme Online-Beratung ein realistischer erster Schritt sein – auch für Angehörige und Nahestehende.',
   },
 ];
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,7 @@
 /* Design note: Global editorial foundation with warm surfaces, serif-led hierarchy, restrained terracotta accents, and generous whitespace. */
-@import "tailwindcss";
-@import "tw-animate-css";
-@import "./styles/primitives.css";
+@import 'tailwindcss';
+@import 'tw-animate-css';
+@import './styles/primitives.css';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -164,7 +164,7 @@
   }
 
   body::before {
-    content: "";
+    content: '';
     position: fixed;
     inset: 0;
     pointer-events: none;
@@ -175,18 +175,22 @@
   }
 
   a {
-    transition: color var(--motion-fast) ease, opacity var(--motion-fast) ease, border-color var(--motion-fast) ease, background-color var(--motion-fast) ease;
+    transition:
+      color var(--motion-fast) ease,
+      opacity var(--motion-fast) ease,
+      border-color var(--motion-fast) ease,
+      background-color var(--motion-fast) ease;
   }
 
   button:not(:disabled),
-  [role="button"]:not([aria-disabled="true"]),
-  [type="button"]:not(:disabled),
-  [type="submit"]:not(:disabled),
-  [type="reset"]:not(:disabled),
+  [role='button']:not([aria-disabled='true']),
+  [type='button']:not(:disabled),
+  [type='submit']:not(:disabled),
+  [type='reset']:not(:disabled),
   a[href],
   select:not(:disabled),
-  input[type="checkbox"]:not(:disabled),
-  input[type="radio"]:not(:disabled) {
+  input[type='checkbox']:not(:disabled),
+  input[type='radio']:not(:disabled) {
     @apply cursor-pointer;
   }
 }
@@ -210,7 +214,7 @@
   }
 
   .editorial-shell::after {
-    content: "";
+    content: '';
     position: absolute;
     inset: 0;
     pointer-events: none;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,5 @@
-import { createRoot } from "react-dom/client";
-import App from "./App.jsx";
-import "./index.css";
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
 
-createRoot(document.getElementById("root")).render(<App />);
+createRoot(document.getElementById('root')).render(<App />);

--- a/src/sections/ElearningSection.jsx
+++ b/src/sections/ElearningSection.jsx
@@ -13,8 +13,7 @@ export default function ElearningSection({ quizState, onAnswer, completedModules
     eyebrow: 'Fachliche Kurzformate',
     title: 'Lernen in',
     accent: 'ruhigen Fachsequenzen.',
-    lead:
-      'Kompakte Module für Gesprächsführung, Sprache und Einschätzung im Klinikalltag. Jedes Modul führt von einer Leitidee zu einer einzelnen Reflexionsfrage und bleibt damit näher an Fallarbeit als an prüfungsartigem Wissenstest.',
+    lead: 'Kompakte Module für Gesprächsführung, Sprache und Einschätzung im Klinikalltag. Jedes Modul führt von einer Leitidee zu einer einzelnen Reflexionsfrage und bleibt damit näher an Fallarbeit als an prüfungsartigem Wissenstest.',
     image: heroIllustration,
     imageAlt: 'Illustration eines Familiensystems mit Beziehungslinien und ruhiger Orientierung',
     asideTitle: 'Zuletzt geprüft',
@@ -88,7 +87,7 @@ export default function ElearningSection({ quizState, onAnswer, completedModules
         completed: completedModules.includes(mod.id),
         onAnswer,
       })),
-    [quizState, completedModules, onAnswer],
+    [quizState, completedModules, onAnswer]
   );
 
   const modulesSection = {
@@ -109,5 +108,12 @@ export default function ElearningSection({ quizState, onAnswer, completedModules
     items: moduleItems,
   };
 
-  return <LearningPageTemplate hero={hero} pageHeadingId={getPageHeadingId('lernmodule')} sequence={sequence} modulesSection={modulesSection} />;
+  return (
+    <LearningPageTemplate
+      hero={hero}
+      pageHeadingId={getPageHeadingId('lernmodule')}
+      sequence={sequence}
+      modulesSection={modulesSection}
+    />
+  );
 }

--- a/src/sections/EvidenceSection.jsx
+++ b/src/sections/EvidenceSection.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import EvidencePageTemplate from '../templates/EvidencePageTemplate';
 import {
   ABOUT_THIS_WEBSITE_POINTS,
@@ -47,13 +46,6 @@ function panelCards(items = []) {
     title: item.title || item.name,
     text: item.text || item.description || item.focus || item.publisher || '',
     note: item.highlight || item.note || item.audience || item.category || null,
-  }));
-}
-
-function listToCards(items = []) {
-  return items.map((item, index) => ({
-    label: `Punkt ${index + 1}`,
-    text: item,
   }));
 }
 
@@ -124,15 +116,36 @@ export default function EvidenceSection({ downloadResources = [] }) {
     aside: {
       label: 'Orientierung',
       title: 'Vom Verstehen zum Handeln',
-      copy:
-        'Jeder Abschnitt übersetzt Forschung, Erfahrungswissen und Versorgungsperspektive in eine kompakte Arbeitslogik für Alltag, Diagnostik, Gespräch und Vernetzung.',
-      badges: ['Kapitel 1 Relevanz', 'Kapitel 2 Psychoedukation', 'Kapitel 3 Elternarbeit', 'Kapitel 4 Vernetzung', 'Kapitel 5 Materialien'],
+      copy: 'Jeder Abschnitt übersetzt Forschung, Erfahrungswissen und Versorgungsperspektive in eine kompakte Arbeitslogik für Alltag, Diagnostik, Gespräch und Vernetzung.',
+      badges: [
+        'Kapitel 1 Relevanz',
+        'Kapitel 2 Psychoedukation',
+        'Kapitel 3 Elternarbeit',
+        'Kapitel 4 Vernetzung',
+        'Kapitel 5 Materialien',
+      ],
     },
     items: [
-      { id: 'evidenz-verstehen', label: '1 Verstehen', note: 'Relevanz, Elternschaft, Familiensystem, kindliches Erleben' },
-      { id: 'evidenz-mit-kindern-sprechen', label: '2 Mit Kindern sprechen', note: 'Vorbereitung, Alterslogik, Schwierigkeitspunkte und Praxis' },
-      { id: 'evidenz-mit-eltern-arbeiten', label: '3 Mit Eltern arbeiten', note: 'Barrieren, Kooperation, Scham und alltagsnahe Entlastung' },
-      { id: 'evidenz-handeln-und-vernetzen', label: '4 Handeln und vernetzen', note: 'Unterstützungsangebote, klinische Schritte und nächste Interventionen' },
+      {
+        id: 'evidenz-verstehen',
+        label: '1 Verstehen',
+        note: 'Relevanz, Elternschaft, Familiensystem, kindliches Erleben',
+      },
+      {
+        id: 'evidenz-mit-kindern-sprechen',
+        label: '2 Mit Kindern sprechen',
+        note: 'Vorbereitung, Alterslogik, Schwierigkeitspunkte und Praxis',
+      },
+      {
+        id: 'evidenz-mit-eltern-arbeiten',
+        label: '3 Mit Eltern arbeiten',
+        note: 'Barrieren, Kooperation, Scham und alltagsnahe Entlastung',
+      },
+      {
+        id: 'evidenz-handeln-und-vernetzen',
+        label: '4 Handeln und vernetzen',
+        note: 'Unterstützungsangebote, klinische Schritte und nächste Interventionen',
+      },
       { id: 'evidenz-materialien', label: '5 Materialien', note: 'Downloads, Literatur, Medien und externe Hilfen' },
     ],
   };
@@ -147,8 +160,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
       aside: {
         label: 'Versorgungsperspektive',
         title: 'Elternschaft ist kein Nebenthema.',
-        copy:
-          'Wenn psychische Belastung den Familienalltag, die Erreichbarkeit von Erwachsenen und die kindliche Orientierung mitprägt, muss Elternschaft früh in Anamnese, Behandlung und Austrittsplanung sichtbar werden.',
+        copy: 'Wenn psychische Belastung den Familienalltag, die Erreichbarkeit von Erwachsenen und die kindliche Orientierung mitprägt, muss Elternschaft früh in Anamnese, Behandlung und Austrittsplanung sichtbar werden.',
       },
       metrics: RELEVANCE_STATS.map((item) => ({
         label: item.label,
@@ -181,8 +193,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
       ],
       cardColumns: 'three',
       callout: {
-        text:
-          'Für die Praxis zählt weniger eine abstrakte Diagnose als die Frage, wie verlässlich Alltag, Kommunikation, Beziehung und Schutzfaktoren aktuell tatsächlich funktionieren.',
+        text: 'Für die Praxis zählt weniger eine abstrakte Diagnose als die Frage, wie verlässlich Alltag, Kommunikation, Beziehung und Schutzfaktoren aktuell tatsächlich funktionieren.',
       },
     },
     {
@@ -197,8 +208,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
       aside: {
         label: 'Leitidee',
         title: 'Verstehbare Sprache schützt.',
-        copy:
-          'Kinder brauchen keine perfekte Erklärung, sondern eine stimmige, wiederholbare und entwicklungsangemessene Sprache dafür, was sich zuhause verändert und was verlässlich bleibt.',
+        copy: 'Kinder brauchen keine perfekte Erklärung, sondern eine stimmige, wiederholbare und entwicklungsangemessene Sprache dafür, was sich zuhause verändert und was verlässlich bleibt.',
       },
       highlightList: {
         tone: 'soft',
@@ -208,17 +218,23 @@ export default function EvidenceSection({ downloadResources = [] }) {
         {
           label: 'Alterslogik',
           title: 'Je jünger das Kind, desto wichtiger sind Sicherheit, Wiederholung und konkrete Alltagssprache.',
-          paragraphs: ['Die Gesprächsführung orientiert sich am Entwicklungsstand des Kindes. Die vorhandenen Altersgruppen helfen, den Schwerpunkt jeweils zwischen Sicherheit, Erklärung, Mitbestimmung und Nachfragen auszubalancieren.'],
+          paragraphs: [
+            'Die Gesprächsführung orientiert sich am Entwicklungsstand des Kindes. Die vorhandenen Altersgruppen helfen, den Schwerpunkt jeweils zwischen Sicherheit, Erklärung, Mitbestimmung und Nachfragen auszubalancieren.',
+          ],
         },
         {
           label: 'Settings',
           title: 'Gespräche können unterschiedlich gerahmt werden – entscheidend ist die Passung.',
-          paragraphs: ['Manchmal sprechen Eltern selbst mit Unterstützung, manchmal ist ein gemeinsames Familiengespräch sinnvoll. Wichtig ist, dass Vorbereitung, Verantwortung und Nachsorge geklärt sind.'],
+          paragraphs: [
+            'Manchmal sprechen Eltern selbst mit Unterstützung, manchmal ist ein gemeinsames Familiengespräch sinnvoll. Wichtig ist, dass Vorbereitung, Verantwortung und Nachsorge geklärt sind.',
+          ],
         },
         {
           label: 'Schwierige Momente',
           title: 'Stockungen, Abbrüche oder viele Fragen sind kein Scheitern.',
-          paragraphs: ['Schwierigkeiten im Gespräch sind oft Ausdruck von Schutz, Loyalität oder Überforderung. Sie brauchen Wiederanknüpfen statt Druck.'],
+          paragraphs: [
+            'Schwierigkeiten im Gespräch sind oft Ausdruck von Schutz, Loyalität oder Überforderung. Sie brauchen Wiederanknüpfen statt Druck.',
+          ],
         },
       ],
       cards: [
@@ -228,8 +244,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
       ],
       cardColumns: 'three',
       callout: {
-        text:
-          'Die Kernbotschaften bleiben über Altersstufen hinweg konstant: Du bist nicht schuld. Du bist nicht allein. Erwachsene kümmern sich.',
+        text: 'Die Kernbotschaften bleiben über Altersstufen hinweg konstant: Du bist nicht schuld. Du bist nicht allein. Erwachsene kümmern sich.',
       },
     },
     {
@@ -244,8 +259,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
       aside: {
         label: 'Kooperation',
         title: 'Ambivalenz ist normal und bearbeitbar.',
-        copy:
-          'Gelingende Zusammenarbeit entlastet, benennt Ängste offen und stärkt die Elternrolle, statt Eltern nur durch Risikobrillen zu betrachten.',
+        copy: 'Gelingende Zusammenarbeit entlastet, benennt Ängste offen und stärkt die Elternrolle, statt Eltern nur durch Risikobrillen zu betrachten.',
       },
       highlightList: {
         tone: 'soft',
@@ -261,12 +275,16 @@ export default function EvidenceSection({ downloadResources = [] }) {
         {
           label: 'Gesprächseinstieg',
           title: 'Gute Kooperation beginnt mit Anlass, Anliegen, Auftrag und Abmachungen.',
-          paragraphs: ['Die Vier-A-Logik schafft Orientierung und verhindert, dass Gespräche diffus bleiben. Sie übersetzt Respekt in eine klare Gesprächsstruktur.'],
+          paragraphs: [
+            'Die Vier-A-Logik schafft Orientierung und verhindert, dass Gespräche diffus bleiben. Sie übersetzt Respekt in eine klare Gesprächsstruktur.',
+          ],
         },
         {
           label: 'Alltagshilfe',
           title: 'Nicht alles stabilisieren wollen – zuerst das Verlässlichste sichern.',
-          paragraphs: ['Im Alltag helfen kleine, wiederholbare Schritte oft mehr als grosse Appelle. Versorgung, Übergaben, Schlaf, Essen und Entlastung haben Priorität.'],
+          paragraphs: [
+            'Im Alltag helfen kleine, wiederholbare Schritte oft mehr als grosse Appelle. Versorgung, Übergaben, Schlaf, Essen und Entlastung haben Priorität.',
+          ],
         },
       ],
       cards: [
@@ -276,8 +294,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
       ],
       cardColumns: 'three',
       callout: {
-        text:
-          'Der fachliche Fokus liegt nicht auf moralischer Bewertung, sondern auf der Frage, wie Eltern konkret entlastet und in ihrer Rolle handlungsfähig gehalten werden können.',
+        text: 'Der fachliche Fokus liegt nicht auf moralischer Bewertung, sondern auf der Frage, wie Eltern konkret entlastet und in ihrer Rolle handlungsfähig gehalten werden können.',
       },
     },
     {
@@ -292,8 +309,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
       aside: {
         label: 'Systemlogik',
         title: 'Schutz entsteht durch Kombination.',
-        copy:
-          'Tragfähig werden Unterstützungsprozesse dann, wenn offizielle Hilfen, private Bezugspersonen und konkrete Alltagsschritte aufeinander bezogen werden.',
+        copy: 'Tragfähig werden Unterstützungsprozesse dann, wenn offizielle Hilfen, private Bezugspersonen und konkrete Alltagsschritte aufeinander bezogen werden.',
       },
       highlightList: {
         tone: 'soft',
@@ -308,17 +324,15 @@ export default function EvidenceSection({ downloadResources = [] }) {
         {
           label: 'Unterstützungslandschaft',
           title: 'Angebote gewinnen an Wirkung, wenn sie nach Funktion und Zugänglichkeit sortiert werden.',
-          paragraphs: ['Für Angehörige, Kinder, Eltern und Fachpersonen ist nicht nur das Vorhandensein von Hilfen entscheidend, sondern die schnelle Übersetzbarkeit in einen konkreten nächsten Schritt.'],
+          paragraphs: [
+            'Für Angehörige, Kinder, Eltern und Fachpersonen ist nicht nur das Vorhandensein von Hilfen entscheidend, sondern die schnelle Übersetzbarkeit in einen konkreten nächsten Schritt.',
+          ],
         },
       ],
-      cards: [
-        ...panelCards(CLINICAL_PRACTICE_PANELS),
-        ...supportOfferCards(SUPPORT_OFFERS),
-      ],
+      cards: [...panelCards(CLINICAL_PRACTICE_PANELS), ...supportOfferCards(SUPPORT_OFFERS)],
       cardColumns: 'three',
       callout: {
-        text:
-          'Die offizielle Angehörigenberatung der PUK Zürich bleibt im Zürcher Kontext eine zentrale Anlaufstelle, besonders wenn Elternschaft, psychische Belastung und kindliche Mitbetroffenheit gemeinsam in den Blick kommen.',
+        text: 'Die offizielle Angehörigenberatung der PUK Zürich bleibt im Zürcher Kontext eine zentrale Anlaufstelle, besonders wenn Elternschaft, psychische Belastung und kindliche Mitbetroffenheit gemeinsam in den Blick kommen.',
       },
     },
   ];
@@ -335,8 +349,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
     aside: {
       label: 'Hinweis',
       title: 'Orientierung statt Ersatz für Beratung',
-      copy:
-        'Downloads und Medien schaffen Sprache, Struktur und Gesprächsanlässe. Sie ersetzen jedoch keine fachliche Beurteilung, kein Krisenmanagement und keine institutionelle Beratung.',
+      copy: 'Downloads und Medien schaffen Sprache, Struktur und Gesprächsanlässe. Sie ersetzen jedoch keine fachliche Beurteilung, kein Krisenmanagement und keine institutionelle Beratung.',
     },
     primaryActions: downloadResources.map((item) => ({
       title: item.title,
@@ -378,5 +391,13 @@ export default function EvidenceSection({ downloadResources = [] }) {
     notes: MEDIA_NOTES,
   });
 
-  return <EvidencePageTemplate hero={hero} pageHeadingId={getPageHeadingId('evidenz')} chapterOverview={chapterOverview} zones={zones} closingSection={closingSection} />;
+  return (
+    <EvidencePageTemplate
+      hero={hero}
+      pageHeadingId={getPageHeadingId('evidenz')}
+      chapterOverview={chapterOverview}
+      zones={zones}
+      closingSection={closingSection}
+    />
+  );
 }

--- a/src/sections/GlossarSection.jsx
+++ b/src/sections/GlossarSection.jsx
@@ -1,11 +1,14 @@
-import {
-  GLOSSARY_GROUPS,
-  GLOSSARY_HERO,
-  GLOSSARY_INTRO,
-} from '../data/glossaryContent';
+import { GLOSSARY_GROUPS, GLOSSARY_HERO, GLOSSARY_INTRO } from '../data/glossaryContent';
 import GlossarPageTemplate from '../templates/GlossarPageTemplate';
 import { getPageHeadingId } from '../utils/appHelpers';
 
 export default function GlossarSection() {
-  return <GlossarPageTemplate hero={GLOSSARY_HERO} pageHeadingId={getPageHeadingId('glossar')} intro={GLOSSARY_INTRO} groups={GLOSSARY_GROUPS} />;
+  return (
+    <GlossarPageTemplate
+      hero={GLOSSARY_HERO}
+      pageHeadingId={getPageHeadingId('glossar')}
+      intro={GLOSSARY_INTRO}
+      groups={GLOSSARY_GROUPS}
+    />
+  );
 }

--- a/src/sections/GrundlagenSection.jsx
+++ b/src/sections/GrundlagenSection.jsx
@@ -5,7 +5,9 @@ import { getPageHeadingId } from '../utils/appHelpers';
 
 function mapGrundlagenDownloads(sharedDownloadResources = []) {
   return sharedDownloadResources
-    .filter((item) => ['Gesprächsleitfaden für Fachpersonen', 'Psychoedukations-Hilfe', 'Schutzfaktoren-Check'].includes(item.title))
+    .filter((item) =>
+      ['Gesprächsleitfaden für Fachpersonen', 'Psychoedukations-Hilfe', 'Schutzfaktoren-Check'].includes(item.title)
+    )
     .map((item) => ({
       ...item,
       kind: 'download',
@@ -27,8 +29,7 @@ export default function GrundlagenSection({ sharedDownloadResources = [], onNavi
     aside: {
       label: 'Arbeitslogik',
       title: 'Von FAQ zu handhabbaren Schritten',
-      copy:
-        'Wenn eine Frage hängen bleibt, hilft oft kein weiteres Lesen, sondern ein kleines Arbeitsmittel oder der Wechsel in den nächsten passenden Seitentyp.',
+      copy: 'Wenn eine Frage hängen bleibt, hilft oft kein weiteres Lesen, sondern ein kleines Arbeitsmittel oder der Wechsel in den nächsten passenden Seitentyp.',
       tone: 'soft',
     },
     collections: mapGrundlagenDownloads(sharedDownloadResources).length
@@ -53,7 +54,8 @@ export default function GrundlagenSection({ sharedDownloadResources = [], onNavi
         {
           kind: 'navigation',
           title: 'Toolbox',
-          description: 'Wenn Antworten in Priorisierung, Sicherheitsplanung oder konkrete nächste Schritte übersetzt werden müssen.',
+          description:
+            'Wenn Antworten in Priorisierung, Sicherheitsplanung oder konkrete nächste Schritte übersetzt werden müssen.',
           meta: ['Arbeitsmodus', 'Nächste Schritte'],
           actionLabel: 'Zur Toolbox wechseln',
           onClick: () => onNavigateToTab('toolbox', { focusTarget: 'heading' }),
@@ -61,7 +63,8 @@ export default function GrundlagenSection({ sharedDownloadResources = [], onNavi
         {
           kind: 'navigation',
           title: 'Glossar',
-          description: 'Wenn Begriffe wie Parentifizierung, Schweigepflicht oder Kindesperspektive zuerst sprachlich geklärt werden sollen.',
+          description:
+            'Wenn Begriffe wie Parentifizierung, Schweigepflicht oder Kindesperspektive zuerst sprachlich geklärt werden sollen.',
           meta: ['Begriffe', 'Einordnung'],
           actionLabel: 'Zum Glossar wechseln',
           onClick: () => onNavigateToTab('glossar', { focusTarget: 'heading' }),
@@ -69,7 +72,8 @@ export default function GrundlagenSection({ sharedDownloadResources = [], onNavi
         {
           kind: 'navigation',
           title: 'Netzwerk',
-          description: 'Wenn aus Orientierung eine konkrete Fachstelle, regionale Hilfe oder Weitervermittlung werden soll.',
+          description:
+            'Wenn aus Orientierung eine konkrete Fachstelle, regionale Hilfe oder Weitervermittlung werden soll.',
           meta: ['Versorgung', 'Weitervermittlung'],
           actionLabel: 'Zum Netzwerk wechseln',
           onClick: () => onNavigateToTab('netzwerk', { focusTarget: 'heading' }),
@@ -78,5 +82,13 @@ export default function GrundlagenSection({ sharedDownloadResources = [], onNavi
     },
   });
 
-  return <GrundlagenPageTemplate hero={GRUNDLAGEN_HERO} pageHeadingId={getPageHeadingId('grundlagen')} intro={GRUNDLAGEN_INTRO} clusters={GRUNDLAGEN_CLUSTERS} closingSection={closingSection} />;
+  return (
+    <GrundlagenPageTemplate
+      hero={GRUNDLAGEN_HERO}
+      pageHeadingId={getPageHeadingId('grundlagen')}
+      intro={GRUNDLAGEN_INTRO}
+      clusters={GRUNDLAGEN_CLUSTERS}
+      closingSection={closingSection}
+    />
+  );
 }

--- a/src/sections/HomeSection.jsx
+++ b/src/sections/HomeSection.jsx
@@ -1,13 +1,33 @@
 // Design note: Editorial landing composition with warm paper panels, serif-led hierarchy, quieter cards, and high whitespace while preserving the original information architecture.
 import { useMemo } from 'react';
-import { ChevronRight, ClipboardCheck, ExternalLink, GraduationCap, HeartHandshake, Library, MapPin } from 'lucide-react';
+import {
+  ChevronRight,
+  ClipboardCheck,
+  ExternalLink,
+  GraduationCap,
+  HeartHandshake,
+  Library,
+  MapPin,
+} from 'lucide-react';
 import heroIllustration from '../assets/relational-recovery-hero-v3-web.png';
 import { E_MODULE_COUNT, HOME_REFERENCE_COUNT, NETWORK_RESOURCE_COUNT, VIGNETTE_COUNT } from '../data/appShellContent';
 
 const overviewCards = [
   { label: 'Module', val: E_MODULE_COUNT, desc: 'kompakte Lernbausteine', icon: GraduationCap, tab: 'lernmodule' },
-  { label: 'Trainingsfälle', val: VIGNETTE_COUNT, desc: 'für Fallreflexion und Dialog', icon: HeartHandshake, tab: 'vignetten' },
-  { label: 'Netzwerkstellen', val: NETWORK_RESOURCE_COUNT, desc: 'für Triage und Entlastung', icon: MapPin, tab: 'netzwerk' },
+  {
+    label: 'Trainingsfälle',
+    val: VIGNETTE_COUNT,
+    desc: 'für Fallreflexion und Dialog',
+    icon: HeartHandshake,
+    tab: 'vignetten',
+  },
+  {
+    label: 'Netzwerkstellen',
+    val: NETWORK_RESOURCE_COUNT,
+    desc: 'für Triage und Entlastung',
+    icon: MapPin,
+    tab: 'netzwerk',
+  },
   { label: 'Referenzen', val: HOME_REFERENCE_COUNT, desc: 'für fachliche Vertiefung', icon: Library, tab: 'evidenz' },
 ];
 
@@ -84,7 +104,7 @@ export default function HomeSection({ activeTab, setActiveTab, progressPercent, 
         note: 'orientierender Lernstand',
       },
     ],
-    [completedModules.length, progressPercent],
+    [completedModules.length, progressPercent]
   );
 
   return (
@@ -118,8 +138,8 @@ export default function HomeSection({ activeTab, setActiveTab, progressPercent, 
             <div className="ui-note-panel home-hero-main__progress-note">
               <div className="ui-note-panel__label">Lernstand</div>
               <p className="ui-note-panel__copy">
-                {completedModules.length} von {E_MODULE_COUNT} Lernmodulen bearbeitet. Das Dashboard unten führt direkt zu den
-                nächsten Arbeitsbereichen.
+                {completedModules.length} von {E_MODULE_COUNT} Lernmodulen bearbeitet. Das Dashboard unten führt direkt
+                zu den nächsten Arbeitsbereichen.
               </p>
             </div>
 
@@ -136,13 +156,18 @@ export default function HomeSection({ activeTab, setActiveTab, progressPercent, 
               <div className="ui-note-panel__label">Wichtiger Hinweis zur Einordnung</div>
               <div className="ui-copy">
                 <p>
-                  Diese Website ist ein ergänzendes psychoedukatives Informationsangebot im Themenfeld Angehörigenarbeit,
-                  psychisch belastete Elternschaft und Kinder psychisch erkrankter Eltern. Für offizielle Informationen und Beratung
-                  bleibt die Angehörigenberatung der PUK Zürich die zentrale Anlaufstelle.
+                  Diese Website ist ein ergänzendes psychoedukatives Informationsangebot im Themenfeld
+                  Angehörigenarbeit, psychisch belastete Elternschaft und Kinder psychisch erkrankter Eltern. Für
+                  offizielle Informationen und Beratung bleibt die Angehörigenberatung der PUK Zürich die zentrale
+                  Anlaufstelle.
                 </p>
               </div>
               <div className="ui-button-row">
-                <button type="button" onClick={() => setActiveTab('netzwerk')} className="ui-button ui-button--secondary">
+                <button
+                  type="button"
+                  onClick={() => setActiveTab('netzwerk')}
+                  className="ui-button ui-button--secondary"
+                >
                   Zum Netzwerkbereich mit PUK-Angeboten
                 </button>
                 <a
@@ -185,10 +210,15 @@ export default function HomeSection({ activeTab, setActiveTab, progressPercent, 
 
           <div className="home-progress-panel__footer">
             <p className="home-progress-panel__copy">
-              Die Fortschrittsansicht bleibt bewusst ruhig und textbasiert, damit Orientierung wichtiger ist als reine UI-Inszenierung.
+              Die Fortschrittsansicht bleibt bewusst ruhig und textbasiert, damit Orientierung wichtiger ist als reine
+              UI-Inszenierung.
             </p>
             {activeTab !== 'vignetten' && (
-              <button type="button" onClick={() => setActiveTab('vignetten')} className="ui-button ui-button--secondary">
+              <button
+                type="button"
+                onClick={() => setActiveTab('vignetten')}
+                className="ui-button ui-button--secondary"
+              >
                 Zu den Trainingsfällen <ChevronRight size={14} />
               </button>
             )}
@@ -204,14 +234,16 @@ export default function HomeSection({ activeTab, setActiveTab, progressPercent, 
               Ein möglicher <span className="ui-hero__accent">Arbeitsweg</span> durch die Website.
             </h3>
             <p className="home-feature-panel__lead">
-              Die Inhalte sind nicht als lose Sammlung gedacht, sondern als fachliche Abfolge: erst verstehen, dann einschätzen,
-              daraus konkrete Schritte ableiten und passende Hilfen vernetzen. Das Diagramm bündelt diese Logik auf einer Seite.
+              Die Inhalte sind nicht als lose Sammlung gedacht, sondern als fachliche Abfolge: erst verstehen, dann
+              einschätzen, daraus konkrete Schritte ableiten und passende Hilfen vernetzen. Das Diagramm bündelt diese
+              Logik auf einer Seite.
             </p>
           </div>
           <aside className="ui-note-panel home-support-panel">
             <div className="ui-note-panel__label">Einordnung</div>
             <p className="ui-note-panel__copy">
-              Kein starres Schema, sondern eine ruhige fachliche Leitstruktur für Orientierung, Triage und Gesprächsplanung.
+              Kein starres Schema, sondern eine ruhige fachliche Leitstruktur für Orientierung, Triage und
+              Gesprächsplanung.
             </p>
           </aside>
         </div>
@@ -241,8 +273,8 @@ export default function HomeSection({ activeTab, setActiveTab, progressPercent, 
 
           <div className="ui-note-panel ui-note-panel--muted home-pathway-summary">
             <p className="ui-note-panel__copy">
-              Leitidee: Gute Begleitung verbindet systemisches Verstehen, pragmatische Einschätzung, klare nächste Schritte und
-              aktivierte Unterstützung statt isolierter Einzelentscheidungen.
+              Leitidee: Gute Begleitung verbindet systemisches Verstehen, pragmatische Einschätzung, klare nächste
+              Schritte und aktivierte Unterstützung statt isolierter Einzelentscheidungen.
             </p>
           </div>
         </div>
@@ -256,8 +288,8 @@ export default function HomeSection({ activeTab, setActiveTab, progressPercent, 
               Einstieg nach <span className="ui-hero__accent">Fachfrage</span> statt nach Menüpunkt.
             </h3>
             <p className="home-feature-panel__lead">
-              Die Startseite funktioniert am besten, wenn typische Praxisanliegen direkt in den passenden Bereich führen. Die Karten
-              unten übersetzen häufige Arbeitsfragen in klare Einstiegswege.
+              Die Startseite funktioniert am besten, wenn typische Praxisanliegen direkt in den passenden Bereich
+              führen. Die Karten unten übersetzen häufige Arbeitsfragen in klare Einstiegswege.
             </p>
           </div>
           <aside className="ui-note-panel home-support-panel">

--- a/src/sections/NetworkSection.jsx
+++ b/src/sections/NetworkSection.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { MapPin, Search } from 'lucide-react';
 import heroIllustration from '../assets/relational-recovery-hero-v3-web.png';
 import {
@@ -59,19 +59,18 @@ export default function NetworkSection({ searchTerm, setSearchTerm, activeResour
     : `${filteredResources.length} Fachstellen werden angezeigt.`;
 
   const filterStatusText =
-    activeResourceFilter === 'all'
-      ? 'Es werden alle Fachstellen angezeigt.'
-      : `Filter aktiv: ${activeResourceFilter}.`;
+    activeResourceFilter === 'all' ? 'Es werden alle Fachstellen angezeigt.' : `Filter aktiv: ${activeResourceFilter}.`;
 
   const activeLens = NETWORK_MAP_LENSES.find((lens) => lens.id === networkLens) ?? NETWORK_MAP_LENSES[0];
-  const visibleMapNodes = NETWORK_MAP_TEMPLATE_NODES.filter((node) => networkLens === 'all' || node.tone === networkLens);
+  const visibleMapNodes = NETWORK_MAP_TEMPLATE_NODES.filter(
+    (node) => networkLens === 'all' || node.tone === networkLens
+  );
 
   const hero = {
     eyebrow: 'Triage und Support',
     title: 'Netzwerk in',
     accent: 'Zürich und schweizweit lesen.',
-    lead:
-      'Die Seite verbindet zürich-zentrierte Krisenwege, Familienberatung, Kinder- und Jugendangebote sowie wenige schweizweite Ergänzungen. Das neue Seitentyp-System trennt dabei Suchlogik, Fachstellenverzeichnis und Netzwerkkarte sauber voneinander.',
+    lead: 'Die Seite verbindet zürich-zentrierte Krisenwege, Familienberatung, Kinder- und Jugendangebote sowie wenige schweizweite Ergänzungen. Das neue Seitentyp-System trennt dabei Suchlogik, Fachstellenverzeichnis und Netzwerkkarte sauber voneinander.',
     image: heroIllustration,
     imageAlt: 'Illustration eines Familiensystems mit Beziehungslinien und ruhiger Orientierung',
     asideTitle: 'Einordnung',
@@ -184,5 +183,12 @@ export default function NetworkSection({ searchTerm, setSearchTerm, activeResour
     nextStepText: LENS_NEXT_STEP[networkLens] ?? LENS_NEXT_STEP.all,
   };
 
-  return <NetworkPageTemplate hero={hero} pageHeadingId={getPageHeadingId('netzwerk')} directory={directory} mapping={mapping} />;
+  return (
+    <NetworkPageTemplate
+      hero={hero}
+      pageHeadingId={getPageHeadingId('netzwerk')}
+      directory={directory}
+      mapping={mapping}
+    />
+  );
 }

--- a/src/sections/ToolboxSection.jsx
+++ b/src/sections/ToolboxSection.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   AlertTriangle,
   Check,
@@ -242,8 +242,7 @@ export default function ToolboxSection({
     aside: {
       label: 'Arbeitslogik',
       title: 'Sicherheit zuerst, dann Struktur, dann Kooperation',
-      copy:
-        'Die Seite priorisiert zuerst akute Risiken, danach Versorgung und Kinder-Schutzteil und erst anschliessend die längerfristige Zusammenarbeit mit Netzwerk und Fachstellen.',
+      copy: 'Die Seite priorisiert zuerst akute Risiken, danach Versorgung und Kinder-Schutzteil und erst anschliessend die längerfristige Zusammenarbeit mit Netzwerk und Fachstellen.',
       tone: 'soft',
     },
   };
@@ -253,8 +252,7 @@ export default function ToolboxSection({
     title: 'Belastung orientierend einschätzen',
     description:
       'Die Faktoren dienen als klinische Gesprächshilfe. Sie helfen, relevante Belastungshinweise sichtbar zu machen und daraus Schutz-, Vorsorge- oder Unterstützungsbedarfe abzuleiten.',
-    note:
-      'Das Instrument ersetzt keine fachliche Gesamtbeurteilung und ist bewusst auf beobachtbare Alltagshinweise fokussiert.',
+    note: 'Das Instrument ersetzt keine fachliche Gesamtbeurteilung und ist bewusst auf beobachtbare Alltagshinweise fokussiert.',
     scoreAside: {
       label: 'Orientierender Hinweis',
       value: score.risk,
@@ -289,8 +287,7 @@ export default function ToolboxSection({
     aside: {
       label: 'Warum diese Reihenfolge?',
       title: 'Niedriger kognitiver Druck in angespannten Situationen',
-      copy:
-        'In akuten oder hoch belasteten Lagen helfen kurze Entscheidungen, sichtbare Prioritäten und konkrete Anschlusswege mehr als grosse Informationsmengen.',
+      copy: 'In akuten oder hoch belasteten Lagen helfen kurze Entscheidungen, sichtbare Prioritäten und konkrete Anschlusswege mehr als grosse Informationsmengen.',
     },
     steps: PATHWAY_STEPS,
   };
@@ -302,8 +299,7 @@ export default function ToolboxSection({
     items: SCORE_BANDS,
     aside: {
       label: 'Interpretation',
-      copy:
-        'Auch niedrige Werte können bei einzelnen hoch relevanten Ereignissen dringlich sein. Umgekehrt bedeuten höhere Werte vor allem: genauer hinschauen, absichern, kooperieren.',
+      copy: 'Auch niedrige Werte können bei einzelnen hoch relevanten Ereignissen dringlich sein. Umgekehrt bedeuten höhere Werte vor allem: genauer hinschauen, absichern, kooperieren.',
     },
   };
 
@@ -545,7 +541,8 @@ export default function ToolboxSection({
           <p className="toolbox-print-kicker">Relational Recovery · Toolbox Arbeitsansicht</p>
           <h1 className="toolbox-print-title">Orientierung, Schutz und nächste Schritte</h1>
           <p className="toolbox-print-lead">
-            Kompakte Gesprächs- und Protokollansicht für akute Belastung, Krisenvorsorge und nächste verlässliche Schritte.
+            Kompakte Gesprächs- und Protokollansicht für akute Belastung, Krisenvorsorge und nächste verlässliche
+            Schritte.
           </p>
         </header>
 
@@ -585,7 +582,10 @@ export default function ToolboxSection({
           <p className="toolbox-print-kicker">Krisenvorsorge und Kinder-Schutzteil</p>
           <div className="toolbox-print-grid-two toolbox-print-grid-two--top-spaced">
             {SAFETY_PLAN_TEMPLATE_FIELDS.map((field) => (
-              <div key={field.title} className="toolbox-print-block toolbox-print-card toolbox-print-card--compact toolbox-print-card--field">
+              <div
+                key={field.title}
+                className="toolbox-print-block toolbox-print-card toolbox-print-card--compact toolbox-print-card--field"
+              >
                 <p className="toolbox-print-label">{field.title}</p>
                 <p className="toolbox-print-hint">{field.hint}</p>
                 <div className="toolbox-print-field toolbox-print-field--large" />
@@ -641,7 +641,8 @@ export default function ToolboxSection({
       {
         kind: 'download',
         title: 'Krisenplan als Textvorlage',
-        description: 'Bearbeitbare Kurzvorlage für Warnzeichen, Kontaktkette, Kinderbetreuung, sichere Orte und nächste Schritte.',
+        description:
+          'Bearbeitbare Kurzvorlage für Warnzeichen, Kontaktkette, Kinderbetreuung, sichere Orte und nächste Schritte.',
         meta: ['TXT editierbar', 'Krise / Vorsorge'],
         actionLabel: 'Vorlage herunterladen',
         ariaLabel: 'Krisenplan als Textvorlage aus der Toolbox herunterladen',

--- a/src/sections/VignettenSection.jsx
+++ b/src/sections/VignettenSection.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import VignettenPageTemplate from '../templates/VignettenPageTemplate';
 import { VIGNETTEN } from '../data/learningContent';
 import { getPageHeadingId } from '../utils/appHelpers';
@@ -16,8 +15,7 @@ export default function VignettenSection({ currentIndex, setCurrentIndex, select
     eyebrow: 'Fallreflexion',
     title: 'Training mit',
     accent: 'Vignetten',
-    lead:
-      'Kurze Fallsituationen zur Reflexion zwischen Schutz, Kooperation und systemischer Entlastung. Die Darstellung bleibt bewusst fachlich und abwägend statt dramatisch.',
+    lead: 'Kurze Fallsituationen zur Reflexion zwischen Schutz, Kooperation und systemischer Entlastung. Die Darstellung bleibt bewusst fachlich und abwägend statt dramatisch.',
     asideTitle: 'Format',
     asideCopy:
       'Ein Fall, zwei Optionen, direkte fachliche Rückmeldung. Gedacht als Gesprächsimpuls, nicht als Prüfung.',
@@ -93,5 +91,13 @@ export default function VignettenSection({ currentIndex, setCurrentIndex, select
     onNext: () => setCurrentIndex((prev) => Math.min(prev + 1, VIGNETTEN.length - 1)),
   };
 
-  return <VignettenPageTemplate hero={hero} pageHeadingId={getPageHeadingId('vignetten')} caseStudy={caseStudy} decision={decision} navigation={navigation} />;
+  return (
+    <VignettenPageTemplate
+      hero={hero}
+      pageHeadingId={getPageHeadingId('vignetten')}
+      caseStudy={caseStudy}
+      decision={decision}
+      navigation={navigation}
+    />
+  );
 }

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -293,7 +293,12 @@
   letter-spacing: 0.18em;
   text-transform: uppercase;
   text-decoration: none;
-  transition: background-color var(--motion-fast) ease, color var(--motion-fast) ease, border-color var(--motion-fast) ease, transform var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+  transition:
+    background-color var(--motion-fast) ease,
+    color var(--motion-fast) ease,
+    border-color var(--motion-fast) ease,
+    transform var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease;
   cursor: pointer;
 }
 
@@ -455,7 +460,12 @@
   letter-spacing: 0.18em;
   line-height: 1;
   text-transform: uppercase;
-  transition: background-color var(--motion-fast) ease, color var(--motion-fast) ease, border-color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
+  transition:
+    background-color var(--motion-fast) ease,
+    color var(--motion-fast) ease,
+    border-color var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease,
+    transform var(--motion-fast) ease;
 }
 
 .ui-chip:hover {
@@ -558,7 +568,10 @@
   font-size: var(--font-size-md);
   line-height: 1.4;
   outline: none;
-  transition: border-color var(--motion-fast) ease, background-color var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+  transition:
+    border-color var(--motion-fast) ease,
+    background-color var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease;
 }
 
 .ui-input::placeholder {
@@ -572,7 +585,11 @@
 }
 
 .ui-card--interactive {
-  transition: transform var(--motion-fast) ease, border-color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, background-color var(--motion-fast) ease;
+  transition:
+    transform var(--motion-fast) ease,
+    border-color var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease,
+    background-color var(--motion-fast) ease;
 }
 
 .ui-card--interactive:hover {
@@ -584,7 +601,9 @@
 .ui-card--interactive:focus-visible {
   outline: none;
   border-color: color-mix(in srgb, var(--accent-primary) 30%, white 70%);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent-primary-soft) 45%, white 55%), var(--shadow-card);
+  box-shadow:
+    0 0 0 4px color-mix(in srgb, var(--accent-primary-soft) 45%, white 55%),
+    var(--shadow-card);
 }
 
 .ui-card--outline {
@@ -632,7 +651,11 @@
   font-size: 1.125rem;
   font-weight: 600;
   color: var(--text-muted);
-  transition: transform var(--motion-fast) ease, border-color var(--motion-fast) ease, background-color var(--motion-fast) ease, color var(--motion-fast) ease;
+  transition:
+    transform var(--motion-fast) ease,
+    border-color var(--motion-fast) ease,
+    background-color var(--motion-fast) ease,
+    color var(--motion-fast) ease;
 }
 
 .ui-disclosure-card[open] .ui-disclosure-card__toggle {
@@ -734,7 +757,11 @@
   font-weight: 700;
   line-height: 1.5;
   text-align: left;
-  transition: border-color var(--motion-fast) ease, background-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+  transition:
+    border-color var(--motion-fast) ease,
+    background-color var(--motion-fast) ease,
+    color var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease;
 }
 
 .ui-choice-card:hover {
@@ -787,7 +814,7 @@
 }
 
 .ui-hero-shell {
-order: 1px solid var(--border-subtle);
+  order: 1px solid var(--border-subtle);
   border-radius: calc(var(--radius-2xl) + 0.25rem);
   background: var(--surface-hero);
   box-shadow: var(--shadow-card);
@@ -981,7 +1008,10 @@ order: 1px solid var(--border-subtle);
   border-radius: var(--radius-2xl);
   border: 2px solid var(--border-default);
   padding: 2rem;
-  transition: transform var(--motion-fast) ease, border-color var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+  transition:
+    transform var(--motion-fast) ease,
+    border-color var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease;
 }
 
 .ui-closing-action:hover .ui-closing-action__preview {
@@ -1112,7 +1142,10 @@ order: 1px solid var(--border-subtle);
   letter-spacing: 0.18em;
   line-height: 1;
   text-transform: uppercase;
-  transition: border-color var(--motion-fast) ease, color var(--motion-fast) ease, transform var(--motion-fast) ease;
+  transition:
+    border-color var(--motion-fast) ease,
+    color var(--motion-fast) ease,
+    transform var(--motion-fast) ease;
 }
 
 .ui-closing-navigator__entry:hover {
@@ -1253,7 +1286,9 @@ order: 1px solid var(--border-subtle);
   font-weight: 800;
   letter-spacing: 0.08em;
   box-shadow: var(--shadow-soft);
-  transition: transform var(--motion-fast) var(--motion-curve-standard), background-color var(--motion-standard) ease;
+  transition:
+    transform var(--motion-fast) var(--motion-curve-standard),
+    background-color var(--motion-standard) ease;
 }
 
 .ui-brand:hover .ui-brand__mark {
@@ -1291,9 +1326,15 @@ order: 1px solid var(--border-subtle);
   justify-self: center;
   border: 1px solid color-mix(in srgb, var(--border-default) 76%, white 24%);
   border-radius: var(--radius-pill);
-  background: linear-gradient(180deg, color-mix(in srgb, white 88%, transparent), color-mix(in srgb, var(--surface-muted) 80%, transparent));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, white 88%, transparent),
+    color-mix(in srgb, var(--surface-muted) 80%, transparent)
+  );
   padding: 0.35rem;
-  box-shadow: inset 0 1px 0 color-mix(in srgb, white 80%, transparent), 0 10px 24px rgba(76, 55, 39, 0.04);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 80%, transparent),
+    0 10px 24px rgba(76, 55, 39, 0.04);
 }
 
 .ui-nav__item {
@@ -1312,7 +1353,12 @@ order: 1px solid var(--border-subtle);
   letter-spacing: var(--letter-spacing-label);
   line-height: 1;
   text-transform: uppercase;
-  transition: background-color var(--motion-standard) ease, color var(--motion-standard) ease, border-color var(--motion-standard) ease, box-shadow var(--motion-standard) ease, transform var(--motion-fast) var(--motion-curve-standard);
+  transition:
+    background-color var(--motion-standard) ease,
+    color var(--motion-standard) ease,
+    border-color var(--motion-standard) ease,
+    box-shadow var(--motion-standard) ease,
+    transform var(--motion-fast) var(--motion-curve-standard);
 }
 
 .ui-nav__item:hover {
@@ -1527,7 +1573,11 @@ order: 1px solid var(--border-subtle);
   padding: 1.25rem;
   background: var(--surface-app);
   cursor: pointer;
-  transition: border-color var(--motion-fast) ease, background-color var(--motion-fast) ease, transform var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+  transition:
+    border-color var(--motion-fast) ease,
+    background-color var(--motion-fast) ease,
+    transform var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease;
 }
 
 .ui-toolbox-check:hover {
@@ -1551,7 +1601,10 @@ order: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   background: white;
   color: transparent;
-  transition: border-color var(--motion-fast) ease, background-color var(--motion-fast) ease, color var(--motion-fast) ease;
+  transition:
+    border-color var(--motion-fast) ease,
+    background-color var(--motion-fast) ease,
+    color var(--motion-fast) ease;
 }
 
 .ui-toolbox-check--checked .ui-toolbox-check__box {
@@ -2127,7 +2180,6 @@ order: 1px solid var(--border-subtle);
     grid-template-columns: minmax(0, 1.2fr) minmax(17rem, 0.8fr);
   }
 }
-
 
 @media (min-width: 64rem) {
   .ui-card-grid--4 {
@@ -3330,7 +3382,11 @@ order: 1px solid var(--border-subtle);
   padding: 1rem;
   color: inherit;
   text-align: left;
-  transition: border-color var(--motion-fast) ease, background-color var(--motion-fast) ease, box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
+  transition:
+    border-color var(--motion-fast) ease,
+    background-color var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease,
+    transform var(--motion-fast) ease;
 }
 
 .footer-nav-link:hover {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -41,8 +41,8 @@
   --focus-outline-radius: 0.875rem;
 
   /* Typography tokens */
-  --font-body: "Manrope", ui-sans-serif, system-ui, sans-serif;
-  --font-heading: "Source Serif 4", Georgia, serif;
+  --font-body: 'Manrope', ui-sans-serif, system-ui, sans-serif;
+  --font-heading: 'Source Serif 4', Georgia, serif;
 
   --font-size-2xs: 0.6875rem;
   --font-size-xs: 0.75rem;

--- a/src/templates/EvidencePageTemplate.jsx
+++ b/src/templates/EvidencePageTemplate.jsx
@@ -1,4 +1,3 @@
-import Button from '../components/ui/Button';
 import Container from '../components/ui/Container';
 import Eyebrow from '../components/ui/Eyebrow';
 import PageHero from '../components/ui/PageHero';
@@ -106,7 +105,9 @@ function ChapterOverview({ chapterOverview }) {
 
           {chapterOverview.aside ? (
             <SurfaceCard as="aside" tone="default">
-              {chapterOverview.aside.label ? <p className="ui-fact-card__label">{chapterOverview.aside.label}</p> : null}
+              {chapterOverview.aside.label ? (
+                <p className="ui-fact-card__label">{chapterOverview.aside.label}</p>
+              ) : null}
               {chapterOverview.aside.title ? <h3 className="ui-card__title">{chapterOverview.aside.title}</h3> : null}
               {chapterOverview.aside.copy ? <p className="ui-card__copy">{chapterOverview.aside.copy}</p> : null}
               {chapterOverview.aside.badges?.length ? (
@@ -141,7 +142,12 @@ function ZoneSection({ zone }) {
   if (!zone) return null;
 
   return (
-    <Section id={zone.id} spacing={zone.spacing || 'tight'} surface={zone.surface || 'plain'} className={zone.className || 'no-print'}>
+    <Section
+      id={zone.id}
+      spacing={zone.spacing || 'tight'}
+      surface={zone.surface || 'plain'}
+      className={zone.className || 'no-print'}
+    >
       <div className="ui-stack ui-stack--loose">
         <div className="ui-split">
           <div className="ui-stack ui-stack--tight">
@@ -162,7 +168,9 @@ function ZoneSection({ zone }) {
           ) : null}
         </div>
 
-        {zone.highlightList ? <BulletList items={zone.highlightList.items} tone={zone.highlightList.tone} icon={zone.highlightList.icon} /> : null}
+        {zone.highlightList ? (
+          <BulletList items={zone.highlightList.items} tone={zone.highlightList.tone} icon={zone.highlightList.icon} />
+        ) : null}
         {zone.metrics?.length ? <MetricGrid items={zone.metrics} /> : null}
         {zone.cards?.length ? <CardGrid items={zone.cards} columns={zone.cardColumns} tone={zone.cardTone} /> : null}
 
@@ -192,7 +200,9 @@ function ZoneSection({ zone }) {
 function MaterialsSection({ closingSection }) {
   if (!closingSection) return null;
 
-  return <ClosingSection section={closingSection} sectionId="evidenz-materialien" surface="plain" className="no-print" />;
+  return (
+    <ClosingSection section={closingSection} sectionId="evidenz-materialien" surface="plain" className="no-print" />
+  );
 }
 
 export default function EvidencePageTemplate({ hero, pageHeadingId, chapterOverview, zones = [], closingSection }) {

--- a/src/templates/GlossarPageTemplate.jsx
+++ b/src/templates/GlossarPageTemplate.jsx
@@ -13,9 +13,7 @@ function GlossarGroup({ group }) {
         <div className="ui-split">
           <div className="ui-stack ui-stack--tight">
             {group.eyebrow ? <Eyebrow>{group.eyebrow}</Eyebrow> : null}
-            <h2 className="ui-hero__title ui-section-title">
-              {group.title}
-            </h2>
+            <h2 className="ui-hero__title ui-section-title">{group.title}</h2>
             {group.description ? (
               <div className="ui-copy">
                 <p>{group.description}</p>

--- a/src/templates/GrundlagenPageTemplate.jsx
+++ b/src/templates/GrundlagenPageTemplate.jsx
@@ -33,9 +33,7 @@ function GrundlagenCluster({ cluster }) {
         <div className="ui-split">
           <div className="ui-stack ui-stack--tight">
             {cluster.eyebrow ? <Eyebrow>{cluster.eyebrow}</Eyebrow> : null}
-            <h2 className="ui-hero__title ui-section-title">
-              {cluster.title}
-            </h2>
+            <h2 className="ui-hero__title ui-section-title">{cluster.title}</h2>
             {cluster.description ? (
               <div className="ui-copy">
                 <p>{cluster.description}</p>
@@ -74,7 +72,14 @@ export default function GrundlagenPageTemplate({ hero, pageHeadingId, intro, clu
       {clusters.map((cluster) => (
         <GrundlagenCluster key={cluster.id} cluster={cluster} />
       ))}
-      {closingSection ? <ClosingSection section={closingSection} sectionId="grundlagen-materials" surface="plain" className="no-print" /> : null}
+      {closingSection ? (
+        <ClosingSection
+          section={closingSection}
+          sectionId="grundlagen-materials"
+          surface="plain"
+          className="no-print"
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/templates/HomeLandingTemplate.jsx
+++ b/src/templates/HomeLandingTemplate.jsx
@@ -8,8 +8,7 @@ export default function HomeLandingTemplate({ setActiveTab, progressPercent, com
     eyebrow: 'Systemische Orientierung',
     title: 'Begleitung ist',
     accent: 'Beziehungsarbeit.',
-    lead:
-      'Interaktive Fachressourcen für die Begleitung von Eltern mit psychischer Belastung – mit Training, systemischer Orientierung, Krisenhilfe, Netzwerk und printfähigen Arbeitshilfen.',
+    lead: 'Interaktive Fachressourcen für die Begleitung von Eltern mit psychischer Belastung – mit Training, systemischer Orientierung, Krisenhilfe, Netzwerk und printfähigen Arbeitshilfen.',
     image: heroIllustration,
     imageAlt: 'Minimalistische Illustration eines Familiensystems mit Nähe, Distanz und Unterstützung',
     asideTitle: 'Wichtiger Hinweis zur Einordnung',

--- a/src/templates/LearningPageTemplate.jsx
+++ b/src/templates/LearningPageTemplate.jsx
@@ -15,7 +15,8 @@ function LearningFlowSection({ sequence }) {
           <div className="ui-stack ui-stack--tight">
             {sequence.eyebrow ? <Eyebrow>{sequence.eyebrow}</Eyebrow> : null}
             <h2 className="ui-hero__title ui-section-title">
-              {sequence.titlePrefix} {sequence.titleAccent ? <span className="ui-hero__accent">{sequence.titleAccent}</span> : null}
+              {sequence.titlePrefix}{' '}
+              {sequence.titleAccent ? <span className="ui-hero__accent">{sequence.titleAccent}</span> : null}
             </h2>
             <div className="ui-copy">
               <p>{sequence.description}</p>
@@ -34,9 +35,7 @@ function LearningFlowSection({ sequence }) {
           <div className="learning-flow-grid">
             {sequence.steps.map((step, index) => (
               <SurfaceCard key={step.title} tone={step.tone || 'default'} className="learning-flow-card">
-                <div className="ui-badge ui-badge--soft">
-                  Schritt {index + 1}
-                </div>
+                <div className="ui-badge ui-badge--soft">Schritt {index + 1}</div>
                 {step.label ? <p className="ui-fact-card__label learning-flow-card__label">{step.label}</p> : null}
                 <h3 className="ui-card__title learning-flow-card__title">{step.title}</h3>
                 <p className="ui-card__copy">{step.copy}</p>
@@ -145,7 +144,9 @@ function LearningModulesSection({ modulesSection }) {
             {modulesSection.eyebrow ? <Eyebrow>{modulesSection.eyebrow}</Eyebrow> : null}
             <h2 className="ui-hero__title ui-section-title">
               {modulesSection.titlePrefix}{' '}
-              {modulesSection.titleAccent ? <span className="ui-hero__accent">{modulesSection.titleAccent}</span> : null}
+              {modulesSection.titleAccent ? (
+                <span className="ui-hero__accent">{modulesSection.titleAccent}</span>
+              ) : null}
             </h2>
             <div className="ui-copy">
               <p>{modulesSection.description}</p>

--- a/src/templates/NetworkPageTemplate.jsx
+++ b/src/templates/NetworkPageTemplate.jsx
@@ -6,7 +6,16 @@ import PageHero from '../components/ui/PageHero';
 import Section from '../components/ui/Section';
 import SurfaceCard from '../components/ui/SurfaceCard';
 
-function FilterToolbar({ filters = [], activeFilter, onFilterChange, searchTerm, onSearchChange, onReset, searchStatusText, filterStatusText }) {
+function FilterToolbar({
+  filters = [],
+  activeFilter,
+  onFilterChange,
+  searchTerm,
+  onSearchChange,
+  onReset,
+  searchStatusText,
+  filterStatusText,
+}) {
   return (
     <div className="ui-network-toolbar">
       <div className="ui-stack ui-stack--tight">
@@ -14,7 +23,8 @@ function FilterToolbar({ filters = [], activeFilter, onFilterChange, searchTerm,
           <Eyebrow>Filter</Eyebrow>
           <div className="ui-copy">
             <p>
-              Die Filter gruppieren Krisenwege, jugendbezogene Angebote, Entlastung und offizielle Stellen, damit je nach Lage schneller priorisiert werden kann.
+              Die Filter gruppieren Krisenwege, jugendbezogene Angebote, Entlastung und offizielle Stellen, damit je
+              nach Lage schneller priorisiert werden kann.
             </p>
           </div>
         </div>
@@ -60,7 +70,13 @@ function FilterToolbar({ filters = [], activeFilter, onFilterChange, searchTerm,
             className="ui-input ui-network-search__input"
           />
         </div>
-        <p id="network-resource-search-status" role="status" aria-live="polite" aria-atomic="true" className="ui-visually-hidden">
+        <p
+          id="network-resource-search-status"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="ui-visually-hidden"
+        >
           {searchStatusText}
         </p>
         {(searchTerm.trim() || activeFilter !== 'all') && (
@@ -76,10 +92,26 @@ function FilterToolbar({ filters = [], activeFilter, onFilterChange, searchTerm,
 function ResourceDirectorySection({ directory }) {
   if (!directory) return null;
 
-  const { intro, filters, activeFilter, onFilterChange, searchTerm, onSearchChange, onReset, searchStatusText, filterStatusText, resources = [] } = directory;
+  const {
+    intro,
+    filters,
+    activeFilter,
+    onFilterChange,
+    searchTerm,
+    onSearchChange,
+    onReset,
+    searchStatusText,
+    filterStatusText,
+    resources = [],
+  } = directory;
 
   return (
-    <Section id={directory.id || 'netzwerk-fachstellen'} spacing="tight" surface={directory.surface || 'plain'} className="no-print">
+    <Section
+      id={directory.id || 'netzwerk-fachstellen'}
+      spacing="tight"
+      surface={directory.surface || 'plain'}
+      className="no-print"
+    >
       <div className="ui-stack ui-stack--loose">
         <div className="ui-split">
           <div className="ui-stack ui-stack--tight">
@@ -143,7 +175,10 @@ function ResourceDirectorySection({ directory }) {
               <div>
                 <p className="ui-fact-card__label">Keine Treffer</p>
                 <h3 className="ui-card__title">Zur aktuellen Kombination wurden keine Fachstellen gefunden.</h3>
-                <p className="ui-card__copy">Prüfen Sie Schreibweise, entfernen Sie einzelne Filter oder setzen Sie Suche und Auswahl gemeinsam zurück.</p>
+                <p className="ui-card__copy">
+                  Prüfen Sie Schreibweise, entfernen Sie einzelne Filter oder setzen Sie Suche und Auswahl gemeinsam
+                  zurück.
+                </p>
               </div>
               <Button type="button" onClick={onReset} variant="secondary">
                 <XCircle size={16} /> Zurücksetzen
@@ -252,11 +287,28 @@ function MobileMapNode({ node, highlighted }) {
 function NetworkMapSection({ mapping }) {
   if (!mapping) return null;
 
-  const { intro, steps = [], questions = [], lenses = [], activeLensId, onLensChange, visibleNodes = [], activeLens, counts = [], lensSummary, nextStepText } = mapping;
+  const {
+    intro,
+    steps = [],
+    questions = [],
+    lenses = [],
+    activeLensId,
+    onLensChange,
+    visibleNodes = [],
+    activeLens,
+    counts = [],
+    lensSummary,
+    nextStepText,
+  } = mapping;
   const highlightedNode = visibleNodes[0] ?? null;
 
   return (
-    <Section id={mapping.id || 'netzwerk-karte'} spacing="tight" surface={mapping.surface || 'subtle'} className="no-print">
+    <Section
+      id={mapping.id || 'netzwerk-karte'}
+      spacing="tight"
+      surface={mapping.surface || 'subtle'}
+      className="no-print"
+    >
       <div className="ui-stack ui-stack--loose">
         <div className="ui-split">
           <div className="ui-stack ui-stack--tight">
@@ -295,7 +347,8 @@ function NetworkMapSection({ mapping }) {
               <div>
                 <p className="ui-fact-card__label">Nutzbare Netzwerkkarte</p>
                 <p className="ui-card__copy">
-                  Die Mitte steht für das Kind oder die Familie. Über die Linsen lässt sich prüfen, ob privates Umfeld, Alltagsstützen, Fachstellen und Versorgungslücken ausreichend sichtbar werden.
+                  Die Mitte steht für das Kind oder die Familie. Über die Linsen lässt sich prüfen, ob privates Umfeld,
+                  Alltagsstützen, Fachstellen und Versorgungslücken ausreichend sichtbar werden.
                 </p>
               </div>
               <MapLensButtons lenses={lenses} activeLens={activeLensId} onLensChange={onLensChange} />
@@ -380,7 +433,8 @@ function NetworkMapSection({ mapping }) {
           <SurfaceCard tone="default">
             <p className="ui-fact-card__label">Arbeitsauswertung</p>
             <p className="ui-card__copy">
-              Die Karte wird am nützlichsten, wenn nach dem Visualisieren drei Fragen folgen: Wer trägt schon? Wo ist die Lage brüchig? Was muss als Nächstes konkret abgesprochen werden?
+              Die Karte wird am nützlichsten, wenn nach dem Visualisieren drei Fragen folgen: Wer trägt schon? Wo ist
+              die Lage brüchig? Was muss als Nächstes konkret abgesprochen werden?
             </p>
           </SurfaceCard>
           <SurfaceCard tone="soft">
@@ -395,7 +449,11 @@ function NetworkMapSection({ mapping }) {
 
         <div className="ui-network-node-grid">
           {visibleNodes.map((node) => (
-            <SurfaceCard key={node.label} tone={node.tone === 'gap' ? 'soft' : 'default'} className="ui-card--full-height">
+            <SurfaceCard
+              key={node.label}
+              tone={node.tone === 'gap' ? 'soft' : 'default'}
+              className="ui-card--full-height"
+            >
               <p className="ui-fact-card__label">
                 {node.zone === 'near'
                   ? 'Nahe Ebene'

--- a/src/templates/ToolboxPageTemplate.jsx
+++ b/src/templates/ToolboxPageTemplate.jsx
@@ -16,9 +16,7 @@ function AssessmentPanel({ assessment, scoreStatusId }) {
         <div className="ui-split">
           <div className="ui-stack ui-stack--tight">
             <Eyebrow>{assessment.eyebrow}</Eyebrow>
-            <h2 className="ui-hero__title ui-section-title">
-              {assessment.title}
-            </h2>
+            <h2 className="ui-hero__title ui-section-title">{assessment.title}</h2>
             <div className="ui-copy">
               <p>{assessment.description}</p>
               {assessment.note ? <p>{assessment.note}</p> : null}
@@ -26,17 +24,25 @@ function AssessmentPanel({ assessment, scoreStatusId }) {
           </div>
           {assessment.scoreAside ? (
             <SurfaceCard as="aside" tone="soft">
-              {assessment.scoreAside.label ? <p className="ui-fact-card__label">{assessment.scoreAside.label}</p> : null}
-              {assessment.scoreAside.value ? (
-                <p className="ui-toolbox-score">{assessment.scoreAside.value}</p>
+              {assessment.scoreAside.label ? (
+                <p className="ui-fact-card__label">{assessment.scoreAside.label}</p>
               ) : null}
+              {assessment.scoreAside.value ? <p className="ui-toolbox-score">{assessment.scoreAside.value}</p> : null}
               {assessment.scoreAside.badge ? (
-                <div className={`ui-toolbox-status-badge ui-toolbox-status-badge--spaced ${assessment.scoreAside.badgeClassName || ''}`}>
+                <div
+                  className={`ui-toolbox-status-badge ui-toolbox-status-badge--spaced ${assessment.scoreAside.badgeClassName || ''}`}
+                >
                   {assessment.scoreAside.badge}
                 </div>
               ) : null}
               {assessment.scoreAside.liveText ? (
-                <p id={scoreStatusId} role="status" aria-live="polite" aria-atomic="true" className="ui-visually-hidden">
+                <p
+                  id={scoreStatusId}
+                  role="status"
+                  aria-live="polite"
+                  aria-atomic="true"
+                  className="ui-visually-hidden"
+                >
                   {assessment.scoreAside.liveText}
                 </p>
               ) : null}
@@ -68,12 +74,13 @@ function AssessmentPanel({ assessment, scoreStatusId }) {
                       key={item.id}
                       className={`ui-card--interactive ui-toolbox-check ${checked ? 'ui-toolbox-check--checked' : ''}`}
                     >
-                      <input type="checkbox" className="ui-visually-hidden" checked={checked} onChange={item.onChange} />
-                      <div
-                        className="ui-toolbox-check__box"
-                      >
-                        {item.checkIcon}
-                      </div>
+                      <input
+                        type="checkbox"
+                        className="ui-visually-hidden"
+                        checked={checked}
+                        onChange={item.onChange}
+                      />
+                      <div className="ui-toolbox-check__box">{item.checkIcon}</div>
                       <div className="ui-toolbox-check__content">
                         <span className="ui-toolbox-check__label">{item.label}</span>
                         {item.meta ? <span className="ui-toolbox-check__meta">{item.meta}</span> : null}
@@ -123,9 +130,7 @@ function PathwaySection({ pathway }) {
                 <div key={step.label} className="ui-toolbox-step">
                   <SurfaceCard tone="soft" className="ui-card--full-height">
                     <div className="ui-toolbox-step__header">
-                      <div className="ui-chip ui-chip--active ui-toolbox-step__chip">
-                        Schritt {index + 1}
-                      </div>
+                      <div className="ui-chip ui-chip--active ui-toolbox-step__chip">Schritt {index + 1}</div>
                       <div className="ui-toolbox-kicker ui-toolbox-step__label">{step.label}</div>
                     </div>
                     <div className="ui-toolbox-step__divider" />
@@ -245,7 +250,11 @@ function TriageSection({ triage }) {
                   <div className="ui-note-panel__label">Einordnung</div>
                   <h4 className="ui-toolbox-feedback__title">{prompt.recommendation.title}</h4>
                   <p className="ui-toolbox-feedback__copy">{prompt.recommendation.text}</p>
-                  <Button variant="secondary" className="ui-editorial-card__action" onClick={() => prompt.recommendation.onJump(prompt.recommendation.target)}>
+                  <Button
+                    variant="secondary"
+                    className="ui-editorial-card__action"
+                    onClick={() => prompt.recommendation.onJump(prompt.recommendation.target)}
+                  >
                     {prompt.recommendation.targetLabel}
                     <ChevronRight size={14} />
                   </Button>
@@ -267,7 +276,11 @@ function TriageSection({ triage }) {
             <div className="ui-note-panel__label">Aktuell wichtigste Spur</div>
             <h3 className="ui-toolbox-priority__title">{triage.primaryPriority.title}</h3>
             <p className="ui-toolbox-priority__copy">{triage.primaryPriority.text}</p>
-            <Button variant="secondary" className="ui-editorial-card__action" onClick={() => triage.primaryPriority.onJump(triage.primaryPriority.target)}>
+            <Button
+              variant="secondary"
+              className="ui-editorial-card__action"
+              onClick={() => triage.primaryPriority.onJump(triage.primaryPriority.target)}
+            >
               {triage.primaryPriority.targetLabel}
               <ChevronRight size={14} />
             </Button>
@@ -309,8 +322,8 @@ function PracticeBlocksSection({ practice }) {
               variant={filter.active ? 'primary' : 'secondary'}
               onClick={filter.onSelect}
               aria-pressed={filter.active}
-                className="ui-button--compact"
-              >
+              className="ui-button--compact"
+            >
               {filter.label}
             </Button>
           ))}
@@ -321,17 +334,18 @@ function PracticeBlocksSection({ practice }) {
             <SurfaceCard key={item.title} tone="default">
               <div className="ui-chip-row">
                 {item.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="ui-toolbox-tag"
-                  >
+                  <span key={tag} className="ui-toolbox-tag">
                     {tag}
                   </span>
                 ))}
               </div>
               <h3 className="ui-card__title ui-editorial-card__action">{item.title}</h3>
               <p className="ui-card__copy">{item.text}</p>
-              <Button variant="secondary" className="ui-editorial-card__action" onClick={() => item.onJump(item.target)}>
+              <Button
+                variant="secondary"
+                className="ui-editorial-card__action"
+                onClick={() => item.onJump(item.target)}
+              >
                 {item.targetLabel}
                 <ChevronRight size={14} />
               </Button>
@@ -366,9 +380,11 @@ function ClusterSection({ cluster }) {
             ) : null}
             {cluster.description ? (
               <div className="ui-copy">
-                {Array.isArray(cluster.description)
-                  ? cluster.description.map((paragraph) => <p key={paragraph}>{paragraph}</p>)
-                  : <p>{cluster.description}</p>}
+                {Array.isArray(cluster.description) ? (
+                  cluster.description.map((paragraph) => <p key={paragraph}>{paragraph}</p>)
+                ) : (
+                  <p>{cluster.description}</p>
+                )}
               </div>
             ) : null}
           </div>
@@ -381,7 +397,9 @@ function ClusterSection({ cluster }) {
                 <div className="ui-stack ui-stack--tight ui-card__section--spaced">
                   {cluster.aside.items.map((item, index) => (
                     <div key={`${cluster.id}-aside-${index}`} className="ui-bullet-panel__item">
-                      {item.icon ? <span className="ui-bullet-panel__marker ui-toolbox-inline-icon">{item.icon}</span> : null}
+                      {item.icon ? (
+                        <span className="ui-bullet-panel__marker ui-toolbox-inline-icon">{item.icon}</span>
+                      ) : null}
                       <p className="ui-bullet-panel__copy">{item.text}</p>
                     </div>
                   ))}
@@ -429,10 +447,14 @@ function ClusterSection({ cluster }) {
                 className={`ui-card--outline ui-toolbox-list-card ${item.className || 'ui-toolbox-list-card--default'}`}
               >
                 <div className="ui-bullet-panel__item">
-                  {item.icon ? <span className="ui-bullet-panel__marker ui-toolbox-inline-icon">{item.icon}</span> : null}
+                  {item.icon ? (
+                    <span className="ui-bullet-panel__marker ui-toolbox-inline-icon">{item.icon}</span>
+                  ) : null}
                   <div>
                     {item.title ? <h3 className="ui-card__title">{item.title}</h3> : null}
-                    {item.text ? <p className={item.title ? 'ui-card__copy' : 'ui-bullet-panel__copy'}>{item.text}</p> : null}
+                    {item.text ? (
+                      <p className={item.title ? 'ui-card__copy' : 'ui-bullet-panel__copy'}>{item.text}</p>
+                    ) : null}
                   </div>
                 </div>
               </div>
@@ -447,27 +469,32 @@ function ClusterSection({ cluster }) {
                 key={item.title}
                 className={`ui-toolbox-disclosure-group ui-card--outline ui-card--interactive ui-toolbox-disclosure ${item.className || ''}`}
               >
-                <summary
-                  className="ui-toolbox-disclosure__summary"
-                  aria-label={item.summaryAriaLabel || item.title}
-                >
+                <summary className="ui-toolbox-disclosure__summary" aria-label={item.summaryAriaLabel || item.title}>
                   <div className="ui-bullet-panel__item">
-                    {item.icon ? <span className="ui-bullet-panel__marker ui-toolbox-inline-icon">{item.icon}</span> : null}
+                    {item.icon ? (
+                      <span className="ui-bullet-panel__marker ui-toolbox-inline-icon">{item.icon}</span>
+                    ) : null}
                     <div>
                       <span className="ui-card__title ui-display-block">{item.title}</span>
                       {item.meta ? <p className="ui-fact-card__label ui-editorial-card__action">{item.meta}</p> : null}
                     </div>
                   </div>
-                  <span className="ui-toolbox-disclosure__toggle">
-                    +
-                  </span>
+                  <span className="ui-toolbox-disclosure__toggle">+</span>
                 </summary>
                 <div className="ui-copy ui-toolbox-disclosure__content">
-                  {Array.isArray(item.content)
-                    ? item.content.map((paragraph) => <p key={paragraph}>{paragraph}</p>)
-                    : <p>{item.content}</p>}
+                  {Array.isArray(item.content) ? (
+                    item.content.map((paragraph) => <p key={paragraph}>{paragraph}</p>)
+                  ) : (
+                    <p>{item.content}</p>
+                  )}
                   {item.href ? (
-                    <Button variant="secondary" className="ui-editorial-card__action" href={item.href} target={item.target} rel={item.rel}>
+                    <Button
+                      variant="secondary"
+                      className="ui-editorial-card__action"
+                      href={item.href}
+                      target={item.target}
+                      rel={item.rel}
+                    >
                       {item.actionLabel || 'Mehr anzeigen'}
                       {item.actionIcon}
                     </Button>
@@ -482,10 +509,16 @@ function ClusterSection({ cluster }) {
           <div className="ui-card--outline ui-toolbox-template">
             <div className="ui-toolbox-template__header">
               <div>
-                {cluster.templateMeta?.label ? <p className="ui-toolbox-template__label">{cluster.templateMeta.label}</p> : null}
-                {cluster.templateMeta?.title ? <h3 className="ui-card__title ui-toolbox-template__title">{cluster.templateMeta.title}</h3> : null}
+                {cluster.templateMeta?.label ? (
+                  <p className="ui-toolbox-template__label">{cluster.templateMeta.label}</p>
+                ) : null}
+                {cluster.templateMeta?.title ? (
+                  <h3 className="ui-card__title ui-toolbox-template__title">{cluster.templateMeta.title}</h3>
+                ) : null}
               </div>
-              {cluster.templateMeta?.meta ? <p className="ui-toolbox-template__meta">{cluster.templateMeta.meta}</p> : null}
+              {cluster.templateMeta?.meta ? (
+                <p className="ui-toolbox-template__meta">{cluster.templateMeta.meta}</p>
+              ) : null}
             </div>
             <div className="ui-toolbox-template__grid">
               {cluster.templateFields.map((field) => (
@@ -528,7 +561,6 @@ function ResourcesSection({ closingSection }) {
   );
 }
 
-
 export default function ToolboxPageTemplate({
   hero,
   pageHeadingId,
@@ -557,10 +589,15 @@ export default function ToolboxPageTemplate({
                     {heroTitleText || 'Orientierung, Schutz und nächste Schritte'}
                   </h2>
                   <p className="ui-card__copy">
-                    Die wichtigsten Arbeitsaktionen der Toolbox sind hier zusätzlich direkt erreichbar, damit Tastatur- und Screenreader-Nutzung ohne Umwege in den zentralen Handlungsbereich gelangen.
+                    Die wichtigsten Arbeitsaktionen der Toolbox sind hier zusätzlich direkt erreichbar, damit Tastatur-
+                    und Screenreader-Nutzung ohne Umwege in den zentralen Handlungsbereich gelangen.
                   </p>
                 </div>
-                <div className="ui-button-row ui-toolbox-quick-access__actions" role="group" aria-label="Primäre Toolbox-Aktionen">
+                <div
+                  className="ui-button-row ui-toolbox-quick-access__actions"
+                  role="group"
+                  aria-label="Primäre Toolbox-Aktionen"
+                >
                   {hero.actions.map((action) => (
                     <Button
                       key={`quick-${action.label}`}

--- a/src/templates/VignettenPageTemplate.jsx
+++ b/src/templates/VignettenPageTemplate.jsx
@@ -61,7 +61,13 @@ function DecisionOption({ option, index, isActive, onSelect }) {
 
   return (
     <label className="ui-choice-control">
-      <input type="radio" name={option.groupName} className="ui-visually-hidden" checked={isActive} onChange={onSelect} />
+      <input
+        type="radio"
+        name={option.groupName}
+        className="ui-visually-hidden"
+        checked={isActive}
+        onChange={onSelect}
+      />
       <span className={toneClass}>
         <span className="ui-choice-card__body">
           <span className="ui-choice-card__stack">
@@ -163,12 +169,7 @@ function VignettenNavigationSection({ navigation }) {
             >
               <ChevronLeft size={16} /> {navigation.previousLabel}
             </Button>
-            <Button
-              type="button"
-              onClick={navigation.onNext}
-              disabled={navigation.disableNext}
-              variant="primary"
-            >
+            <Button type="button" onClick={navigation.onNext} disabled={navigation.disableNext} variant="primary">
               {navigation.nextLabel} <ChevronRight size={16} />
             </Button>
           </div>

--- a/src/utils/appHelpers.js
+++ b/src/utils/appHelpers.js
@@ -82,17 +82,17 @@ export const isValidQuizState = (value) =>
   !Array.isArray(value) &&
   Object.values(value).every(
     (entry) =>
-      entry &&
-      typeof entry === 'object' &&
-      typeof entry.answerIdx === 'number' &&
-      typeof entry.isCorrect === 'boolean'
+      entry && typeof entry === 'object' && typeof entry.answerIdx === 'number' && typeof entry.isCorrect === 'boolean'
   );
 
 export const isValidResourceFilter = (value) =>
   typeof value === 'string' && NETWORK_FILTERS.some((filter) => filter.id === value);
 
 export const normalizeHashToTab = (hashValue) => {
-  const cleaned = String(hashValue || '').replace(/^#/, '').trim().toLowerCase();
+  const cleaned = String(hashValue || '')
+    .replace(/^#/, '')
+    .trim()
+    .toLowerCase();
   const aliased = TAB_ALIASES[cleaned] ?? cleaned;
   return TAB_ITEMS.some((item) => item.id === aliased) ? aliased : 'start';
 };
@@ -146,7 +146,8 @@ const normalizeQuizStateData = (value) => {
     Object.entries(value).flatMap(([moduleId, entry]) => {
       const module = MODULE_BY_ID.get(moduleId);
       if (!module) return [];
-      if (!Number.isInteger(entry.answerIdx) || entry.answerIdx < 0 || entry.answerIdx >= module.quizOptions.length) return [];
+      if (!Number.isInteger(entry.answerIdx) || entry.answerIdx < 0 || entry.answerIdx >= module.quizOptions.length)
+        return [];
 
       return [[moduleId, { answerIdx: entry.answerIdx, isCorrect: entry.answerIdx === module.correctQuizIdx }]];
     })
@@ -160,7 +161,9 @@ export const normalizeAppStateData = (value) => {
   return {
     activeTab: normalizeTabId(source.activeTab),
     currentVignette:
-      Number.isInteger(source.currentVignette) && source.currentVignette >= 0 && source.currentVignette < VIGNETTEN.length
+      Number.isInteger(source.currentVignette) &&
+      source.currentVignette >= 0 &&
+      source.currentVignette < VIGNETTEN.length
         ? source.currentVignette
         : defaults.currentVignette,
     selectedOption: normalizeSelectedOptionData(source.selectedOption),
@@ -194,7 +197,12 @@ export const getInitialAppState = (storageKey) => {
   const rawHash = String(window.location.hash || '').replace(/^#/, '');
   const rawHashLower = rawHash.toLowerCase();
   const normalizedHash = normalizeHashToTab(rawHashLower);
-  const requestedTab = rawHash && normalizedHash !== 'start' ? normalizedHash : TAB_ITEMS.some((item) => item.id === rawHashLower) ? rawHashLower : null;
+  const requestedTab =
+    rawHash && normalizedHash !== 'start'
+      ? normalizedHash
+      : TAB_ITEMS.some((item) => item.id === rawHashLower)
+        ? rawHashLower
+        : null;
   const storedAppState = safeParse(storageKey, null, (value) => isValidStoredAppState(value));
 
   if (storedAppState?.data) {
@@ -225,8 +233,6 @@ const PAGE_HEADING_IDS = {
 };
 
 export const getPageHeadingId = (tab) => PAGE_HEADING_IDS[tab] ?? 'page-heading-start';
-
-
 
 export const getRiskLabel = (risk) => {
   if (risk >= 7) return 'Hinweis auf Schutzabklärung';


### PR DESCRIPTION
- Add ESLint 10 with react-hooks and react-refresh plugins
- Add Prettier with project-specific config (120 cols, single quotes)
- Add npm scripts: lint, lint:fix, format, format:check
- Format entire codebase with Prettier (33 files)
- Remove unused imports: React (5 files), safeParse, Button, listToCards
- Remove dead print-isolation system from App.jsx (getToolboxPrintMode, ToolboxPrintPage, openIsolatedPrintView, and helpers) — superseded by the inline window.print() handler
- Remove unused dompurify dependency (only consumer was dead code)
- 0 ESLint errors, 0 warnings; Prettier clean; build + 29 E2E tests pass

https://claude.ai/code/session_01YKq9W9S6WmYrvGXvM3Hn5q