### PR TITLE
ux(home): hero-stats pro karte konditional ab count >= 3

### DIFF
--- a/src/templates/HomeLandingTemplate.jsx
+++ b/src/templates/HomeLandingTemplate.jsx
@@ -65,23 +65,40 @@ export default function HomeLandingTemplate({ pageHeadingId }) {
         icon: ExternalLink,
       },
     ],
+    // Content-Stats werden pro Karte nur angezeigt, sobald der Count die
+    // Signal-Schwelle erreicht (>= 3). Vorher wirken einzelne kleine Werte
+    // wie "Trainingsfaelle: 1" eher entmutigend als vertrauensbildend
+    // (Verifikation P3 nach PR #40). Sobald Inhalte wachsen, kehrt die
+    // jeweilige Karte automatisch zurueck — keine redaktionelle Pflege.
     stats: [
       ...progressStat,
-      {
-        label: 'Module',
-        value: String(E_MODULE_COUNT),
-        note: 'kompakte Lernbausteine für die systemische Einordnung',
-      },
-      {
-        label: 'Trainingsfälle',
-        value: String(VIGNETTE_COUNT),
-        note: 'für Fallreflexion, Sprache und Dialog',
-      },
-      {
-        label: 'Netzwerkstellen',
-        value: String(NETWORK_RESOURCE_COUNT),
-        note: 'für Triage, Entlastung und Weitervermittlung',
-      },
+      ...(E_MODULE_COUNT >= 3
+        ? [
+            {
+              label: 'Module',
+              value: String(E_MODULE_COUNT),
+              note: 'kompakte Lernbausteine für die systemische Einordnung',
+            },
+          ]
+        : []),
+      ...(VIGNETTE_COUNT >= 3
+        ? [
+            {
+              label: 'Trainingsfälle',
+              value: String(VIGNETTE_COUNT),
+              note: 'für Fallreflexion, Sprache und Dialog',
+            },
+          ]
+        : []),
+      ...(NETWORK_RESOURCE_COUNT >= 3
+        ? [
+            {
+              label: 'Netzwerkstellen',
+              value: String(NETWORK_RESOURCE_COUNT),
+              note: 'für Triage, Entlastung und Weitervermittlung',
+            },
+          ]
+        : []),
     ],
   };
 


### PR DESCRIPTION
## Summary

Folge der Verifikation (P3 nach PR #40). Einzelne Stat-Karten mit niedrigen Werten (\`Module: 2\`, \`Trainingsfaelle: 1\`) wirkten eher entmutigend als vertrauensbildend.

- Pro Stat-Karte konditionale Rendering-Schwelle: \`count >= 3\`
- Aktuell sichtbar bleibt nur \`Netzwerkstellen: 19\` — der einzige starke Beleg
- \`Module\` und \`Trainingsfaelle\` kehren automatisch zurueck, sobald Count >= 3
- Keine redaktionelle Pflege noetig, keine qualitativen Formulierungen
- Konsistent mit dem bereits bestehenden \`progressStat\`-Pattern (aus PR #38)

## Test plan

- [x] Lint + Build sauber
- [x] \`qa/scripts/interaction-overlap.mjs\`: 0 Overlaps
- [x] \`qa/scripts/click-reachability.mjs\`: 0 Failures
- [x] Live-Check Desktop-1920 + Mobile-375: Hero-Stats zeigen nur \`Netzwerkstellen: 19\`
- [x] Keine Regression in Navigation, Routing, Notfall-Erreichbarkeit

🤖 Generated with [Claude Code](https://claude.com/claude-code)