### PR TITLE
content(glossar+evidenz): 4 neue begriffe + OBSAN-prävalenz als anker

### DIFF
--- a/src/data/glossaryContent.js
+++ b/src/data/glossaryContent.js
@@ -75,6 +75,14 @@ export const GLOSSARY_GROUPS = [
         practice:
           'Wird wichtig, wenn eskalierende Situationen wieder in Beobachtung, Sprache und Beziehung übersetzt werden müssen.',
       },
+      {
+        id: 'tabuisierung',
+        term: 'Tabuisierung',
+        definition:
+          'Wenn über die psychische Erkrankung innerhalb der Familie oder gegenüber Aussenstehenden nicht gesprochen wird — oft aus Scham, Angst vor Stigmatisierung, Sorge um die Kinder oder dem Wunsch, sie zu schützen.',
+        practice:
+          'Tabuisierung isoliert Kinder, nimmt ihnen die Sprache für ihre Erlebnisse und verstärkt Schuldgefühle. Im Beratungskontext: das Schweigegebot aktiv und feinfühlig ansprechen, ohne es zu forcieren. Offenheit ist ein spezifischer Schutzfaktor.',
+      },
     ],
   },
   {
@@ -115,6 +123,22 @@ export const GLOSSARY_GROUPS = [
           'Ein stabilisierendes Element, das Belastung abfedern oder Risiken begrenzen kann, zum Beispiel eine verlässliche Bezugsperson, Tagesstruktur oder erreichbare Hilfe.',
         practice:
           'Schutzfaktoren machen Risiken nicht ungeschehen, helfen aber einzuschätzen, welche Hilfe wirklich nötig ist.',
+      },
+      {
+        id: 'resilienz',
+        term: 'Resilienz',
+        definition:
+          'Erworbene psychische Widerstandsfähigkeit, die es ermöglicht, trotz belastender Lebensumstände eine gesunde Entwicklung zu nehmen. Resilienz ist keine stabile Persönlichkeitseigenschaft, sondern variabel, kontextabhängig und durch Umweltfaktoren beeinflussbar.',
+        practice:
+          'In der Arbeit mit belasteten Familien: Schutzfaktoren systematisch erfassen und stärken, statt nur Risiken zu dokumentieren. Auch in schwierigen Konstellationen danach fragen, was trägt — nicht nur, was fehlt.',
+      },
+      {
+        id: 'kohaerenzgefuehl',
+        term: 'Kohärenzgefühl',
+        definition:
+          'Die Überzeugung, dass das Leben und die zu bewältigenden Aufgaben sinnvoll, verstehbar und handhabbar sind — auch unter schwierigen Bedingungen. Geht auf Antonovskys Salutogenese-Modell zurück.',
+        practice:
+          'Bei Kindern psychisch kranker Eltern kann ein starkes Kohärenzgefühl dazu beitragen, Belastungen besser einzuordnen und Handlungsfähigkeit zu bewahren. Förderbar durch verlässliche Strukturen, verständliche Erklärungen und erlebte Wirksamkeit.',
       },
       {
         id: 'triage',
@@ -214,6 +238,14 @@ export const GLOSSARY_GROUPS = [
           'Praktischer Begriff für den Moment, in dem Familien, Fachpersonen und Hilfesystem gleichzeitig erreichbar genug sind, um einen nächsten Schritt verbindlich zu vereinbaren.',
         practice:
           'Gerade in instabilen Verläufen lohnt es sich, dieses Zeitfenster aktiv zu nutzen statt nur lose Hinweise mitzuteilen.',
+      },
+      {
+        id: 'helferkonferenz',
+        term: 'Helferkonferenz',
+        definition:
+          'Strukturiertes Treffen der involvierten Fachpersonen rund um eine belastete Familie. Klärt Verantwortlichkeiten, Ressourcen, zeitliche Grenzen und das weitere Vorgehen.',
+        practice:
+          'Gelingensbedingungen: gegenseitige Kenntnis der Aufgabenprofile, gleichberechtigter Austausch ohne Statusgefälle, personelle Kontinuität und realistisches Zeitbudget. Frühzeitig die Fallführung klären.',
       },
     ],
   },

--- a/src/sections/EvidenceSection.jsx
+++ b/src/sections/EvidenceSection.jsx
@@ -108,8 +108,9 @@ export default function EvidenceSection({ downloadResources = [] }) {
     eyebrow: 'Evidenz und klinische Orientierung',
     title: 'Einordnen, benennen und',
     accent: 'familienorientiert handeln.',
+    lead: 'Knapp 18 % der Schweizer Bevölkerung leben gemäss OBSAN-Analysen mit einer wahrscheinlichen psychischen Störung. Wenn Betroffene Kinder haben, wird die Erkrankung zur Familienangelegenheit.',
     description:
-      'Diese Seite bündelt die fachliche Logik hinter Relational Recovery: warum Elternschaft in der Erwachsenenpsychiatrie relevant ist, wie Kinder Belastung erleben und welche Gesprächs- und Unterstützungsformen sich für die Praxis besonders bewähren.',
+      'Diese Seite bündelt die fachliche Logik dahinter: warum Elternschaft in der Erwachsenenpsychiatrie relevant ist, wie Kinder Belastung erleben und welche Gesprächs- und Unterstützungsformen sich für die Praxis besonders bewähren.',
     supportingPoints: [
       'systemischer Blick statt isolierte Symptomperspektive',
       'kindliche Entlastung durch Sprache, Struktur und verlässliche Erwachsene',


### PR DESCRIPTION
## Summary

P2-Ergänzungen aus dem Transfer-Audit.

### Glossar — 4 neue Begriffe

- **Tabuisierung** (Cluster 1) — Schweigen über die Erkrankung; isoliert Kinder, verstärkt Schuldgefühle
- **Resilienz** (Cluster 2) — Erworbene Widerstandsfähigkeit, variabel und kontextabhängig
- **Kohärenzgefühl** (Cluster 2) — Verstehbarkeit/Handhabbarkeit/Sinnhaftigkeit nach Antonovsky
- **Helferkonferenz** (Cluster 3) — Strukturiertes Fachpersonen-Treffen mit Rollen-/Zeitklärung

### Evidenz — OBSAN-Anker

Neuer \`lead\`-Prop im Hero: *«Knapp 18 % der Schweizer Bevölkerung leben gemäss OBSAN-Analysen mit einer wahrscheinlichen psychischen Störung. Wenn Betroffene Kinder haben, wird die Erkrankung zur Familienangelegenheit.»*

Verankert das Portal in der CH-Versorgungsrealität (OBSAN = Schweizerisches Gesundheitsobservatorium).

## Test plan

- [x] Lint + Build sauber
- [x] Alle 4 neuen Begriffe auf Glossar-Seite sichtbar
- [x] OBSAN im Evidenz-Hero-Lead sichtbar
- [x] 0 Overlaps, 0 Click-Failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)