### PR TITLE
audit(04): Evidence-Content-Audit Phase 1+2 — Inventur, Diagnose, Recherche-Liste

### DIFF
--- a/qa/audit-04-evidence-content.md
+++ b/qa/audit-04-evidence-content.md
@@ -289,7 +289,11 @@ Für den Kanton Zürich:
 
 **Beleg-Formulierung für Phase 3:** sourceId `kokes-2024`, bereits als Referenz in der juristischen Faktenbasis vorhanden. Die Aussage "die meisten sind unterstützend" ist durch 77-86% Beistandschaften quantitativ belegbar.
 
-**Status:** Kann in Phase 3 ohne externe Recherche geschlossen werden. Blaupause für Audit-übergreifende Quellennutzung.
+**Status:** Kann in Phase 3 ohne externe Recherche geschlossen werden.
+
+#### Audit-übergreifende Wiederverwendung
+
+E18 ist der erste dokumentierte Fall, in dem ein Audit ein Artefakt eines früheren Audits als Quellenbeleg nutzt: Audit 04 (Evidence) bedient sich an der juristischen Faktenbasis aus Audit 03 (KESB), konkret an der KOKES-Jahresstatistik 2024 mit ihren ZGB-Artikel-spezifischen Bestandszahlen. Das Muster ist übertragbar: Künftige Audits sollten vor einer externen Recherche prüfen, ob ein bereits abgeschlossenes Audit die benötigte Quelle bereits inventarisiert hat. Dafür ist entscheidend, dass jedes Audit seine Quellen mit maschinenlesbaren Identifikatoren versieht (hier: `kokes-2024`), die audit-übergreifend referenzierbar sind. Die in Abschnitt 2.3 vorgeschlagene `sourcesContent.js` wird damit zum zentralen Quellen-Register des gesamten Projekts, nicht nur des Evidence-Teils.
 
 ---
 

--- a/qa/audit-04-evidence-content.md
+++ b/qa/audit-04-evidence-content.md
@@ -115,4 +115,192 @@ Die LITERATUR-Liste steht separat und ist mit keiner einzelnen Aussage direkt ve
 
 ---
 
-*Phase 1 abgeschlossen. Warte auf Freigabe für Phase 2 (Diagnose und Recherche-Liste).*
+## Phase 2 -- Diagnose und Recherche-Liste
+
+### 2.1 Diagnose
+
+#### Themenbereich-Schwächen
+
+| Themenbereich | Claims | Davon ohne Quelle | Davon "zu prüfen" | Bewertung |
+|---|---|---|---|---|
+| **Prävalenz / Statistiken** (RELEVANCE_STATS) | 6 | 4 | 6 | **Schwächster Bereich** -- jeder einzelne Wert braucht eine direkte Quelle |
+| Elternerleben (PARENT_*) | 5 | 4 | 0 | Fachlich solide, aber quellenarm |
+| Kindliches Erleben (CHILD_*) | 4 | 4 | 0 | Konsens-Aussagen, trotzdem Beleg wünschenswert |
+| Psychoedukation (PSYCHOEDUCATION_*) | 4 | 4 | 0 | Lehrbuch-Wissen, Quellenlücke akzeptabel |
+| Hilfebarrieren (HELP_BARRIER_*) | 1 | 1 | 1 | E18 intern belegbar (Audit 03) |
+| Interventionen (INTERVENTION_*) | 3 | 0 | 0 | Am besten belegt (Lenz-Verweis) |
+| Institutionell (PUK, SUPPORT) | 2 | 0 | 1 | E24 abhängig vom aktuellen Angebotsstand |
+
+#### Referenzen ohne Jahr -- eigene Kategorie
+
+Die folgenden 4 Literatur-Einträge haben **kein Erscheinungsjahr** und sind damit faktisch unbelegt, weil sie weder verifizierbar noch zeitlich einordbar sind:
+
+| # | Eintrag | Problem | Priorität |
+|---|---------|---------|-----------|
+| L5 | Gesundheitsförderung Kt. ZH -- Online-Informationsseite | Kein Jahr, kein Titel eines konkreten Dokuments. Ist das eine Webseite? Ein Faktenblatt? | P1 -- identifizieren |
+| L6 | PUK Zürich -- Informationen für Angehörige | Kein Jahr. Institutionelle Webseite, kein zitierfähiges Dokument. | P2 -- als Weblink kennzeichnen, nicht als Quelle |
+| L7 | Institut Kinderseele Schweiz -- Hilfe finden | Kein Jahr. Orientierungshilfe, kein Forschungsdokument. | P2 -- als Weblink kennzeichnen |
+| L10 | Stauber, A. et al. -- Praxisforschung Band 25 | Kein Jahr. Praxisforschungsband, aber ohne Jahr und Verlag nicht auffindbar. | P1 -- Jahr und Verlag identifizieren |
+
+**Empfehlung:** L5, L6, L7 sind keine Literatur-Referenzen im wissenschaftlichen Sinn, sondern Weblinks zu Institutionen. Sie sollten aus der LITERATUR-Liste entfernt und stattdessen in SUPPORT_OFFERS oder als separate `WEBLINKS`-Kategorie geführt werden. L10 braucht eine vollständige bibliographische Identifikation.
+
+#### Stilistische Inkonsistenzen im Quellen-Format
+
+| Problem | Beispiel | Häufigkeit |
+|---|---|---|
+| Autor-Format uneinheitlich | "Lenz, A. (2014)" vs. "pädiatrie schweiz (2021)" vs. "Jones, M. et al. (2016)" | Durchgehend |
+| Publisher vs. Journal ungetrennt | "Psychiatrische Praxis, 38." vs. "Göttingen: Hogrefe." vs. "Online-Informationsseite." | Durchgehend |
+| DOI manchmal im publisher-Feld | "Sozialpädiatrie / DOI: 10.35190/d2021.4.5" | 2x |
+| Link manchmal vorhanden, manchmal nicht | L1-L3 ohne Link, L4-L9 mit Link | ~50/50 |
+
+---
+
+### 2.2 Priorisierung
+
+#### P1 -- Vor Release zwingend
+
+| ID | Aussage | Warum P1 |
+|---|---------|---------|
+| E1 | 18% CH-Prävalenz | Zentrale Eingangsstatistik, kein Beleg, konkreter Wert |
+| E4 | 17-45% Elternschaft stationär | Enorme Spannbreite suggeriert Präzision, wo keine ist |
+| E5 | 53% Hilfebedarf stationär | Konkreter Prozentwert ohne Quelle |
+| E6 | ca. 70% Elternschaftsrate affektive Störungen | Konkreter Prozentwert ohne Quelle |
+| L10 | Stauber et al. ohne Jahr | Nicht verifizierbar, muss identifiziert werden |
+| L5 | Gesundheitsförderung ZH ohne Jahr | Muss als Weblink reklassifiziert oder identifiziert werden |
+
+#### P2 -- Empfehlenswert
+
+| ID | Aussage | Warum P2 |
+|---|---------|---------|
+| E2 | 300'000 Kinder CH | Hat Teil-Quelle (pädiatrie schweiz), aber indirekt |
+| E3 | 15-23% international | Hat Teil-Quelle, gängige Schätzung |
+| E18 | "Die meisten KS-Massnahmen unterstützend" | **Intern abgedeckt via Audit 03** (KOKES 2024) |
+| E24 | PUK-Beratung kostenlos | Institutionelle Angabe, Aktualität prüfen |
+| L2 | Krumm/Becker 2011 | Veralterungsrisiko bei Versorgungsforschung |
+| L6, L7 | Institutionelle Webseiten | Aus LITERATUR entfernen, als Weblinks führen |
+
+#### P3 -- Kann warten
+
+| ID | Aussage | Warum P3 |
+|---|---------|---------|
+| E10-E17 | Fachbehauptungen (Konsens) | Unauffällig, Lehrbuch-Niveau, Quellen wünschenswert aber nicht zwingend |
+| E19-E21 | Interventionsprogramme | Bereits teil-belegt über Lenz |
+| E22-E23 | Differenzierung Diagnose/Gefährdung | Konsens-Aussagen |
+| L1, L3, L8 | Ältere Standardwerke | Stabile Inhalte, Aktualisierung nice-to-have |
+
+---
+
+### 2.3 Zitations-Architektur
+
+#### Warum eine Architektur nötig ist
+
+Bei 0 von 23 Inline-Zitationen ist das Problem nicht "einzelne Lücken füllen", sondern "eine Zitations-Praxis etablieren, wo heute keine ist". Die LITERATUR-Liste steht als separater Export ohne Verbindung zu einzelnen Claims. Für Leser:innen (Fachpersonen) ist nicht erkennbar, auf welcher Grundlage eine Zahl basiert.
+
+#### Datenstruktur-Vorschlag
+
+**Option A: Source-IDs an Claims (empfohlen)**
+
+Jeder Daten-Export, der verifiable Claims enthält, erhält ein optionales `sourceIds`-Array:
+
+```js
+export const RELEVANCE_STATS = [
+  {
+    label: 'Behandlungsbedürftige psychische Störungen',
+    value: '18 %',
+    note: 'Anteil der Bevölkerung in der Schweiz...',
+    sourceIds: ['obsan-2023'],
+  },
+];
+```
+
+Die Quellen selbst werden in einer neuen Datei `src/data/sourcesContent.js` strukturiert:
+
+```js
+export const SOURCES = {
+  'obsan-2023': {
+    author: 'Schweizerisches Gesundheitsobservatorium (Obsan)',
+    year: 2023,
+    title: 'Psychische Gesundheit in der Schweiz',
+    type: 'report',
+    doi: null,
+    link: 'https://...',
+    chFocus: true,
+  },
+  'paediatrie-ch-2021': {
+    author: 'pädiatrie schweiz',
+    year: 2021,
+    title: 'Kinder und Jugendliche aus Familien mit...',
+    type: 'journal',
+    doi: '10.35190/d2021.4.5',
+    link: 'https://...',
+    chFocus: true,
+  },
+};
+```
+
+**Vorteile gegenüber Fliesstext-Zitaten:**
+1. **Maschinenlesbar**: Quellen können automatisch geprüft, sortiert und angezeigt werden
+2. **Deduplizierung**: Eine Quelle wird einmal definiert und kann von beliebig vielen Claims referenziert werden
+3. **CH-Fokus-Markierung**: `chFocus: true/false` ermöglicht Filterung nach Schweizer Evidenz
+4. **Aktualitäts-Tracking**: Automatische Altersberechnung aus `year`
+5. **Konsistenz**: Einheitliches Format statt der heutigen Mischung aus "Göttingen: Hogrefe" und "DOI: 10.35190/..."
+
+#### Visueller Darstellungs-Vorschlag
+
+**Im Frontend (Empfehlung für Audit 08 Visual):**
+
+1. **Superscript-Nummern** neben Claims, die auf Quellen verweisen: "18% der Bevölkerung¹"
+2. **Aufklapp-Details** pro Sektion: Ein diskreter "Quellen"-Button am Ende jeder Zone, der die referenzierten Quellen einblendet
+3. **Literaturverzeichnis** am Ende der Evidenz-Seite: Automatisch generiert aus allen referenzierten `sourceIds` der angezeigten Sektionen
+
+Das Frontend-Rendering wird in Phase 3 **nicht** gebaut -- nur die Datenstruktur. Die visuelle Umsetzung ist Sache von Audit 08.
+
+#### Migration der bestehenden 11 Literatur-Referenzen
+
+| Heutiger Eintrag | Neue ID | Typ im neuen Schema | Aktion |
+|---|---|---|---|
+| Lenz, A. (2014) | `lenz-2014` | book | Übernehmen |
+| Krumm & Becker (2011) | `krumm-becker-2011` | journal | Übernehmen, Veralterungsrisiko markieren |
+| Plass & Wiegand-Grefe (2012) | `plass-wiegandgrefe-2012` | book | Übernehmen |
+| pädiatrie schweiz (2021) | `paediatrie-ch-2021` | journal | Übernehmen, chFocus: true |
+| Gesundheitsförderung ZH | -- | **Weblink, nicht Quelle** | In SUPPORT_OFFERS oder WEBLINKS verschieben |
+| PUK Zürich | -- | **Weblink, nicht Quelle** | In SUPPORT_OFFERS verschieben (dort bereits vorhanden) |
+| Institut Kinderseele | -- | **Weblink, nicht Quelle** | In SUPPORT_OFFERS verschieben (dort bereits vorhanden) |
+| Jones et al. (2016) | `jones-2016` | journal | Übernehmen |
+| Reupert et al. (2021) | `reupert-2021` | journal | Übernehmen, chFocus: false |
+| Stauber et al. (o.J.) | -- | **Identifikation nötig** | In Recherche-Liste |
+| Lenz, A. (2019) | `lenz-2019` | conference | Übernehmen |
+
+**Ergebnis:** Von 11 Einträgen werden 7 migriert, 3 als Weblinks reklassifiziert, 1 muss erst identifiziert werden.
+
+---
+
+### 2.4 E18 als intern abgedeckter Claim
+
+**Aussage E18:** "In der Praxis sind die meisten Kindesschutzmassnahmen unterstützend, nicht trennend" (HELP_BARRIER_PANELS[1])
+
+**Interner Beleg (Audit 03):** Die KOKES-Jahresstatistik 2024 (Quelle: `qa/juristische-faktenbasis-kindesschutz.md`, Abschnitt 1) weist schweizweit aus:
+- 49'875 Kinder mit Kindesschutzmassnahmen total
+- 38'392 zu Art. 308 ZGB (Beistandschaft) = **77%**
+- 5'107 zu Art. 310 ZGB (Aufhebung Aufenthaltsbestimmungsrecht) = **10%**
+
+Für den Kanton Zürich:
+- 7'351 von 8'542 = Art. 308 = **86%**
+
+**Beleg-Formulierung für Phase 3:** sourceId `kokes-2024`, bereits als Referenz in der juristischen Faktenbasis vorhanden. Die Aussage "die meisten sind unterstützend" ist durch 77-86% Beistandschaften quantitativ belegbar.
+
+**Status:** Kann in Phase 3 ohne externe Recherche geschlossen werden. Blaupause für Audit-übergreifende Quellennutzung.
+
+---
+
+### 2.5 Risikoeinschätzung
+
+**Vor Release zwingend:**
+Die 6 P1-Stellen (E1, E4, E5, E6, L10, L5) müssen belegt oder als "Schätzung ohne Primärquelle" deklariert werden. 4 davon sind konkrete Prozentwerte auf der prominentesten Seite des Portals (Evidenz-Eingangsstatistiken).
+
+**Systemisches Risiko:**
+Das Fehlen jeglicher Inline-Zitation ist für ein Fachportal, das Fachpersonen adressiert, ein Glaubwürdigkeitsproblem. Fachpersonen erwarten nachvollziehbare Quellenangaben, insbesondere bei Statistiken. Die Zitations-Architektur (2.3) hat deshalb strategische Priorität.
+
+---
+
+*Phase 2 abgeschlossen. Warte auf Freigabe für Phase 3.*

--- a/qa/audit-04-evidence-content.md
+++ b/qa/audit-04-evidence-content.md
@@ -1,0 +1,118 @@
+# Audit 04 -- Evidence-Content-Audit
+
+## Phase 1 -- Inventur
+
+### 1.1 Literatur-Referenzen: Aktualität
+
+| # | Autor | Jahr | Alter | Klassifikation | Begründung |
+|---|-------|------|-------|----------------|------------|
+| L1 | Lenz, A. | 2014 | 12 J. | veraltet-unkritisch | Grundlagenwerk, stabile Inhalte |
+| L2 | Krumm, S. & Becker, T. | 2011 | 15 J. | veraltet-risiko | Psychiatrische Versorgungsforschung, Strukturen ändern sich |
+| L3 | Plass, A. & Wiegand-Grefe, S. | 2012 | 14 J. | veraltet-unkritisch | Lehrbuch, stabile Grundlagen |
+| L4 | pädiatrie schweiz | 2021 | 5 J. | aktuell | Schweizer Prävalenz, relativ stabil |
+| L5 | Gesundheitsförderung Kt. ZH | o.J. | n/a | nicht beurteilbar | Online-Info, kein Erscheinungsjahr |
+| L6 | PUK Zürich | o.J. | n/a | nicht beurteilbar | Institutionelle Seite |
+| L7 | Institut Kinderseele Schweiz | o.J. | n/a | nicht beurteilbar | Institutionelle Seite |
+| L8 | Jones, M. et al. | 2016 | 10 J. | älter | Qualitative Studie, moderat stabil |
+| L9 | Reupert, A. et al. | 2021 | 5 J. | aktuell | Stigma-Review, aktiv beforscht |
+| L10 | Stauber, A. et al. | o.J. | n/a | nicht beurteilbar | Praxisforschungsband, kein Jahr |
+| L11 | Lenz, A. | 2019 | 7 J. | älter | Interventionskongress, stabil |
+
+**Verteilung:** 2 aktuell, 2 älter, 3 veraltet (davon 1 Risiko), 4 ohne Jahr.
+
+---
+
+### 1.2 Aussagen-Inventar
+
+#### Statistiken (härteste Claims)
+
+| ID | Zitat (max 30 W.) | Sektion | Typ | Quelle | Fact-Check |
+|----|-------------------|---------|-----|--------|------------|
+| E1 | "18% -- Anteil der Bevölkerung in der Schweiz mit behandlungsbedürftiger psychischer Störung" | RELEVANCE_STATS[0] | Statistik | fehlend | zu prüfen |
+| E2 | "ca. 300'000 -- auf die Schweiz übertragene Grössenordnung für unter 18-Jährige gemäss pädiatrie schweiz (2021)" | RELEVANCE_STATS[1] | Statistik | teilweise (L4) | zu prüfen |
+| E3 | "15-23% -- internationale Prävalenzschätzung; von pädiatrie schweiz auf die Schweiz übertragen" | RELEVANCE_STATS[2] | Statistik | teilweise (L4) | unauffällig |
+| E4 | "17-45% -- Anteil stationärer Patient:innen in der Erwachsenenpsychiatrie mit minderjährigen Kindern" | RELEVANCE_STATS[3] | Statistik | fehlend | zu prüfen |
+| E5 | "53% -- Anteil stationär behandelter Eltern mit zusätzlichem Hilfebedarf bezüglich ihrer Kinder" | RELEVANCE_STATS[4] | Statistik | fehlend | zu prüfen |
+| E6 | "ca. 70% -- besonders hohe Elternschaftsrate bei affektiven Störungen" | RELEVANCE_STATS[5] | Statistik | fehlend | zu prüfen |
+
+#### Fachbehauptungen
+
+| ID | Zitat (max 30 W.) | Sektion | Typ | Quelle | Fact-Check |
+|----|-------------------|---------|-----|--------|------------|
+| E10 | "Psychische Erkrankungen greifen oft genau dort ein, wo Eltern besonders präsent sein müssten: bei Feinfühligkeit, Struktur, Geduld" | PARENT_EXPERIENCE_POINTS[0] | Fachbehauptung | fehlend | unauffällig |
+| E11 | "Stigma, Scham und die Angst [...] können Offenheit und Hilfesuche deutlich erschweren" | PARENT_ROLE_EVIDENCE_POINTS[2] | Fachbehauptung | teilweise (L8, L9) | unauffällig |
+| E12 | "Kinder psychisch erkrankter Eltern tragen ein deutlich erhöhtes Risiko für emotionale Belastungen" | CHILD_EXPERIENCE_PANELS[0] | Fachbehauptung | fehlend | unauffällig |
+| E13 | "Entscheidend ist nicht nur die Diagnose, sondern wie stark Alltag, Beziehung, Sprache und Schutzfaktoren beeinträchtigt sind" | CHILD_EXPERIENCE_PANELS[0] | Fachbehauptung | fehlend | unauffällig |
+| E14 | "Wissen reduziert kindliche Schuldgefühle und falsche Selbstzuschreibungen" | PSYCHOEDUCATION_BENEFITS[0] | Fachbehauptung | fehlend | unauffällig |
+| E15 | "Vorschulkinder denken oft magisch und beziehen vieles auf sich" | PSYCHOEDUCATION_AGE_GROUPS[1] | Fachbehauptung | fehlend | unauffällig |
+| E16 | "Jugendliche fragen häufiger nach Vererbbarkeit, Verantwortung und eigener Abgrenzung" | PSYCHOEDUCATION_AGE_GROUPS[3] | Fachbehauptung | fehlend | unauffällig |
+| E17 | "Nicht die Information selbst überfordert meist, sondern das Fehlen einer verstehbaren Erklärung" | PSYCHOEDUCATION_PREPARATION_POINTS[3] | Fachbehauptung | fehlend | unauffällig |
+| E18 | "In der Praxis sind die meisten Kindesschutzmassnahmen unterstützend, nicht trennend" | HELP_BARRIER_PANELS[1] | Fachbehauptung | fehlend | zu prüfen |
+| E22 | "Nicht jede psychische Erkrankung führt automatisch zu einer Kindeswohlgefährdung" | CROSS_DIAGNOSIS_POINTS[0] | Fachbehauptung | fehlend | unauffällig |
+| E23 | "Für Kinder ist weniger die Diagnose als solche zentral als das konkrete Erleben" | CROSS_DIAGNOSIS_POINTS[1] | Fachbehauptung | fehlend | unauffällig |
+
+#### Studienreferenzen und Programme
+
+| ID | Zitat (max 30 W.) | Sektion | Typ | Quelle | Fact-Check |
+|----|-------------------|---------|-----|--------|------------|
+| E19 | "Vortragsmaterial von Lenz verweist auf Beardslee, CHIMPs, Kindergruppen und mentalisierungsorientierte Elternprogramme" | INTERVENTION_PROGRAM_POINTS[1] | Studienreferenz | teilweise (L11) | unauffällig |
+| E20 | Beardslee als Interventionsprogramm | INTERVENTION_PROGRAM_POINTS[1] | Studienreferenz | teilweise | unauffällig |
+| E21 | CHIMPs als Interventionsprogramm | INTERVENTION_PROGRAM_POINTS[1] | Studienreferenz | teilweise | unauffällig |
+
+#### Institutionelle Claims
+
+| ID | Zitat (max 30 W.) | Sektion | Typ | Quelle | Fact-Check |
+|----|-------------------|---------|-----|--------|------------|
+| E24 | "Die offizielle PUK-Beratung ist kostenlos, institutionell verankert und kann auch ohne Hospitalisation genutzt werden" | PUK_CONTEXT_POINTS[2] | Fachbehauptung | teilweise (L6) | zu prüfen |
+| E26 | "AdoASSIP -- Spezifisches Angebot für Jugendliche nach Suizidversuchen im Umfeld der PUK" | MEDIA_DIGITAL[2] | Studienreferenz | fehlend | unauffällig |
+
+---
+
+### 1.3 Quellen-Klassifizierung Gesamtbild
+
+| Klassifizierung | Anzahl | Anteil |
+|-----------------|--------|--------|
+| vollständig (Autor + Jahr + Titel + direkt am Claim) | 0 | 0% |
+| teilweise (Quelle vorhanden, aber nicht direkt am Claim) | 9 | 39% |
+| fehlend (kein Beleg am Claim) | 14 | 61% |
+| unpassend | 0 | 0% |
+
+### 1.4 Fact-Check-Verteilung
+
+| Bewertung | Anzahl | IDs |
+|-----------|--------|-----|
+| unauffällig | 15 | E3, E10-E17, E19-E23, E26 |
+| zu prüfen | 7 | E1, E2, E4, E5, E6, E18, E24 |
+| fragwürdig | 0 | -- |
+| nicht beurteilbar | 0 | -- |
+
+### 1.5 Gesamtbild und Hot-Spots
+
+**Gesamtzahlen:**
+- 23 verifiable Claims (ohne Duplikate)
+- 0 vollständige Inline-Zitationen
+- 7 Claims mit "zu prüfen"-Status
+- 6 Statistiken ohne direkte Quellenangabe (E1, E4, E5, E6 komplett ohne; E2, E3 nur indirekt via pädiatrie schweiz)
+
+**Top-5 Hot-Spots** (schlechteste Kombination aus Quelle + Fact-Check + Relevanz):
+
+| Rang | ID | Warum Hot-Spot |
+|------|-----|---------------|
+| 1 | **E1** (18% CH-Prävalenz) | Zentrale Eingangsstatistik, keine Quelle, konkreter Wert |
+| 2 | **E4** (17-45% Elternschaft stationär) | Enorme Spannbreite, keine Quelle, irreführend ohne Kontext |
+| 3 | **E5** (53% Hilfebedarf) | Konkreter Prozentwert, keine Quelle |
+| 4 | **E6** (70% Elternschaft affektive Störungen) | Konkreter Prozentwert, keine Quelle |
+| 5 | **E18** (meisten KS-Massnahmen unterstützend) | Quantitative Aussage ("die meisten") ohne Beleg -- allerdings durch KOKES 2024 (Audit 03) jetzt belegbar |
+
+**Positiv:**
+- Keine fragwürdigen Aussagen identifiziert
+- Alle Fachbehauptungen konsistent mit dem aktuellen Forschungsstand
+- Interventionsprogramme korrekt benannt
+- Die LITERATUR-Liste enthält relevante Standardwerke
+
+**Strukturelles Problem:**
+Die LITERATUR-Liste steht separat und ist mit keiner einzelnen Aussage direkt verknüpft. Es gibt kein Inline-Zitationssystem. Dadurch ist für Leser:innen nicht erkennbar, welche Aussage auf welcher Quelle basiert.
+
+---
+
+*Phase 1 abgeschlossen. Warte auf Freigabe für Phase 2 (Diagnose und Recherche-Liste).*

--- a/qa/audit-04-recherche-liste.md
+++ b/qa/audit-04-recherche-liste.md
@@ -1,0 +1,121 @@
+# Audit 04 -- Recherche-Liste für externe Sitzung
+
+Dieses Dokument ist das Gesprächsdokument für die Recherche-Sitzung zwischen Christa und Claude (Chat, nicht Claude Code). Die Recherche-Aufträge sind nach Priorität sortiert.
+
+---
+
+## P1 -- Vor Release zwingend
+
+### R1: E1 -- 18% CH-Prävalenz psychische Störungen
+
+**Aussage:** "18% der Bevölkerung in der Schweiz mit behandlungsbedürftiger psychischer Störung"
+**Konkrete Frage:** Gibt es eine aktuelle Schweizer Quelle (Obsan, SGB, BAG) für die Prävalenz behandlungsbedürftiger psychischer Störungen in der erwachsenen Bevölkerung? Welcher Prozentwert wird genannt, und wie ist "behandlungsbedürftig" definiert?
+**Warum wichtig:** P1 -- zentrale Eingangsstatistik des Evidenzteils, ohne Quelle
+**Zielquellen-Typ:** Obsan-Bericht oder Schweizerische Gesundheitsbefragung (SGB)
+**Erwartetes Ergebnis:** Autor/Institution, Jahr, Titel, Link, exakter Prozentwert mit Definition
+
+### R2: E4 -- 17-45% Elternschaft stationäre Psychiatrie
+
+**Aussage:** "17-45% der stationären Patient:innen in der Erwachsenenpsychiatrie haben minderjährige Kinder"
+**Konkrete Frage:** Woher stammt die Spannbreite 17-45%? Gibt es eine Meta-Analyse oder einen Review, der diese Bandbreite belegt? Gibt es eine Schweizer Studie (z.B. aus dem PUK-Kontext oder aus der OBSAN-Psychiatriestatistik)?
+**Warum wichtig:** P1 -- die enorme Spannbreite suggeriert Präzision, wo wenig ist; die Quelle bestimmt den Kontext
+**Zielquellen-Typ:** Systematischer Review oder Schweizer Erhebung
+**Erwartetes Ergebnis:** Autor, Jahr, Titel, DOI; idealerweise eine Schweizer Primärquelle
+
+### R3: E5 -- 53% Hilfebedarf stationäre Eltern
+
+**Aussage:** "53% der stationär behandelten Eltern mit zusätzlichem Hilfebedarf bezüglich ihrer Kinder"
+**Konkrete Frage:** Aus welcher Studie stammt der Wert 53%? Vermutlich Lenz (2014) oder Krumm/Becker (2011) -- aber welche Stichprobe, welches Land, welche Definition von "Hilfebedarf"?
+**Warum wichtig:** P1 -- konkreter Prozentwert, prominent platziert, ohne Beleg
+**Zielquellen-Typ:** Primärstudie oder Lehrbuch-Kapitel mit Seitenangabe
+**Erwartetes Ergebnis:** Autor, Jahr, Titel, Seitenzahl, Stichprobenbeschreibung
+
+### R4: E6 -- 70% Elternschaftsrate bei affektiven Störungen
+
+**Aussage:** "ca. 70% -- besonders hohe Elternschaftsrate bei affektiven Störungen im Vergleich zu anderen Diagnosegruppen"
+**Konkrete Frage:** Woher stammt der Wert 70%? Gibt es eine Studie, die Elternschaftsraten nach Diagnosegruppe vergleicht?
+**Warum wichtig:** P1 -- konkreter Prozentwert ohne Quelle, diagnosegruppenspezifisch
+**Zielquellen-Typ:** Epidemiologische Studie oder Review
+**Erwartetes Ergebnis:** Autor, Jahr, Titel, DOI, Vergleichszahlen für andere Diagnosegruppen
+
+### R5: L10 -- Stauber, Nyffeler & Gosteli (kein Jahr)
+
+**Aussage:** Literatur-Referenz "Praxisforschung Band 25" ohne Jahr und ohne Verlag
+**Konkrete Frage:** Um welche Publikation handelt es sich genau? Welches Jahr, welcher Verlag, welche Institution? Ist es eine ZHAW-Publikation?
+**Warum wichtig:** P1 -- Quelle ohne Jahr ist faktisch unbelegt
+**Zielquellen-Typ:** Bibliographische Identifikation (Verlag, Jahr, ISBN)
+**Erwartetes Ergebnis:** Vollständige bibliographische Angabe
+
+### R6: L5 -- Gesundheitsförderung Kanton Zürich (kein Jahr)
+
+**Aussage:** Literatur-Referenz "Online-Informationsseite" ohne Jahr
+**Konkrete Frage:** Handelt es sich um eine spezifische Publikation (Faktenblatt, Bericht) oder nur um eine Webseite? Falls Webseite: aus LITERATUR entfernen und als Weblink in SUPPORT_OFFERS führen.
+**Warum wichtig:** P1 -- nicht verifizierbar in aktueller Form
+**Zielquellen-Typ:** Identifikation: Publikation oder Weblink?
+**Erwartetes Ergebnis:** Entweder vollständige bibliographische Angabe oder Reklassifikation als Weblink
+
+---
+
+## P2 -- Empfehlenswert
+
+### R7: E2/E3 -- 300'000 Kinder CH / 15-23% international
+
+**Aussage:** "ca. 300'000 betroffene Kinder" und "15-23% internationale Prävalenz", beide verweisend auf pädiatrie schweiz (2021)
+**Konkrete Frage:** Gibt es neben pädiatrie schweiz (2021) eine aktuellere Schweizer Quelle (z.B. Obsan, BAG, BFS) für die Prävalenz betroffener Kinder? Wie aktuell ist die Schätzung 300'000?
+**Warum wichtig:** P2 -- hat Teilquelle, aber Aktualität und Methodik der Hochrechnung unklar
+**Zielquellen-Typ:** Schweizer Statistik oder Obsan-Bericht
+**Erwartetes Ergebnis:** Bestätigung oder Aktualisierung der Zahl, ggf. alternative CH-Quelle
+
+### R8: E24 -- PUK-Beratung kostenlos und ohne Hospitalisation
+
+**Aussage:** "Die offizielle PUK-Beratung ist kostenlos, institutionell verankert und kann auch ohne Hospitalisation in der PUK genutzt werden"
+**Konkrete Frage:** Stimmt diese Aussage noch mit dem aktuellen Angebotsstand der PUK Zürich überein (Stand 2026)?
+**Warum wichtig:** P2 -- institutionelle Angabe, die sich ändern kann
+**Zielquellen-Typ:** Aktuelle PUK-Webseite oder direkte Bestätigung durch Auftraggeberin
+**Erwartetes Ergebnis:** Bestätigung oder Korrektur
+
+### R9: L2 -- Krumm & Becker (2011) Veralterungsrisiko
+
+**Aussage:** Literatur-Referenz 15 Jahre alt, Versorgungsforschung
+**Konkrete Frage:** Gibt es eine neuere deutschsprachige Publikation zum Thema "Elternschaft als Herausforderung für die Psychiatrie" (publiziert nach 2018)?
+**Warum wichtig:** P2 -- Veralterungsrisiko bei Versorgungsstrukturen
+**Zielquellen-Typ:** Aktuellerer Review oder Fachaufsatz
+**Erwartetes Ergebnis:** Autor, Jahr, Titel, DOI -- als Ergänzung oder Ersatz
+
+---
+
+## Intern abgedeckt (keine externe Recherche nötig)
+
+### E18 -- "Die meisten Kindesschutzmassnahmen sind unterstützend"
+
+**Status:** Intern abgedeckt via Audit 03
+**Beleg:** KOKES Jahresstatistik 2024 (qa/juristische-faktenbasis-kindesschutz.md, Abschnitt 1):
+- CH: 38'392 von 49'875 = Art. 308 (Beistandschaft) = 77%
+- ZH: 7'351 von 8'542 = 86%
+**Source-ID für neues Schema:** `kokes-2024`
+**Aktion in Phase 3:** sourceIds: ['kokes-2024'] an HELP_BARRIER_PANELS[1] anhängen
+
+---
+
+## P3 -- Kann warten
+
+### R10-R18: Fachbehauptungen ohne Quelle (E10-E17, E22-E23)
+
+Diese Claims sind fachlich unauffällig (Konsens, Lehrbuch-Niveau). Eine Quellenunterlegung wäre ideal, ist aber nicht release-kritisch. Falls in der Recherche-Sitzung Zeit bleibt:
+
+**Sammel-Frage:** Gibt es eine aktuelle deutschsprachige Meta-Analyse oder ein Lehrbuch-Kapitel (nach 2018), das die Kernaussagen zu "Kinder psychisch erkrankter Eltern" zusammenfasst und als Sammelreferenz für E10-E17 dienen könnte?
+
+**Zielquellen-Typ:** Lehrbuch (z.B. Lenz 2019 Neuauflage, Wiegand-Grefe aktuell) oder Systematic Review
+
+---
+
+## Zusammenfassung
+
+| Priorität | Recherche-Aufträge | Geschätzter Aufwand |
+|---|---|---|
+| P1 (vor Release) | R1-R6 | 6 gezielte Suchen |
+| P2 (empfehlenswert) | R7-R9 | 3 gezielte Suchen |
+| Intern abgedeckt | E18 | Kein Aufwand |
+| P3 (kann warten) | R10-R18 | 1 Sammelsuche |
+
+**Total: 10 Recherche-Aufträge**, davon 6 zwingend vor Release.


### PR DESCRIPTION
## Summary
- **Phase 1 Inventur**: 23 verifiable claims extracted, 0 inline citations, 7 "zu prüfen" (6 statistics without source), 15 "unauffällig", 0 "fragwürdig"
- **Phase 2 Diagnose**: Prevalence statistics identified as weakest area (6 claims, 4 without any source). Citation architecture proposed (sourcesContent.js with structured entries + sourceIds[] at claims)
- **Recherche-Liste**: 10 research tasks (6 P1, 3 P2, 1 batch P3) in `qa/audit-04-recherche-liste.md` — ready for external research session
- **E18 as cross-audit pattern**: First documented case of inter-audit source reuse (KOKES 2024 from Audit 03 backs Evidence claim)
- **4 undated references** separated as "nicht verifizierbar" category with higher priority

Phase 3 awaits external research results.

## Deliverables
- `qa/audit-04-evidence-content.md` — full report (Phase 1+2)
- `qa/audit-04-recherche-liste.md` — structured research list for external session

## Test plan
- [x] No code changes — read-only audit
- [x] Report complete and internally consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)