### PR TITLE
fix: netlify-build (VITE_BASE_URL fallback + prerender timeout/health-check)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build && node scripts/replace-env.mjs && node scripts/prerender.mjs",
     "build:no-prerender": "vite build && node scripts/replace-env.mjs",
-    "preview": "vite preview",
+    "preview": "vite preview --host 0.0.0.0 --port 4173",
     "test:e2e": "npx playwright test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -43,7 +43,12 @@ async function isPreviewReady() {
 }
 
 function spawnPreview() {
-  const child = spawn('npx', ['vite', 'preview', '--port', String(previewPort), '--strictPort'], {
+  // --host 0.0.0.0: in CI-Umgebungen (Netlify u. a.) wichtig, damit der
+  // Server auf alle Interfaces bindet. Default 'localhost' kann in
+  // Container-Netzwerken zu Bind-Konflikten oder nicht-erreichbaren
+  // Endpoints fuehren; 127.0.0.1-Requests gegen einen 'localhost'-Bind
+  // klappen nicht zuverlaessig.
+  const child = spawn('npx', ['vite', 'preview', '--host', '0.0.0.0', '--port', String(previewPort), '--strictPort'], {
     cwd: projectRoot,
     stdio: ['ignore', 'pipe', 'pipe'],
   });

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -21,34 +21,73 @@ const distDir = path.join(projectRoot, 'dist');
 const indexPath = path.join(distDir, 'index.html');
 const previewPort = 4173;
 const previewUrl = `http://127.0.0.1:${previewPort}/`;
-const readyTimeoutMs = 30000;
+// Audit-13-Follow-up (Netlify-Build-Fix): Timeout von 30s auf 90s erhoeht,
+// plus aktiver HTTP-Health-Check statt blosser stdout-Beobachtung. CI-
+// Umgebungen wie Netlify starten Vite-Preview teils deutlich langsamer
+// als lokale Entwickler-Maschinen.
+const readyTimeoutMs = 90_000;
+const healthCheckIntervalMs = 500;
 const renderWaitMs = 800;
 
-function startPreview() {
-  return new Promise((resolve, reject) => {
-    const child = spawn('npx', ['vite', 'preview', '--port', String(previewPort), '--strictPort'], {
-      cwd: projectRoot,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    const timer = setTimeout(() => {
-      child.kill();
-      reject(new Error(`Vite-Preview-Server ist nach ${readyTimeoutMs} ms nicht bereit geworden.`));
-    }, readyTimeoutMs);
-    child.stdout.on('data', (chunk) => {
-      const text = chunk.toString();
-      if (text.includes(`localhost:${previewPort}`) || text.includes(`${previewPort}/`)) {
-        clearTimeout(timer);
-        resolve(child);
-      }
-    });
-    child.stderr.on('data', (chunk) => {
-      process.stderr.write(`[preview] ${chunk}`);
-    });
-    child.on('error', (err) => {
-      clearTimeout(timer);
-      reject(err);
-    });
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function isPreviewReady() {
+  try {
+    const res = await fetch(previewUrl, { method: 'HEAD' });
+    return res.ok || (res.status >= 200 && res.status < 500);
+  } catch {
+    return false;
+  }
+}
+
+function spawnPreview() {
+  const child = spawn('npx', ['vite', 'preview', '--port', String(previewPort), '--strictPort'], {
+    cwd: projectRoot,
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
+  // Vite-Preview-Output durchreichen, damit der Netlify-Build-Log
+  // sichtbar zeigt, was los ist, falls der Start scheitert.
+  child.stdout.on('data', (chunk) => {
+    process.stdout.write(`[preview] ${chunk}`);
+  });
+  child.stderr.on('data', (chunk) => {
+    process.stderr.write(`[preview] ${chunk}`);
+  });
+  return child;
+}
+
+async function startPreview() {
+  const child = spawnPreview();
+
+  // Aktives Polling des HTTP-Endpoints. So erkennen wir genau dann,
+  // wenn der Server tatsaechlich antwortet -- nicht nur wenn er etwas
+  // ins stdout schreibt.
+  const deadline = Date.now() + readyTimeoutMs;
+  let exited = false;
+  // Flag, das main() setzt, wenn wir den Prozess selbst beenden wollen
+  // -- dann ist ein anschliessender exit kein Fehler, sondern erwartet.
+  child.__intentionalShutdown = false;
+  child.on('exit', (code, signal) => {
+    exited = true;
+    if (!child.__intentionalShutdown) {
+      console.error(`[prerender] Vite-Preview-Prozess ist frueh beendet (code=${code}, signal=${signal}).`);
+    }
+  });
+
+  while (Date.now() < deadline) {
+    if (exited) {
+      throw new Error('Vite-Preview-Prozess ist vor Bereitschaft beendet worden.');
+    }
+    if (await isPreviewReady()) {
+      return child;
+    }
+    await wait(healthCheckIntervalMs);
+  }
+
+  child.kill();
+  throw new Error(`Vite-Preview-Server ist nach ${readyTimeoutMs} ms nicht bereit geworden (Health-Check auf ${previewUrl} schlug fehl).`);
 }
 
 async function prerenderStartRoute() {
@@ -98,6 +137,7 @@ async function main() {
     htmlSize = await injectPrerenderedHtml(rootInnerHTML);
     console.log(`[prerender] dist/index.html aktualisiert, neue Groesse: ${htmlSize} Bytes.`);
   } finally {
+    previewProcess.__intentionalShutdown = true;
     previewProcess.kill();
   }
 }

--- a/scripts/replace-env.mjs
+++ b/scripts/replace-env.mjs
@@ -59,6 +59,24 @@ async function main() {
       console.warn(`[replace-env] ${file} konnte nicht verarbeitet werden: ${err.message}`);
     }
   }
+
+  // Fallback-Schutz fuer index.html: Wenn Vite die VITE_BASE_URL-Env nicht
+  // sah (typisch bei CI-Umgebungen ohne .env), bleibt der Vite-Platzhalter
+  // %VITE_BASE_URL% in der dist/index.html stehen. Hier raeumen wir das
+  // nachtraeglich auf, damit die Seite trotz fehlender Env-Variable deploybar
+  // bleibt. Bei korrekt gesetzter Env-Variable ist der Platzhalter ohnehin
+  // schon durch Vite ersetzt -- dann ist dieser Block ein No-op.
+  try {
+    const indexPath = path.join(distDir, 'index.html');
+    let indexContent = await fs.readFile(indexPath, 'utf8');
+    if (indexContent.includes('%VITE_BASE_URL%')) {
+      indexContent = indexContent.split('%VITE_BASE_URL%').join(baseUrl);
+      await fs.writeFile(indexPath, indexContent, 'utf8');
+      console.log(`[replace-env] index.html: Vite-Platzhalter %VITE_BASE_URL% nachtraeglich ersetzt durch ${baseUrl}`);
+    }
+  } catch (err) {
+    console.warn(`[replace-env] index.html-Fallback konnte nicht verarbeitet werden: ${err.message}`);
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

Zwei im Netlify-Build-Log sichtbare Probleme adressiert. Kein Audit-Thema mehr, ein sauberer Deployment-Fix.

## Problem 1: VITE_BASE_URL-Platzhalter-Fallback

**Symptom**: Vite warnte 6× im Build-Log (`%VITE_BASE_URL% is not defined in env variables`), weil die Environment-Variable auf Netlify nicht gesetzt war. Die `.env`-Datei ist gitignored und damit nicht im CI-Checkout.

**Fix**: `scripts/replace-env.mjs` erweitert. Der Script räumt jetzt auch `%VITE_BASE_URL%`-Leftovers in `dist/index.html` auf — mit dem gleichen Fallback (`https://eltern-a.netlify.app`), den das Script ohnehin für `robots.txt` und `sitemap.xml` nutzt.

Das ist ein reiner Fallback-Schutz: bei **korrekt gesetzter Env-Variable** ist der Vite-Platzhalter ohnehin schon ersetzt, dann ist der neue Code-Block ein No-op.

**Für den Netlify-Admin:** Die Env-Variable `VITE_BASE_URL` in Site configuration → Environment variables → Add a variable mit der finalen Produktions-URL setzen lässt die Vite-Warnungen verschwinden und injiziert die URL schon zur Build-Zeit. Der Fallback in diesem PR ist das Sicherheitsnetz, falls das vergessen wird.

## Problem 2: Prerender-Server-Timeout auf CI

**Symptom**: `[prerender] Vite-Preview-Server ist nach 30000 ms nicht bereit geworden.` Der Build brach am Prerender-Step ab.

**Fix** (Option A aus dem Auftrag): `scripts/prerender.mjs` robuster gemacht:

- Timeout von 30 s → **90 s**
- **Aktiver HTTP-Health-Check** (HEAD-Request gegen `http://127.0.0.1:4173/`) mit 500ms-Polling statt stdout-Pattern-Matching. Der Server zählt erst als „bereit", wenn er tatsächlich antwortet.
- **Preview-stdout/stderr wird mit `[preview]`-Prefix ins Build-Log durchgereicht** — bei Fehlern auf CI sieht man jetzt, was Vite meldet.
- **Exit-Listener**: wenn Vite-Preview unerwartet stirbt, bricht der Prerender sauber ab, statt bis zum Timeout zu warten.
- **Intentional-Shutdown-Flag**: unterdrückt die „früh beendet"-Warnung, wenn `main()` den Prozess regulär am Ende beendet (kosmetisch, aber schöner im Log).

Falls das auf Netlify trotzdem scheitert, wäre Option B aus dem Auftrag der nächste Schritt: Prerender lokal generieren und committen.

## Verifikation

Lokal mit und ohne `.env`-Datei gebaut; in beiden Fällen:

- `dist/index.html`: 0 verbleibende `%VITE_BASE_URL%`-Platzhalter
- `dist/robots.txt`, `dist/sitemap.xml`: 0 verbleibende `__VITE_BASE_URL__`-Platzhalter
- Alle URL-Referenzen zeigen auf `https://eltern-a.netlify.app`
- Prerender liefert 31 149 Bytes in `dist/index.html` wie vorher

🤖 Generated with [Claude Code](https://claude.com/claude-code)