### PR TITLE
ux(training): seo-titel auf leit-nomenklatur Training vereinheitlicht

### DIFF
--- a/src/data/routeMeta.js
+++ b/src/data/routeMeta.js
@@ -55,7 +55,7 @@ export const ROUTE_META = {
       'Schrittweise Lernbausteine für Fachpersonen: Sprache, Falllogik und Gesprächsorientierung in der Begleitung psychisch belasteter Eltern.',
   },
   vignetten: {
-    title: 'Training und Vignetten – Relational Recovery',
+    title: 'Training – Relational Recovery',
     description:
       'Trainingsfälle zur Fallreflexion und Dialogführung in belasteten Familiensystemen, mit klinisch angelegter Entscheidungslogik.',
     ogTitle: 'Fallvignetten für Reflexion und Dialog – Relational Recovery',


### PR DESCRIPTION
## Summary

Follow-up zur Verifikation nach PR #38. Einzige verbliebene Inkonsistenz der user-facing Training-Nomenklatur war der Route-Meta-Seitentitel, der noch "Training und Vignetten" hiess.

- `src/data/routeMeta.js:58` — `title` von `'Training und Vignetten – Relational Recovery'` auf `'Training – Relational Recovery'`.

Konsistent mit Nav-Label, Section-Hero ("Training / mit Fallvignetten"), Stats-Einheit ("Trainingsfaelle") und Hash-Aliasen (`#training`, `#trainingsfaelle`, `#vignetten`).

`ogTitle` bleibt als "Fallvignetten für Reflexion und Dialog" unveraendert — SEO-Detailtitel darf spezifizierender sein als Hauptseitentitel und ist mit dem Section-Hero-Accent "mit Fallvignetten" konsistent.

## Test plan

- [x] Build sauber
- [x] Lint sauber
- [x] `#vignetten`, `#training`, `#trainingsfaelle` liefern alle Browser-Titel `Training – Relational Recovery`
- [x] Audit-14-Scripts: 0 Overlaps, 0 Klick-Failures (keine Regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)