### PR TITLE
fix(a11y): resolve WCAG compliance issues across layouts and components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -648,7 +648,7 @@ Aktueller Assessment-Score: ${score.risk}
         <div className="relative z-[100] border-b border-[#4b392f] bg-[linear-gradient(180deg,#3f322b,#2d241f)] px-3 py-3 text-[#f6efe7] no-print">
           <div className="mx-auto flex max-w-[86rem] flex-col items-start justify-between gap-3 px-2 md:flex-row md:items-center md:px-6">
             <div className="flex items-center gap-3 text-[10px] font-extrabold uppercase tracking-[0.24em] text-[#eadfce]">
-              <ShieldCheck size={16} className="shrink-0 text-[#f0c786]" />
+              <ShieldCheck size={16} className="shrink-0 text-[#f0c786]" aria-hidden="true" />
               <span>
                 Lokale Speicherung im Browser • auf gemeinsam genutzten Geräten nach der Nutzung zurücksetzen • keine
                 serverseitige Falldokumentation in dieser Ansicht
@@ -658,6 +658,7 @@ Aktueller Assessment-Score: ${score.risk}
               type="button"
               onClick={() => setShowSafeNote(false)}
               className="haptic-btn rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-[10px] font-extrabold uppercase tracking-[0.18em] text-[#f0c786] transition-colors hover:bg-white/10 hover:text-white"
+              aria-label="Datenschutzhinweis schliessen"
             >
               Schliessen
             </button>
@@ -680,8 +681,9 @@ Aktueller Assessment-Score: ${score.risk}
             type="button"
             onClick={handleEmergencyAccess}
             className="haptic-btn inline-flex items-center gap-2 rounded-full border border-[#dec2b2] bg-white/80 px-4 py-2 text-[11px] font-extrabold uppercase tracking-[0.18em] text-[#8d3f32] shadow-[0_10px_24px_rgba(141,63,50,0.06)] transition-colors hover:bg-[#fff0e6]"
+            aria-label="Zu Notfallinformationen wechseln"
           >
-            <AlertTriangle size={14} />
+            <AlertTriangle size={14} aria-hidden="true" />
             Zu Notfallinformationen
           </button>
         </div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -22,7 +22,7 @@ const Footer = memo(function Footer() {
         <div className="footer-grid">
           <div className="footer-panel footer-panel--brand">
             <div className="footer-brand-badge">
-              <Library size={14} />
+              <Library size={14} aria-hidden="true" />
               Fachportal Zürich
             </div>
             <h2 className="footer-brand-title">
@@ -48,7 +48,7 @@ const Footer = memo(function Footer() {
             </div>
           </div>
 
-          <div className="footer-panel footer-panel--nav">
+          <nav className="footer-panel footer-panel--nav" aria-label="Fusszeilen-Navigation">
             <div className="footer-kicker">Bereiche</div>
             <div className="footer-nav-list">
               {footerRoutes.map((route) => (
@@ -62,24 +62,24 @@ const Footer = memo(function Footer() {
                     <div className="footer-nav-link__title">{route.label}</div>
                     <p className="footer-nav-link__copy">{route.note}</p>
                   </div>
-                  <ArrowUpRight size={16} className="footer-nav-link__icon" />
+                  <ArrowUpRight size={16} className="footer-nav-link__icon" aria-hidden="true" />
                 </button>
               ))}
             </div>
-          </div>
+          </nav>
 
           <div className="footer-panel footer-panel--framework">
             <div className="footer-kicker footer-kicker--inverse">Arbeitsrahmen</div>
             <div className="footer-framework-list">
               <div className="footer-framework-item">
-                <ShieldCheck size={18} className="footer-framework-item__icon" />
+                <ShieldCheck size={18} className="footer-framework-item__icon" aria-hidden="true" />
                 <p className="footer-framework-item__copy">
                   Zentrale Orientierung für Fachpersonen mit Fokus auf Einordnung, Triage, Gesprächsführung und
                   regionale Weitervermittlung.
                 </p>
               </div>
               <div className="footer-framework-item">
-                <Users size={18} className="footer-framework-item__icon" />
+                <Users size={18} className="footer-framework-item__icon" aria-hidden="true" />
                 <p className="footer-framework-item__copy">
                   Arbeitsstände bleiben lokal im Browser und können jederzeit zurückgesetzt oder neu aufgebaut werden.
                 </p>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -49,7 +49,7 @@ const Header = memo(function Header({
             RR
           </div>
           <div className="ui-brand__copy">
-            <h1 className="ui-brand__title">Relational Recovery</h1>
+            <span className="ui-brand__title">Relational Recovery</span>
             <p className="ui-kicker ui-brand__meta">Schweizer Fachportal</p>
           </div>
         </button>

--- a/src/components/ui/PageHero.jsx
+++ b/src/components/ui/PageHero.jsx
@@ -43,7 +43,7 @@ export default function PageHero({
           <h1
             id={headingId}
             tabIndex={-1}
-            aria-label={headingAriaLabel}
+            aria-label={headingAriaLabel || (accent ? `${title} ${accent}` : undefined)}
             className="ui-hero__title focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-emerald-200 focus-visible:ring-offset-4 focus-visible:ring-offset-white"
           >
             {title} {accent ? <span className="ui-hero__accent">{accent}</span> : null}

--- a/src/styles/app-global.css
+++ b/src/styles/app-global.css
@@ -99,6 +99,21 @@
   box-shadow: var(--shadow-focus);
 }
 
+.ui-disclosure-card__summary:focus-visible,
+.ui-toolbox-disclosure__summary:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-focus);
+}
+
+.ui-choice-card:focus-within {
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-focus);
+}
+
 .print-only {
   display: none;
 }

--- a/src/templates/NetworkPageTemplate.jsx
+++ b/src/templates/NetworkPageTemplate.jsx
@@ -193,7 +193,7 @@ function ResourceDirectorySection({ directory }) {
 
 function MapLensButtons({ lenses = [], activeLens, onLensChange }) {
   return (
-    <div className="ui-chip-row">
+    <div className="ui-chip-row" role="group" aria-label="Netzwerkkarte Lesart wählen">
       {lenses.map((lens) => {
         const isActive = activeLens === lens.id;
 
@@ -356,10 +356,10 @@ function NetworkMapSection({ mapping }) {
 
             <div className="ui-network-map-shell">
               <div>
-                <div className="ui-card--outline ui-network-map-stage is-desktop">
-                  <div className="ui-network-map-center-shell" />
-                  <div className="ui-network-map-center-orbit" />
-                  <div className="ui-network-map-ring" />
+                <div className="ui-card--outline ui-network-map-stage is-desktop" role="img" aria-label="Netzwerkkarte: visuelle Darstellung der Bezugspersonen rund um Kind und Familie">
+                  <div className="ui-network-map-center-shell" aria-hidden="true" />
+                  <div className="ui-network-map-center-orbit" aria-hidden="true" />
+                  <div className="ui-network-map-ring" aria-hidden="true" />
 
                   <div className="ui-network-map-center">
                     <div>

--- a/src/templates/ToolboxPageTemplate.jsx
+++ b/src/templates/ToolboxPageTemplate.jsx
@@ -315,7 +315,7 @@ function PracticeBlocksSection({ practice }) {
           ) : null}
         </div>
 
-        <div className="ui-chip-row" aria-label={practice.filterAriaLabel}>
+        <div className="ui-chip-row" role="group" aria-label={practice.filterAriaLabel}>
           {practice.filters.map((filter) => (
             <Button
               key={filter.id}


### PR DESCRIPTION
## Summary

- **Heading hierarchy**: Fix duplicate `<h1>` — Header brand title changed from `<h1>` to `<span>` so each page has exactly one `<h1>` from PageHero
- **ARIA attributes**: Add `aria-hidden="true"` to 6 decorative icons, `role="group"` to filter chip rows, `role="img"` to network map, `aria-label` to buttons and nav landmarks
- **Keyboard focus**: Add `:focus-visible` styles for disclosure/details summaries and `:focus-within` for radio choice cards
- **Landmarks**: Wrap Footer navigation in `<nav>` with `aria-label`
- **Heading labels**: Auto-compose `aria-label` from title+accent on PageHero `<h1>` for screen readers

## Test plan

- [ ] Verify only one `<h1>` per page (Header brand is now `<span>`)
- [ ] Tab through all interactive elements — focus ring visible on disclosure summaries and choice cards
- [ ] Screen reader: decorative icons not announced, buttons have descriptive labels
- [ ] Footer navigation announced as landmark region
- [ ] Network map announced as image with descriptive label
- [ ] Build passes (`npm run build`)
- [ ] ESLint passes with no errors

https://claude.ai/code/session_014EWaTJzQrAm8KWRbdAxBRx