### PR TITLE
fix(security, a11y): harden dev server, fix focus and motion issues

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,8 @@ const EvidenceSection = lazy(() => import('./sections/EvidenceSection'));
 
 const SectionLoadingFallback = function SectionLoadingFallback() {
   return (
-    <section className="rounded-[3rem] border border-slate-200 bg-white px-8 py-12 shadow-sm md:px-12 md:py-16">
+    <section aria-busy="true" aria-label="Inhalt wird geladen" className="rounded-[3rem] border border-slate-200 bg-white px-8 py-12 shadow-sm md:px-12 md:py-16">
+      <p className="ui-visually-hidden">Inhalt wird geladen…</p>
       <div className="max-w-2xl">
         <div className="mb-5 h-2 w-20 rounded-full bg-emerald-100" />
         <div className="mb-4 h-8 w-64 rounded-full bg-slate-100" />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -17,7 +17,7 @@ const Footer = memo(function Footer() {
   );
 
   return (
-    <footer className="footer-shell no-print" role="contentinfo">
+    <footer className="footer-shell no-print">
       <div className="footer-shell__inner">
         <div className="footer-grid">
           <div className="footer-panel footer-panel--brand">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -42,7 +42,7 @@ const Header = memo(function Header({
         <button
           type="button"
           onClick={handleHomeClick}
-          className="ui-brand focus-visible:outline-none"
+          className="ui-brand"
           aria-label="Zur Startseite wechseln"
         >
           <div className="ui-brand__mark" aria-hidden="true">

--- a/src/components/closing/ClosingSection.jsx
+++ b/src/components/closing/ClosingSection.jsx
@@ -342,7 +342,7 @@ function ClosingReferences({ references }) {
               {item.publisher ? <p className="ui-card__copy">{item.publisher}</p> : null}
               {item.link ? (
                 <p className="ui-closing-reference-card__action">
-                  <a href={item.link} target="_blank" rel="noreferrer">
+                  <a href={item.link} target="_blank" rel="noopener noreferrer">
                     Quelle öffnen
                   </a>
                 </p>

--- a/src/components/ui/PageHero.jsx
+++ b/src/components/ui/PageHero.jsx
@@ -44,7 +44,7 @@ export default function PageHero({
             id={headingId}
             tabIndex={-1}
             aria-label={headingAriaLabel || (accent ? `${title} ${accent}` : undefined)}
-            className="ui-hero__title focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-emerald-200 focus-visible:ring-offset-4 focus-visible:ring-offset-white"
+            className="ui-hero__title"
           >
             {title} {accent ? <span className="ui-hero__accent">{accent}</span> : null}
           </h1>

--- a/src/index.css
+++ b/src/index.css
@@ -72,6 +72,12 @@
     background: var(--background);
   }
 
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  }
+
   body {
     @apply bg-background text-foreground;
     font-family: var(--font-body);

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -567,7 +567,6 @@
   font-family: var(--font-body);
   font-size: var(--font-size-md);
   line-height: 1.4;
-  outline: none;
   transition:
     border-color var(--motion-fast) ease,
     background-color var(--motion-fast) ease,
@@ -579,6 +578,7 @@
 }
 
 .ui-input:focus {
+  outline: 3px solid transparent;
   border-color: color-mix(in srgb, var(--accent-primary) 32%, white 68%);
   background: var(--surface-note);
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent-primary-soft) 45%, white 55%);
@@ -599,7 +599,7 @@
 }
 
 .ui-card--interactive:focus-visible {
-  outline: none;
+  outline: 3px solid transparent;
   border-color: color-mix(in srgb, var(--accent-primary) 30%, white 70%);
   box-shadow:
     0 0 0 4px color-mix(in srgb, var(--accent-primary-soft) 45%, white 55%),
@@ -2730,6 +2730,19 @@
   .ui-button:hover,
   .ui-chip:hover,
   .ui-card--interactive:hover {
+    transform: none;
+  }
+
+  .page-enter {
+    animation: none;
+  }
+
+  .haptic-btn {
+    transition: none;
+  }
+
+  .haptic-btn:hover,
+  .haptic-btn:active {
     transform: none;
   }
 }

--- a/src/templates/NetworkPageTemplate.jsx
+++ b/src/templates/NetworkPageTemplate.jsx
@@ -149,7 +149,7 @@ function ResourceDirectorySection({ directory }) {
                 <h3 className="ui-card__title">{resource.name}</h3>
                 <p className="ui-card__copy">{resource.info}</p>
                 <div className="ui-editorial-card__action">
-                  <Button href={resource.link} target="_blank" rel="noopener noreferrer" variant="subtle">
+                  <Button href={resource.link} target="_blank" rel="noopener noreferrer" variant="subtle" aria-label={`${resource.name} – Webseite öffnen (neues Fenster)`}>
                     Webseite öffnen <ExternalLink size={16} />
                   </Button>
                 </div>

--- a/src/templates/ToolboxPageTemplate.jsx
+++ b/src/templates/ToolboxPageTemplate.jsx
@@ -226,7 +226,7 @@ function TriageSection({ triage }) {
               </div>
 
               {prompt.recommendation ? (
-                <div className={`ui-toolbox-feedback ui-editorial-card__action ${prompt.recommendation.className}`}>
+                <div role="status" aria-live="polite" className={`ui-toolbox-feedback ui-editorial-card__action ${prompt.recommendation.className}`}>
                   <div className="ui-note-panel__label">Einordnung</div>
                   <h4 className="ui-toolbox-feedback__title">{prompt.recommendation.title}</h4>
                   <p className="ui-toolbox-feedback__copy">{prompt.recommendation.text}</p>
@@ -518,7 +518,7 @@ export default function ToolboxPageTemplate({
   const heroTitleText = [hero?.title, hero?.accent].filter(Boolean).join(' ').trim();
 
   return (
-    <div className="ui-stack" role="region" aria-labelledby={pageHeadingId}>
+    <div className="ui-stack">
       <div className="ui-stack">
         <Container width="wide">
           {hero?.actions?.length ? (

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,13 +6,14 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     host: '0.0.0.0',
-    allowedHosts: true,
+    allowedHosts: ['localhost'],
   },
   preview: {
     host: '0.0.0.0',
-    allowedHosts: true,
+    allowedHosts: ['localhost'],
   },
   build: {
+    sourcemap: false,
     target: 'es2020',
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Summary
- **Security**: restrict Vite `allowedHosts` to `['localhost']`, disable production source maps, consistent `rel="noopener noreferrer"`
- **A11y (critical)**: remove `outline-none` on Home button — keyboard focus was invisible (WCAG 2.4.7)
- **A11y (high)**: use `outline: 3px solid transparent` for Forced-Colors-Mode on inputs and interactive cards
- **A11y (high)**: add `prefers-reduced-motion` support for `page-enter`, `haptic-btn`, `scroll-behavior: smooth`
- **A11y (medium)**: `aria-busy` + screen reader text on loading fallback, `aria-live` on triage recommendations, differentiating `aria-label` on network links, fix inconsistent focus ring on PageHero h1
- **A11y (low)**: remove redundant `role="contentinfo"` on footer and `role="region"` on toolbox wrapper

## Test plan
- [x] `npx vite build` passes
- [x] `npx eslint` passes on all changed files
- [ ] Verify keyboard focus is visible on Home button
- [ ] Verify focus indicators work in Windows High Contrast Mode
- [ ] Verify `prefers-reduced-motion` disables animations
- [ ] Verify screen reader announces loading state and triage recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)