### PR TITLE
ux(audience): phase 1 fachpersonen-fokus, grundlagen als nebenpfad

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -65,6 +65,7 @@ const Header = memo(function Header({
             >
               <item.icon size={14} strokeWidth={2.1} aria-hidden="true" />
               <span>{item.label}</span>
+              {item.audienceBadge ? <span className="ui-nav__badge">{item.audienceBadge}</span> : null}
             </button>
           ))}
         </nav>
@@ -183,6 +184,7 @@ const Header = memo(function Header({
                   >
                     <item.icon size={18} strokeWidth={2.1} aria-hidden="true" />
                     <span>{item.label}</span>
+                    {item.audienceBadge ? <span className="ui-nav__badge">{item.audienceBadge}</span> : null}
                   </button>
                 ))}
               </nav>

--- a/src/components/ui/PageHero.jsx
+++ b/src/components/ui/PageHero.jsx
@@ -36,6 +36,7 @@ export default function PageHero({
   headingAriaLabel,
   audienceEntries = [],
   audienceLabel,
+  audienceNote,
 }) {
   return (
     <div className="ui-hero">
@@ -90,6 +91,34 @@ export default function PageHero({
                 </Button>
               ))}
             </div>
+          ) : null}
+
+          {audienceNote ? (
+            <p className="ui-hero__audience-note">
+              {audienceNote.prefix ? (
+                <span className="ui-hero__audience-note-prefix">{audienceNote.prefix}</span>
+              ) : null}
+              {audienceNote.href ? (
+                <a
+                  className="ui-hero__audience-note-link"
+                  href={audienceNote.href}
+                  target={audienceNote.target}
+                  rel={audienceNote.rel}
+                  aria-label={audienceNote.ariaLabel}
+                >
+                  {audienceNote.label}
+                </a>
+              ) : (
+                <button
+                  type="button"
+                  className="ui-hero__audience-note-link"
+                  onClick={audienceNote.onClick}
+                  aria-label={audienceNote.ariaLabel}
+                >
+                  {audienceNote.label}
+                </button>
+              )}
+            </p>
           ) : null}
 
           {stats.length ? (

--- a/src/data/appShellContent.js
+++ b/src/data/appShellContent.js
@@ -71,6 +71,10 @@ export const TAB_ITEMS = [
     footerNote: 'FAQ, Einordnung und Orientierung',
     priority: 'primary',
     primaryAudience: 'angehoerige',
+    // Sichtbarer Zielgruppen-Marker in der Haupt-/Mobile-Nav: Grundlagen
+    // ist der einzige Angehoerigen-Nebenpfad im sonst fachpersonenorientierten
+    // Portal (Audit-Phase-1 Audience-Cut-Strategie).
+    audienceBadge: 'Für Angehörige',
   },
   {
     id: 'evidenz',

--- a/src/data/grundlagenContent.js
+++ b/src/data/grundlagenContent.js
@@ -1,8 +1,8 @@
 export const GRUNDLAGEN_HERO = {
-  eyebrow: 'Redaktioneller Wissensbereich',
+  eyebrow: 'Für Angehörige',
   title: 'Häufige Fragen für',
   accent: 'ruhigere Orientierung im Alltag.',
-  lead: 'Der Grundlagenbereich richtet sich primär an Angehörige und beantwortet typische Fragen in klarer, entlastender Sprache. Er soll Unsicherheit reduzieren, Begriffe in Alltagssituationen übersetzen und den Blick auf nächste Schritte öffnen. Fachpersonen können den Bereich ergänzend als Sprach- und Einordnungshilfe für Gespräche mit Angehörigen nutzen.',
+  lead: 'Der Grundlagenbereich richtet sich an Angehörige und beantwortet typische Fragen in klarer, entlastender Sprache. Er soll Unsicherheit reduzieren, Begriffe in Alltagssituationen übersetzen und den Blick auf nächste Schritte öffnen.',
   asideTitle: 'Einordnung',
   asideCopy:
     'Die Antworten ersetzen keine individuelle klinische, rechtliche oder kindesschutzbezogene Beurteilung. Sie dienen als tragfähige Erstorientierung für Gespräch, Reflexion und Weitervermittlung.',

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -908,6 +908,41 @@
   color: var(--text-primary);
 }
 
+/* Schmaler Angehoerigen-Nebenpfad-Hinweis unter den Hero-Actions.
+   Ersatz fuer die frueher zweigliedrige Audience-Row (Audit-Phase-1,
+   Audience-Cut-Strategie: Fachpersonen-Fokus mit Angehoerigen als
+   markiertem Nebenpfad). */
+.ui-hero__audience-note {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+
+.ui-hero__audience-note-prefix {
+  color: var(--text-muted);
+}
+
+.ui-hero__audience-note-link {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  color: var(--accent-primary-strong);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 1px;
+}
+
+.ui-hero__audience-note-link:hover,
+.ui-hero__audience-note-link:focus-visible {
+  text-decoration-thickness: 2px;
+}
+
 .ui-hero__actions {
   display: flex;
   flex-wrap: wrap;
@@ -1433,6 +1468,38 @@
 
 .ui-nav__item svg {
   flex: none;
+}
+
+/* Dezenter Zielgruppen-Marker am Grundlagen-Tab. Sichtbar, aber optisch
+   nachgeordnet: weder eigene Nav-Ebene noch reine Farbtrennung. Default
+   aller Tabs ist Fachperson; nur Tabs mit explizitem Badge tragen das
+   Label (Audit-Phase-1, Audience-Cut-Strategie). */
+.ui-nav__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  border: 1px solid color-mix(in srgb, var(--accent-primary) 22%, white 78%);
+  border-radius: var(--radius-pill);
+  background: var(--surface-note);
+  color: var(--accent-primary-strong);
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  line-height: 1;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.ui-nav__item[aria-current='page'] .ui-nav__badge,
+.ui-nav__item.is-active .ui-nav__badge {
+  background: color-mix(in srgb, var(--surface-note) 82%, white 18%);
+  border-color: color-mix(in srgb, var(--surface-note) 60%, white 40%);
+}
+
+/* Im Mobile-Menue weiter Platz geben (Label-/Badge-Kombi bricht in 2 Zeilen). */
+.ui-nav--mobile .ui-nav__item {
+  flex-wrap: wrap;
+  row-gap: 0.25rem;
 }
 
 .ui-header-actions {

--- a/src/templates/HomeLandingTemplate.jsx
+++ b/src/templates/HomeLandingTemplate.jsx
@@ -25,20 +25,12 @@ export default function HomeLandingTemplate({ pageHeadingId }) {
     eyebrow: 'Systemische Orientierung',
     title: 'Wenn ein Elternteil',
     accent: 'psychisch belastet ist.',
-    lead: 'Orientierung, Triage und Arbeitshilfen für Fachpersonen. FAQ und Einordnung für Angehörige. Krisenhilfe und regionale Netzwerkstellen für beide Zielgruppen.',
-    audienceLabel: 'Zugang nach Rolle wählen',
-    audienceEntries: [
-      {
-        label: 'Für Fachpersonen',
-        destination: 'Toolbox',
-        onClick: () => navigate('toolbox', { focusTarget: 'heading' }),
-      },
-      {
-        label: 'Für Angehörige',
-        destination: 'Grundlagen-FAQ',
-        onClick: () => navigate('grundlagen', { focusTarget: 'heading' }),
-      },
-    ],
+    lead: 'Orientierung, Triage und Arbeitshilfen für Fachpersonen, die mit Familien mit psychisch belasteten Eltern arbeiten. Krisenhilfe und regionale Netzwerkstellen bleiben auch für Angehörige erreichbar.',
+    audienceNote: {
+      prefix: 'Sie sind Angehörige?',
+      label: 'Zur Grundlagen-FAQ',
+      onClick: () => navigate('grundlagen', { focusTarget: 'heading' }),
+    },
     image: heroIllustration,
     imageAlt: 'Minimalistische Illustration eines Familiensystems mit Nähe, Distanz und Unterstützung',
     asideTitle: 'Wichtiger Hinweis zur Einordnung',


### PR DESCRIPTION
## Summary

Phase-1-Umsetzung der freigegebenen Audience-Cut-Strategie. Vier gezielte Oberflaechen-Anpassungen ohne IA-Reform, ohne Tab-Entfernung, ohne Design-Umbau.

### 1. Hero-Lead fachpersonenorientiert
Der Drei-Saetze-Spagat "fuer Fachpersonen / fuer Angehoerige / fuer beide" ist weg. Neu: *"Orientierung, Triage und Arbeitshilfen fuer Fachpersonen, die mit Familien mit psychisch belasteten Eltern arbeiten. Krisenhilfe und regionale Netzwerkstellen bleiben auch fuer Angehoerige erreichbar."*

### 2. Audience-Row zurueckgebaut
Die zweigliedrige Chip-Leiste aus PR #40 ist entfernt. Ersatz: schmaler, dezenter Angehoerigen-Link unter den Hero-CTAs *"Sie sind Angehoerige? Zur Grundlagen-FAQ"*. Umgesetzt via neuem `PageHero.audienceNote`-Prop + `.ui-hero__audience-note`-CSS.

### 3. Grundlagen-Hero klarer gewidmet
Eyebrow: *"Redaktioneller Wissensbereich"* → *"Fuer Angehoerige"*. Lead: Fachpersonen-Ausgleichs-Satz gestrichen.

### 4. Grundlagen-Nav-Tab-Marker
Neues Feld `audienceBadge` in TAB_ITEMS; nur Grundlagen traegt den Badge *"Fuer Angehoerige"*. Desktop- und Mobile-Nav rendern ihn als dezenten Pill-Chip.

## Was unveraendert bleibt
8 Tabs, Notfall-Layer (R31/P0/F4/K1), Toolbox-Inhalte, Netzwerk-Inhalte, Print-Footer, Routing, Evidenz.

## Test plan

- [x] `npm run lint` sauber
- [x] `npm run build` erfolgreich
- [x] `qa/scripts/interaction-overlap.mjs`: 0 Overlaps
- [x] `qa/scripts/click-reachability.mjs`: 0 Failures
- [x] Hero-Lead, Audience-Note, Grundlagen-Eyebrow, Mobile-Nav-Badge live verifiziert
- [x] Audience-Note-Link navigiert zu `#grundlagen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)