### PR TITLE
content(lernmodule): modul 3 «die vier A — auftragsklärung im erstgespräch»

### DIFF
--- a/src/data/learningContent.js
+++ b/src/data/learningContent.js
@@ -64,6 +64,24 @@ export const E_MODULES = [
     ],
     correctQuizIdx: 1,
   },
+  {
+    // Vier-A-Modell nach Von Schlippe & Schweitzer (2009), referenziert
+    // in Stauber et al. (2018), Kap. 3.2. Empowerment-orientierte
+    // Auftragsklärung als Gesprächsgerüst für den Beziehungsaufbau mit
+    // psychisch belasteten Eltern.
+    id: 'mod3',
+    title: 'Die Vier A — Auftragsklärung im Erstgespräch',
+    duration: '4 Min.',
+    storyboard:
+      'Anlass, Anliegen, Auftrag und Abmachungen klären — ein strukturiertes Gesprächsgerüst, das psychisch belastete Eltern als Kundige ihrer Situation ernst nimmt und Selbstwirksamkeit stärkt, statt Hilflosigkeit zu vertiefen.',
+    quiz: 'Was ist das Hauptziel der Vier-A-Auftragsklärung?',
+    quizOptions: [
+      'Die Fachperson legt das Vorgehen fest',
+      'Eltern werden in Zieldefinition und Prozessgestaltung einbezogen',
+      'Der Auftrag wird durch die KESB formuliert',
+    ],
+    correctQuizIdx: 1,
+  },
 ];
 
 export const ASSESSMENT_ITEMS = [


### PR DESCRIPTION
## Summary

Neues Lernmodul (Modul 3) zum **Vier-A-Modell** nach Von Schlippe & Schweitzer (2009). Referenziert in Stauber et al. (2018), Kap. 3.2.

**Anlass → Anliegen → Auftrag → Abmachungen** als strukturiertes Gesprächsgerüst für den Beziehungsaufbau mit psychisch belasteten Eltern.

- Quiz mit 3 Optionen (korrekt: Eltern werden in Zieldefinition einbezogen)
- Empowerment-orientiert, auf Augenhöhe
- 4 Min. Dauer (konsistent mit Modul 2)

### Nebeneffekt

E_MODULE_COUNT steigt von 2 auf 3 → die konditionale Module-Stat-Karte auf der Startseite wird wieder sichtbar (Schwelle ≥ 3 aus PR #41). Hero-Stats zeigen jetzt **Module=3 + Netzwerkstellen=19**.

## Test plan

- [x] Lint + Build sauber
- [x] 3 Modultitel auf Lernmodule-Seite sichtbar ("Still-Face", "Metaphern", "Die Vier A")
- [x] Hero-Stats: Module=3, Netzwerkstellen=19
- [x] 0 Overlaps, 0 Click-Failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)