### PR TITLE
fix(e2e): hartkodierter chromium-pfad entfernt, selektoren repariert — 29/29 grün

### DIFF
--- a/e2e/assessment-score.spec.js
+++ b/e2e/assessment-score.spec.js
@@ -92,7 +92,9 @@ test.describe('Assessment Score', () => {
     const liveRegion = page.locator('#assessment-score-status');
     await expect(liveRegion).toContainText('Aktueller Assessment-Score: 0');
 
-    await checkboxFor(page, ITEMS[1].label).check({ force: true });
+    // Label-Click statt force:true, um React-State-Updates sicherzustellen.
+    await page.locator('label').filter({ hasText: ITEMS[1].label }).click();
+    await expect(checkboxFor(page, ITEMS[1].label)).toBeChecked();
 
     await expect(liveRegion).toContainText('Aktueller Assessment-Score: 3');
     await expect(liveRegion).toContainText('Hinweis auf vertiefte Begleitung');

--- a/e2e/navigation.spec.js
+++ b/e2e/navigation.spec.js
@@ -177,8 +177,10 @@ test.describe('Emergency Access', () => {
     await page.addInitScript(() => localStorage.clear());
     await page.goto('/');
 
-    // Verify emergency button exists with correct aria-label
-    const emergencyBtn = page.locator('.ui-header-actions button[aria-label*="Notfall"]');
+    // Verify emergency button exists with correct aria-label.
+    // Seit Audit 13/14 ist nur noch der Compact-Actions-Block sichtbar
+    // (Desktop-Nav permanent ausgeblendet).
+    const emergencyBtn = page.locator('.ui-header-compact-actions button[aria-label*="Notfall"]');
     await expect(emergencyBtn).toBeVisible();
 
     // Verify it has a click handler

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -22,10 +22,6 @@ export default defineConfig({
       name: 'chromium',
       use: {
         browserName: 'chromium',
-        channel: undefined,
-        launchOptions: {
-          executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
-        },
       },
     },
   ],


### PR DESCRIPTION
## Summary

Die gesamte E2E-Testsuite lief seit Monaten mit **29/29 Failures**. Ursache: hartkodierter Linux-CI-Pfad für Chromium-Binary in `playwright.config.js` — existiert auf macOS nicht, Playwright konnte keinen Browser starten.

### Fixes

1. **`playwright.config.js`**: `executablePath: '/opt/pw-browsers/chromium-1194/...'` entfernt. Playwright nutzt die automatisch installierte Version.

2. **`e2e/navigation.spec.js:182`**: Emergency-Button-Selektor von `.ui-header-actions` (Desktop, seit Audit 13 `display:none`) auf `.ui-header-compact-actions` umgestellt.

3. **`e2e/assessment-score.spec.js:95`**: Checkbox-Interaktion von `force:true` auf Label-Click umgestellt, um React-State-Race zu eliminieren.

### Ergebnis

**29/29 passed** (9.2s) — vorher: 29/29 failed.

## Test plan

- [x] `npm run test:e2e`: **29 passed, 0 failed**
- [x] `npm run lint`: sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)