### PR TITLE
ux(home): zielgruppen-weiche in den hero gezogen

### DIFF
--- a/src/components/ui/PageHero.jsx
+++ b/src/components/ui/PageHero.jsx
@@ -34,6 +34,8 @@ export default function PageHero({
   imageAlt,
   stats = [],
   headingAriaLabel,
+  audienceEntries = [],
+  audienceLabel,
 }) {
   return (
     <div className="ui-hero">
@@ -49,6 +51,26 @@ export default function PageHero({
             {title} {accent ? <span className="ui-hero__accent">{accent}</span> : null}
           </h1>
           {lead ? <p className="ui-hero__lead">{lead}</p> : null}
+
+          {audienceEntries.length ? (
+            <div className="ui-hero__audience" role="group" aria-label={audienceLabel || 'Zugang nach Rolle wählen'}>
+              {audienceEntries.map((entry) => (
+                <button
+                  key={entry.label}
+                  type="button"
+                  className="ui-hero__audience-entry haptic-btn"
+                  onClick={entry.onClick}
+                  aria-label={entry.ariaLabel || `${entry.label}: ${entry.destination}`}
+                >
+                  <span className="ui-hero__audience-label">{entry.label}</span>
+                  <span className="ui-hero__audience-destination">
+                    <span aria-hidden="true">→ </span>
+                    {entry.destination}
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : null}
 
           {actions.length ? (
             <div className="ui-hero__actions">

--- a/src/data/grundlagenContent.js
+++ b/src/data/grundlagenContent.js
@@ -2,7 +2,7 @@ export const GRUNDLAGEN_HERO = {
   eyebrow: 'Redaktioneller Wissensbereich',
   title: 'Häufige Fragen für',
   accent: 'ruhigere Orientierung im Alltag.',
-  lead: 'Der Grundlagenbereich beantwortet typische Fragen von Angehörigen und Fachpersonen in einer klaren, entlastenden Sprache. Er soll Unsicherheit reduzieren, Begriffe in Alltagssituationen übersetzen und den Blick auf nächste Schritte öffnen.',
+  lead: 'Der Grundlagenbereich richtet sich primär an Angehörige und beantwortet typische Fragen in klarer, entlastender Sprache. Er soll Unsicherheit reduzieren, Begriffe in Alltagssituationen übersetzen und den Blick auf nächste Schritte öffnen. Fachpersonen können den Bereich ergänzend als Sprach- und Einordnungshilfe für Gespräche mit Angehörigen nutzen.',
   asideTitle: 'Einordnung',
   asideCopy:
     'Die Antworten ersetzen keine individuelle klinische, rechtliche oder kindesschutzbezogene Beurteilung. Sie dienen als tragfähige Erstorientierung für Gespräch, Reflexion und Weitervermittlung.',

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -856,6 +856,58 @@
   line-height: var(--line-height-relaxed);
 }
 
+/* Zielgruppen-Weiche direkt nach dem Lead. Kompakte Zwei-Eintraege-Leiste,
+   die Doppelzielgruppe bereits im ersten Nutzungsfenster sichtbar macht
+   (Audit-14-Folge / Verifikation-PR #39). Siehe audienceEntries-Prop in
+   PageHero.jsx. */
+.ui-hero__audience {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.ui-hero__audience-entry {
+  flex: 1 1 18rem;
+  min-height: var(--touch-target-min);
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.75rem 1.125rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--accent-primary) 22%, white 78%);
+  background: var(--surface-note);
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background-color var(--motion-fast) ease,
+    border-color var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease,
+    transform var(--motion-fast) ease;
+}
+
+.ui-hero__audience-entry:hover {
+  background: color-mix(in srgb, var(--surface-note) 82%, white 18%);
+  border-color: color-mix(in srgb, var(--accent-primary) 40%, white 60%);
+  box-shadow: var(--shadow-soft);
+}
+
+.ui-hero__audience-label {
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent-primary-strong);
+}
+
+.ui-hero__audience-destination {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
 .ui-hero__actions {
   display: flex;
   flex-wrap: wrap;

--- a/src/templates/HomeLandingTemplate.jsx
+++ b/src/templates/HomeLandingTemplate.jsx
@@ -26,6 +26,19 @@ export default function HomeLandingTemplate({ pageHeadingId }) {
     title: 'Wenn ein Elternteil',
     accent: 'psychisch belastet ist.',
     lead: 'Orientierung, Triage und Arbeitshilfen für Fachpersonen. FAQ und Einordnung für Angehörige. Krisenhilfe und regionale Netzwerkstellen für beide Zielgruppen.',
+    audienceLabel: 'Zugang nach Rolle wählen',
+    audienceEntries: [
+      {
+        label: 'Für Fachpersonen',
+        destination: 'Toolbox',
+        onClick: () => navigate('toolbox', { focusTarget: 'heading' }),
+      },
+      {
+        label: 'Für Angehörige',
+        destination: 'Grundlagen-FAQ',
+        onClick: () => navigate('grundlagen', { focusTarget: 'heading' }),
+      },
+    ],
     image: heroIllustration,
     imageAlt: 'Minimalistische Illustration eines Familiensystems mit Nähe, Distanz und Unterstützung',
     asideTitle: 'Wichtiger Hinweis zur Einordnung',
@@ -73,35 +86,14 @@ export default function HomeLandingTemplate({ pageHeadingId }) {
   };
 
   // Startseite traegt genau zwei Orientierungs-Schichten:
-  // 1) Zielgruppen-Einstieg (Fachperson / Angehoerige) als sichtbare Doppelzielgruppen-Aufloesung
-  // 2) Phasen-Logik (Verstehen / Einschaetzen / Handeln / Vernetzen) als Haupt-Gliederung
-  // Die frueheren Bloecke "Direkte Einstiege" und "Vertrauen und Orientierung" wurden
-  // entfernt, weil sie dieselben Wege in anderer Form wiederholt haben.
+  // 1) Zielgruppen-Einstieg (Fachperson / Angehoerige) direkt im Hero als
+  //    audienceEntries-Chipleiste nach dem Lead — sichtbar im oberen
+  //    Nutzungsfenster (Verifikations-Befund nach PR #38: die frueher
+  //    eigene "Zugang waehlen"-Section lag auf allen Viewports unter der
+  //    Fold; siehe PR #39 / Verifikation).
+  // 2) Phasen-Logik (Verstehen / Einschaetzen / Handeln / Vernetzen) als
+  //    Haupt-Gliederung der Content-Sections darunter.
   const sections = [
-    {
-      eyebrow: 'Zugang wählen',
-      title: 'Zwei Einstiege, je nach Rolle.',
-      description:
-        'Das Portal richtet sich an zwei Zielgruppen. Fachpersonen finden den Einstieg über Triage und Arbeitshilfen, Angehörige über eine Einordnung in verständlicher Sprache.',
-      cards: [
-        {
-          label: 'Für Fachpersonen',
-          title: 'Mit der Toolbox beginnen',
-          copy: 'Strukturierte Einschätzung, Krisenplan, Gesprächsleitfaden und Downloads für die direkte Fallarbeit — inklusive Sofort-Triage und Notfall-Kontakte.',
-          tone: 'accent',
-          onClick: () => navigate('toolbox', { focusTarget: 'heading' }),
-          actionLabel: 'Zur Toolbox',
-        },
-        {
-          label: 'Für Angehörige',
-          title: 'Mit der Grundlagen-FAQ beginnen',
-          copy: 'Einordnung zu häufigen Fragen rund um psychische Belastung in der Familie, verständlich formuliert, mit Weiterverweisen auf offizielle Beratung.',
-          tone: 'soft',
-          onClick: () => navigate('grundlagen', { focusTarget: 'heading' }),
-          actionLabel: 'Zu den Grundlagen',
-        },
-      ],
-    },
     {
       eyebrow: 'Orientierung',
       title: 'Ein ruhiger, fachlich klarer Weg durch die Inhalte.',


### PR DESCRIPTION
## Summary

Folge der Verifikation nach PR #38/#39. Die bisherige grosse "Zugang waehlen"-Section lag auf allen Viewports unter der Fold. Hier zwei gezielte Fixes:

**1. Zielgruppen-Weiche in den Hero**
- `PageHero` um optionalen `audienceEntries`-Prop erweitert — rendert zwei kompakte Eintraege direkt nach dem Lead, vor den Actions
- Minimales `ui-hero__audience`-CSS in `primitives.css`
- `HomeLandingTemplate` nutzt den Prop fuer "Fuer Fachpersonen → Toolbox" und "Fuer Angehoerige → Grundlagen-FAQ"
- Die bisherige grosse `Zugang waehlen`-Section entfernt (redundant)

**2. Grundlagen-Lead geschaerft**
- `grundlagenContent.js`: primaere Widmung an Angehoerige explizit; Fachpersonen als ergaenzende Nutzergruppe benannt

## Messung Zielgruppen-Weiche (y-Position)

| Viewport | vorher | nachher | Δ | ATF? |
|---|---:|---:|---:|---|
| Laptop-1366 (fold 768) | 1174 | **683** | −491 | **Ja** |
| Desktop-1920 (fold 1080) | 1290 | **778** | −512 | **Ja** |
| Mobile-375 (fold 812) | 2197 | **970** | −1227 | Nein (158 px unter fold) |

Mobile bleibt knapp unter der Fold, weil Persistenz-Banner + Akute-Krise-Banner + Header ~590 px konsumieren. Das sind die Audit-09/11/13-Notfall-Primitives — nicht beruehrt. Von 2.7 Screens auf 1.2 Screens reduziert.

## Test plan

- [x] Lint sauber, Build erfolgreich
- [x] `qa/scripts/interaction-overlap.mjs`: 0 Overlaps
- [x] `qa/scripts/click-reachability.mjs`: 0 Failures, 122 Nav + 63/63 tel
- [x] Screenshots Laptop + Desktop: Audience-Row klar ATF, Zielgruppen sofort erkennbar
- [x] Mobile-375: Audience-Row nach 1 Finger-Wisch sichtbar (vorher: 2–3 Wische)
- [x] A11y: `audienceEntries` als `role="group"` mit aria-label; jeder Eintrag als `<button>` mit `aria-label` kombinierend Label + Ziel
- [x] Keine Regression in Navigation, Routing, Mobile-Menue, Notfall-Erreichbarkeit

🤖 Generated with [Claude Code](https://claude.com/claude-code)