### PR TITLE
ux(audience): neuer offizieller titel + phase 2 fachpersonen-fokus

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,26 +6,26 @@
     <meta name="theme-color" content="#f9f4ee" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <title>Relational Recovery – Schweizer Fachportal</title>
+    <title>Eltern mit psychischen Erkrankungen im Beratungskontext</title>
     <meta
       name="description"
-      content="Psychoedukative Web-App für Angehörige und Fachpersonen mit Fokus auf Elternschaft, psychische Krise, Kindesschutz und regionale Unterstützung in Zürich und der Schweiz."
+      content="Fachportal für Orientierung, Triage und Weitervermittlung: Arbeitshilfen für Fachpersonen, die mit Familien mit psychisch belasteten Eltern arbeiten. Schwerpunkt Kanton Zürich, schweizweite Ergänzungen."
     />
     <link rel="canonical" href="%VITE_BASE_URL%/" />
-    <meta property="og:title" content="Relational Recovery – Begleitung ist Beziehungsarbeit" />
+    <meta property="og:title" content="Fachportal für Orientierung, Triage und Weitervermittlung" />
     <meta
       property="og:description"
-      content="Interaktive Fachressourcen für die Begleitung von Eltern mit psychischer Belastung – mit Training, systemischer Orientierung, Krisenhilfe und Netzwerk."
+      content="Arbeitshilfen für Fachpersonen, die mit Familien mit psychisch belasteten Eltern arbeiten – Toolbox, Trainingsfälle, Wissensraum, regionale Fachstellen."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="%VITE_BASE_URL%/" />
     <meta property="og:image" content="%VITE_BASE_URL%/og-image.webp" />
     <meta property="og:locale" content="de_CH" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Relational Recovery – Begleitung ist Beziehungsarbeit" />
+    <meta name="twitter:title" content="Fachportal für Orientierung, Triage und Weitervermittlung" />
     <meta
       name="twitter:description"
-      content="Interaktive Fachressourcen für die Begleitung von Eltern mit psychischer Belastung – mit Training, systemischer Orientierung, Krisenhilfe und Netzwerk."
+      content="Arbeitshilfen für Fachpersonen, die mit Familien mit psychisch belasteten Eltern arbeiten – Toolbox, Trainingsfälle, Wissensraum, regionale Fachstellen."
     />
     <meta name="twitter:image" content="%VITE_BASE_URL%/og-image.webp" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -35,8 +35,7 @@
       {
         "@context": "https://schema.org",
         "@type": "Organization",
-        "name": "Angehörigenarbeit PUK Zürich",
-        "alternateName": "Relational Recovery",
+        "name": "Eltern mit psychischen Erkrankungen im Beratungskontext",
         "url": "%VITE_BASE_URL%/",
         "logo": "%VITE_BASE_URL%/og-image.webp",
         "inLanguage": "de-CH",
@@ -44,7 +43,7 @@
           "@type": "AdministrativeArea",
           "name": "Kanton Zürich, Schweiz"
         },
-        "description": "Psychoedukatives Fachportal für Angehörige und Fachpersonen mit Fokus auf Elternschaft, psychische Krise, Kindesschutz und regionale Unterstützung.",
+        "description": "Fachportal für Orientierung, Triage und Weitervermittlung: Arbeitshilfen für Fachpersonen, die mit Familien mit psychisch belasteten Eltern arbeiten.",
         "contactPoint": [
           {
             "@type": "ContactPoint",

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -23,11 +23,11 @@ const Footer = memo(function Footer() {
           <div className="footer-panel footer-panel--brand">
             <div className="footer-brand-badge">Fachportal Zürich</div>
             <h2 className="footer-brand-title">
-              Relational <br /> Recovery
+              Eltern im <br /> Beratungskontext
             </h2>
             <p className="footer-brand-copy">
-              Ergänzendes psychoedukatives Informationsangebot zu psychisch belasteter Elternschaft, Kinderschutz,
-              Angehörigenarbeit und zürich-zentrierter Vernetzung mit punktuellen schweizweiten Ergänzungen.
+              Fachportal für Orientierung, Triage und Weitervermittlung: Arbeitshilfen für Fachpersonen, die mit
+              Familien mit psychisch belasteten Eltern arbeiten. Schwerpunkt Kanton Zürich, schweizweite Ergänzungen.
             </p>
             <div className="footer-stat-grid">
               <div className="footer-stat-card">
@@ -80,7 +80,7 @@ const Footer = memo(function Footer() {
                 </p>
               </div>
             </div>
-            <div className="footer-framework-legal">© 2026 Relational Recovery Fachportal.</div>
+            <div className="footer-framework-legal">© 2026 Eltern mit psychischen Erkrankungen im Beratungskontext.</div>
           </div>
         </div>
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -43,13 +43,13 @@ const Header = memo(function Header({
           type="button"
           onClick={handleHomeClick}
           className="ui-brand"
-          aria-label="Relational Recovery – zur Startseite wechseln"
+          aria-label="Eltern mit psychischen Erkrankungen im Beratungskontext – zur Startseite wechseln"
         >
           <div className="ui-brand__mark" aria-hidden="true">
             RR
           </div>
           <div className="ui-brand__copy">
-            <span className="ui-brand__title">Relational Recovery</span>
+            <span className="ui-brand__title">Eltern im Beratungskontext</span>
             <p className="ui-kicker ui-brand__meta">Schweizer Fachportal</p>
           </div>
         </button>

--- a/src/data/appShellContent.js
+++ b/src/data/appShellContent.js
@@ -17,7 +17,13 @@ import { FACHSTELLEN, SUPPORT_OFFER_IDS } from './fachstellenContent';
  */
 
 /**
- * @typedef {('fachpersonen'|'angehoerige'|'beide')} PrimaryAudience
+ * @typedef {('angehoerige')} AngehoerigenAudience
+ * Redaktionelles Metadatum fuer Ausnahme-Tabs. Seit Audience-Cut-Phase 2
+ * ist Fachperson der Default — nur Tabs, die sich explizit an Angehoerige
+ * richten, tragen das Feld `primaryAudience: 'angehoerige'`. Die fruehere
+ * Dreiwertigkeit (fachpersonen | angehoerige | beide) ist aufgehoben,
+ * weil "beide" und "fachpersonen" nach der Fokus-Entscheidung identisch
+ * behandelt werden (Default-Adressat Fachperson).
  */
 
 /**
@@ -27,26 +33,27 @@ import { FACHSTELLEN, SUPPORT_OFFER_IDS } from './fachstellenContent';
  * @property {React.ComponentType} icon - Lucide-React-Icon-Komponente.
  * @property {string} footerNote - Kurzer Beschreibungstext fuer den Footer.
  * @property {'primary'} priority - Aktuell sind alle Top-Level-Tabs 'primary'.
- * @property {PrimaryAudience} primaryAudience - Redaktionelles Metadatum aus
- *   Audit 02. Dokumentiert die primaere Zielgruppe eines Tabs. Wird aktuell
- *   nicht im Runtime-Code konsumiert, aber bei redaktionellen Entscheidungen
- *   aktiv verwendet, z.B. bei der Fachjargon-Schwelle in Audit 06 Block 5
- *   ('Desorganisation nur in Angehoerigen-Texten verwenden'). Bei neuen Tabs
- *   setzen, damit die Konvention lebendig bleibt. Option PA1 aus Audit 12:
- *   bewusst ohne Runtime-Integration, um die Seite nach Audit 10 release-fest
- *   nicht durch neue Design-Entscheidungen zu belasten.
+ * @property {AngehoerigenAudience} [primaryAudience] - Optional. Nur gesetzt
+ *   fuer Tabs, die sich primaer an Angehoerige richten. Fehlendes Feld
+ *   bedeutet: Default-Adressat Fachperson. Kombiniert mit `audienceBadge`
+ *   fuer sichtbare Nav-Markierung.
+ * @property {string} [audienceBadge] - Optional. Sichtbarer Zielgruppen-
+ *   Marker im Nav-Button (Desktop + Mobile). Aktuell nur Grundlagen.
  */
 
 /** @type {TabItem[]} */
 export const TAB_ITEMS = [
-  { id: 'start', label: 'Start', icon: LayoutDashboard, footerNote: 'Dashboard und Orientierung', priority: 'primary', primaryAudience: 'beide' },
+  // Default-Adressat aller Tabs ohne explizites primaryAudience-Feld:
+  // Fachperson. Nur Tabs, die sich primaer an Angehoerige richten,
+  // setzen das Feld — sie erhalten zusaetzlich einen sichtbaren
+  // audienceBadge in der Nav.
+  { id: 'start', label: 'Start', icon: LayoutDashboard, footerNote: 'Dashboard und Orientierung', priority: 'primary' },
   {
     id: 'lernmodule',
     label: 'Lernmodule',
     icon: GraduationCap,
     footerNote: 'Kurzformate für Fachpraxis',
     priority: 'primary',
-    primaryAudience: 'fachpersonen',
   },
   {
     id: 'vignetten',
@@ -54,7 +61,6 @@ export const TAB_ITEMS = [
     icon: HeartHandshake,
     footerNote: 'Fallreflexion und Dialog',
     priority: 'primary',
-    primaryAudience: 'fachpersonen',
   },
   {
     id: 'glossar',
@@ -62,18 +68,14 @@ export const TAB_ITEMS = [
     icon: BookOpenText,
     footerNote: 'Begriffe, Konzepte und Sprache',
     priority: 'primary',
-    primaryAudience: 'fachpersonen',
   },
   {
     id: 'grundlagen',
     label: 'Grundlagen',
     icon: CircleHelp,
-    footerNote: 'FAQ, Einordnung und Orientierung',
+    footerNote: 'FAQ und Einordnung für Angehörige',
     priority: 'primary',
     primaryAudience: 'angehoerige',
-    // Sichtbarer Zielgruppen-Marker in der Haupt-/Mobile-Nav: Grundlagen
-    // ist der einzige Angehoerigen-Nebenpfad im sonst fachpersonenorientierten
-    // Portal (Audit-Phase-1 Audience-Cut-Strategie).
     audienceBadge: 'Für Angehörige',
   },
   {
@@ -82,7 +84,6 @@ export const TAB_ITEMS = [
     icon: Activity,
     footerNote: 'Grundlagen, Vertiefung, Materialien',
     priority: 'primary',
-    primaryAudience: 'fachpersonen',
   },
   {
     id: 'toolbox',
@@ -90,15 +91,13 @@ export const TAB_ITEMS = [
     icon: ClipboardCheck,
     footerNote: 'Triage, Schutz, nächste Schritte',
     priority: 'primary',
-    primaryAudience: 'fachpersonen',
   },
   {
     id: 'netzwerk',
     label: 'Netzwerk',
     icon: MapPin,
-    footerNote: 'Hilfen, Stellen, Weitervermittlung',
+    footerNote: 'Fachstellen und Weitervermittlung',
     priority: 'primary',
-    primaryAudience: 'beide',
   },
 ];
 

--- a/src/data/routeMeta.js
+++ b/src/data/routeMeta.js
@@ -22,9 +22,15 @@
 // Fallback sichert Dev- und Preview-Szenarien, in denen keine .env existiert.
 export const BASE_URL = import.meta.env.VITE_BASE_URL || 'https://eltern-angehoerige-fa.netlify.app';
 
-const DEFAULT_TITLE = 'Relational Recovery – Schweizer Fachportal';
+// Offizieller Website-Titel (seit Audience-Cut-Strategie Phase 2):
+// Klares Fachportal-Profil. Der frühere Projekt-/Arbeitstitel
+// "Relational Recovery" wird in Meta, SEO und sichtbarem Branding durch
+// den fachlich präzisen Titel abgelöst. Angehörige sind weiterhin
+// erreichbar, aber nicht mehr als gleichrangige Hauptzielgruppe in der
+// Portal-Selbstbeschreibung genannt.
+const DEFAULT_TITLE = 'Eltern mit psychischen Erkrankungen im Beratungskontext';
 const DEFAULT_DESCRIPTION =
-  'Psychoedukative Web-App für Angehörige und Fachpersonen mit Fokus auf Elternschaft, psychische Krise, Kindesschutz und regionale Unterstützung in Zürich und der Schweiz.';
+  'Fachportal für Orientierung, Triage und Weitervermittlung: Arbeitshilfen für Fachpersonen, die mit Familien mit psychisch belasteten Eltern arbeiten. Schwerpunkt Kanton Zürich, schweizweite Ergänzungen.';
 const DEFAULT_OG_IMAGE = `${BASE_URL}/og-image.webp`;
 
 /** @type {RouteMeta} */
@@ -39,68 +45,68 @@ export const DEFAULT_META = {
 
 export const ROUTE_META = {
   start: {
-    title: 'Relational Recovery – Orientierung für Angehörige und Fachpersonen',
+    title: 'Eltern mit psychischen Erkrankungen im Beratungskontext',
     description:
-      'Einstieg in das Fachportal mit Training, systemischer Orientierung, Krisenhilfe, Netzwerk und printfähigen Arbeitshilfen.',
-    ogTitle: 'Relational Recovery – Begleitung ist Beziehungsarbeit',
+      'Fachportal für Orientierung, Triage und Weitervermittlung: Einstieg mit Arbeitshilfen, Trainingsfällen, systemischer Einordnung und regionalen Fachstellen.',
+    ogTitle: 'Fachportal für Orientierung, Triage und Weitervermittlung',
     ogDescription:
-      'Interaktive Fachressourcen für die Begleitung von Eltern mit psychischer Belastung – mit Training, systemischer Orientierung, Krisenhilfe und Netzwerk.',
+      'Arbeitshilfen für Fachpersonen, die mit Familien mit psychisch belasteten Eltern arbeiten – Toolbox, Trainingsfälle, Wissensraum, regionale Fachstellen.',
   },
   lernmodule: {
-    title: 'Lernmodule – Relational Recovery',
+    title: 'Lernmodule – Eltern mit psychischen Erkrankungen im Beratungskontext',
     description:
-      'Kompakte Lerneinheiten zur systemischen Falllogik, Sprache und Gesprächsführung in belasteten Familiensituationen.',
-    ogTitle: 'Lernmodule für die Fachpraxis – Relational Recovery',
+      'Kompakte Lerneinheiten für Fachpersonen: Sprache, Falllogik und Gesprächsführung in der Arbeit mit belasteten Familiensystemen.',
+    ogTitle: 'Lernmodule für die Fachpraxis',
     ogDescription:
       'Schrittweise Lernbausteine für Fachpersonen: Sprache, Falllogik und Gesprächsorientierung in der Begleitung psychisch belasteter Eltern.',
   },
   vignetten: {
-    title: 'Training – Relational Recovery',
+    title: 'Training – Eltern mit psychischen Erkrankungen im Beratungskontext',
     description:
-      'Trainingsfälle zur Fallreflexion und Dialogführung in belasteten Familiensystemen, mit klinisch angelegter Entscheidungslogik.',
-    ogTitle: 'Fallvignetten für Reflexion und Dialog – Relational Recovery',
+      'Trainingsfälle für Fachpersonen: Fallreflexion und Dialogführung in belasteten Familiensystemen, mit klinisch angelegter Entscheidungslogik.',
+    ogTitle: 'Trainingsfälle für Reflexion und Dialog',
     ogDescription:
       'Typische Entscheidungssituationen aus der Fachpraxis: Belastungsdynamik, Sprache und nächste Schritte konkret üben.',
   },
   glossar: {
-    title: 'Glossar – Relational Recovery',
+    title: 'Glossar – Eltern mit psychischen Erkrankungen im Beratungskontext',
     description:
-      'Zentrale Fachbegriffe für die Arbeit mit psychisch belasteten Eltern und ihren Angehörigen, kurz und anwendungsbezogen definiert.',
+      'Zentrale Fachbegriffe für die Arbeit mit psychisch belasteten Eltern und ihren Familien, kurz und anwendungsbezogen definiert.',
     ogTitle: 'Glossar – Gemeinsame Sprache für die Fachpraxis',
     ogDescription:
       'Sprache im Kontakt, Schutz und Risiko, Versorgung und Trialog – kompakt definiert und auf typische Arbeitssituationen bezogen.',
   },
   grundlagen: {
-    title: 'Grundlagen und häufige Fragen – Relational Recovery',
+    title: 'Grundlagen – Für Angehörige',
     description:
-      'Orientierende Antworten für Angehörige: Belastung verstehen, Grenzen und Verantwortung sortieren, Zusammenarbeit mit Hilfen strukturieren.',
-    ogTitle: 'Grundlagen für Angehörige – Relational Recovery',
+      'FAQ und Einordnung für Angehörige: Belastung verstehen, Grenzen und Verantwortung sortieren, Zusammenarbeit mit Hilfen strukturieren.',
+    ogTitle: 'Grundlagen-FAQ für Angehörige',
     ogDescription:
       'Häufige Fragen in einer klaren, entlastenden Sprache: Belastung verstehen, Grenzen klären, nächste Schritte finden.',
   },
   evidenz: {
-    title: 'Evidenzbereich – Relational Recovery',
+    title: 'Evidenz – Eltern mit psychischen Erkrankungen im Beratungskontext',
     description:
       'Kuratierte Einstiegspunkte, Materialien und Referenzen für die systemische Einordnung von Belastung in Elternsystemen.',
-    ogTitle: 'Evidenz und Wissensraum – Relational Recovery',
+    ogTitle: 'Evidenz und Wissensraum',
     ogDescription:
       'Familiendynamik, Schutzfaktoren und Psychoedukation – Grundlagen, Vertiefung und Materialien für die Fachpraxis.',
   },
   toolbox: {
     title: 'Toolbox – Orientierung, Schutz und nächste Schritte',
     description:
-      'Klinische Gesprächshilfe für Belastungseinschätzung, Triage, Sicherheitsplanung und Kindesschutz – ohne Diagnosefunktion.',
-    ogTitle: 'Toolbox – Relational Recovery',
+      'Klinische Gesprächshilfe für Fachpersonen: Belastungseinschätzung, Triage, Sicherheitsplanung und Kindesschutz – ohne Diagnosefunktion.',
+    ogTitle: 'Toolbox – Arbeitshilfen für die Fachpraxis',
     ogDescription:
       'Strukturierte Einschätzung familiärer Belastung als Gesprächshilfe für Abwägung, Schutz und nächste tragfähige Schritte.',
   },
   netzwerk: {
-    title: 'Netzwerk und Fachstellen – Relational Recovery',
+    title: 'Netzwerk – Weitervermittlung, Triage, regionale Fachstellen',
     description:
-      'Regionale Fachstellen für Krise, Beratung, Entlastung und Weitervermittlung im Kanton Zürich und schweizweit, plus Arbeitskarte.',
-    ogTitle: 'Netzwerk – Relational Recovery',
+      'Fachstellenverzeichnis und Netzwerkkarte für die Arbeit mit Familien mit psychisch belasteten Eltern: Weitervermittlung, Triage, Entlastung – Kanton Zürich und schweizweite Ergänzungen.',
+    ogTitle: 'Netzwerk – Fachstellen und Weitervermittlung',
     ogDescription:
-      'Fachstellenverzeichnis und Netzwerkkarte für Triage, Entlastung und Weitervermittlung an passende Angebote.',
+      'Regionale Fachstellen für Weitervermittlung, Triage und Entlastung – Zürich-Fokus mit schweizweiten Ergänzungen.',
   },
 };
 

--- a/src/sections/NetworkSection.jsx
+++ b/src/sections/NetworkSection.jsx
@@ -69,10 +69,10 @@ export default function NetworkSection() {
   );
 
   const hero = {
-    eyebrow: 'Triage und Support',
-    title: 'Netzwerk in',
-    accent: 'Zürich und schweizweit lesen.',
-    lead: 'Die Seite verbindet zürich-zentrierte Krisenwege, Familienberatung und Kinder- und Jugendangebote mit einzelnen schweizweiten Ergänzungen. Sie können nach Fachstellen suchen oder die Netzwerkkarte nutzen.',
+    eyebrow: 'Weitervermittlung und Triage',
+    title: 'Fachstellen für',
+    accent: 'Zürich und schweizweite Ergänzungen.',
+    lead: 'Fachstellenverzeichnis und Netzwerkkarte für die Arbeit mit Familien mit psychisch belasteten Eltern: Weitervermittlung, Triage und Entlastung. Schwerpunkt Kanton Zürich, ergänzt durch ausgewählte schweizweite Angebote.',
     image: heroIllustration,
     imageAlt: 'Illustration eines Familiensystems mit Beziehungslinien und ruhiger Orientierung',
     asideTitle: 'Einordnung',

--- a/src/templates/HomeLandingTemplate.jsx
+++ b/src/templates/HomeLandingTemplate.jsx
@@ -22,10 +22,10 @@ export default function HomeLandingTemplate({ pageHeadingId }) {
       : [];
 
   const hero = {
-    eyebrow: 'Systemische Orientierung',
-    title: 'Wenn ein Elternteil',
-    accent: 'psychisch belastet ist.',
-    lead: 'Orientierung, Triage und Arbeitshilfen für Fachpersonen, die mit Familien mit psychisch belasteten Eltern arbeiten. Krisenhilfe und regionale Netzwerkstellen bleiben auch für Angehörige erreichbar.',
+    eyebrow: 'Eltern mit psychischen Erkrankungen im Beratungskontext',
+    title: 'Fachportal für',
+    accent: 'Orientierung, Triage und Weitervermittlung.',
+    lead: 'Arbeitshilfen für Fachpersonen, die mit Familien mit psychisch belasteten Eltern arbeiten – Toolbox, Trainingsfälle, Wissensraum und regionale Fachstellen.',
     audienceNote: {
       prefix: 'Sie sind Angehörige?',
       label: 'Zur Grundlagen-FAQ',


### PR DESCRIPTION
## Summary

Strategische Entscheidung aus dem Audience-Cut-Audit umgesetzt. Der Arbeitstitel "Relational Recovery" wird im sichtbaren Branding und in allen Meta-Titeln durch den offiziellen Website-Titel abgelöst:

**Offizieller Titel (Meta/Branding):** Eltern mit psychischen Erkrankungen im Beratungskontext

**Startseiten-Claim (sichtbare H1):** Fachportal für Orientierung, Triage und Weitervermittlung

## Änderungen

### 1. Offizieller Titel in Meta + Branding
- `index.html`: title, meta/OG/Twitter-Texte, Schema.org Organization
- `src/data/routeMeta.js`: DEFAULT_TITLE + DEFAULT_DESCRIPTION + alle Route-Metas
- `src/components/Header.jsx`: kompakter Brand-Title "Eltern im Beratungskontext", voller Titel im aria-label
- `src/components/Footer.jsx`: Footer-Brand, Copy, Copyright

### 2. Fachpersonen-Fokus in Meta
- Start-Meta nicht mehr "für Angehörige und Fachpersonen", sondern Fachportal
- Alle Fach-Tabs konsistent
- Grundlagen-Meta explizit "Für Angehörige"

### 3. Startseiten-Claim im Hero
- Eyebrow: offizieller Titel in voller Länge
- H1 (Title + Accent): **"Fachportal für Orientierung, Triage und Weitervermittlung."**
- Lead kompakt auf Fachpersonen ausgerichtet

### 4. primaryAudience vereinfacht
- Dreiwertigkeit (`fachpersonen`/`angehoerige`/`beide`) aufgelöst
- Default-Adressat: Fachperson (Feld entfällt bei allen Tabs ausser Grundlagen)
- Nur Grundlagen trägt `primaryAudience: 'angehoerige'` + `audienceBadge`

### 5. Netzwerk sprachlich fachlicher
- Eyebrow: "Weitervermittlung und Triage"
- Lead: Fachstellenverzeichnis für die Arbeit mit Familien, Weitervermittlung/Triage/Entlastung, Zürich-Fokus

## Was bleibt unverändert

Grundlagen bleibt in der Hauptnavigation (markierter Nebenpfad), Notfall-Layer, Toolbox-Inhalte, Evidenz-Label, Print-Footer, Routing.

## Test plan

- [x] `npm run lint` sauber
- [x] `npm run build` erfolgreich (Prerender OK, neuer Snapshot)
- [x] `qa/scripts/interaction-overlap.mjs`: 0 Overlaps
- [x] `qa/scripts/click-reachability.mjs`: 0 Failures
- [x] Live-Check Browser-Tab-Titel: Start/Netzwerk/Grundlagen alle neu
- [x] Live-Check H1 Start: "Fachportal für Orientierung, Triage und Weitervermittlung."
- [x] Live-Check Header + Footer: neue Brand-Darstellung konsistent
- [x] Grundlagen-Tab-Badge "Für Angehörige" weiterhin sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)