### PR TITLE
content(evidenz): spezifische schutzfaktoren als evidenz-kapitel-opener

### DIFF
--- a/src/data/evidenceContent.js
+++ b/src/data/evidenceContent.js
@@ -238,6 +238,21 @@ export const CHILD_EXPERIENCE_PRACTICE_POINTS = [
 
 
 
+// Spezifische Schutzfaktoren nach Stauber et al. (2018), Kap. 2.5 — die
+// Resilienzforschung identifiziert genau diese zwei Punkte als evidenzbasiert
+// protektiv speziell für Kinder psychisch kranker Eltern (über allgemeine
+// Schutzfaktoren hinaus).
+export const SPECIFIC_PROTECTIVE_FACTORS = [
+  {
+    title: 'Krankheitswissen und Krankheitsverstehen',
+    text: 'Kinder, die eine altersgerechte Aufklärung über die Erkrankung ihres Elternteils erhalten, können die Situation besser einordnen. Wissen gibt Kontrolle, reduziert Schuldgefühle und ersetzt diffuse Ängste durch benennbare Zusammenhänge.',
+  },
+  {
+    title: 'Offener Umgang mit der Erkrankung in der Familie',
+    text: 'Wenn in einer Familie offen über die Erkrankung gesprochen werden darf, können Kinder ihre Fragen stellen, Worte für ihre Erlebnisse finden und ausserfamiliäre Unterstützung leichter annehmen. Offenheit wirkt als Gegenmittel zur Tabuisierung.',
+  },
+];
+
 export const PSYCHOEDUCATION_BENEFITS = [
   'Wissen reduziert kindliche Schuldgefühle und falsche Selbstzuschreibungen.',
   'Benennbare Zusammenhänge schaffen Orientierung und ein Gefühl von Kontrolle.',

--- a/src/sections/EvidenceSection.jsx
+++ b/src/sections/EvidenceSection.jsx
@@ -35,6 +35,7 @@ import {
   PSYCHOEDUCATION_SETTINGS,
   RELEVANCE_POINTS,
   RELEVANCE_STATS,
+  SPECIFIC_PROTECTIVE_FACTORS,
 } from '../data/evidenceContent';
 import { FACHSTELLEN, SUPPORT_OFFER_IDS } from '../data/fachstellenContent';
 import { SOURCES } from '../data/sourcesContent';
@@ -214,6 +215,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
       title: 'Mit Kindern sprechen –',
       accent: 'klar, altersgerecht und entlastend',
       paragraphs: [
+        'Zwei Faktoren gelten als besonders starke Schutzfaktoren speziell für Kinder psychisch kranker Eltern — über allgemeine Resilienzfaktoren hinaus: ein altersgerechtes Krankheitswissen und ein offener Umgang mit der Erkrankung in der Familie.',
         'Psychoedukation hilft Kindern, Verhalten und Belastung eines Elternteils besser einzuordnen. Nicht das Wissen an sich überfordert, sondern meist die Sprachlosigkeit, Unsicherheit und Fantasie ohne Erklärung.',
         'Entscheidend ist eine Haltung, die ehrlich benennt, was los ist, ohne Kinder mit Erwachseneninhalten zu überladen. Gute Gespräche reduzieren Schuldgefühle, schaffen Orientierung und stärken Beziehung.',
       ],
@@ -245,6 +247,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
         },
       ],
       cards: [
+        ...panelCards(SPECIFIC_PROTECTIVE_FACTORS),
         ...panelCards(PSYCHOEDUCATION_AGE_GROUPS),
         ...panelCards(PSYCHOEDUCATION_SETTINGS),
         ...panelCards(PSYCHOEDUCATION_DIFFICULTIES),


### PR DESCRIPTION
## Summary

P2-2 aus dem Transfer-Audit. Die Resilienzforschung identifiziert genau zwei **spezifische Schutzfaktoren** für Kinder psychisch kranker Eltern:

1. **Krankheitswissen und Krankheitsverstehen** — gibt Kindern Kontrolle, reduziert Schuldgefühle
2. **Offener Umgang mit der Erkrankung in der Familie** — Gegenmittel zur Tabuisierung

Im Evidenz-Kapitel 2 «Mit Kindern sprechen» als prominente Panel-Cards am Beginn des Card-Bereichs platziert. Einleitender Paragraph benennt sie als «besonders starke Schutzfaktoren speziell für Kinder psychisch kranker Eltern — über allgemeine Resilienzfaktoren hinaus».

## Test plan

- [x] Lint + Build sauber
- [x] Beide Schutzfaktoren-Panels auf Evidenz-Seite sichtbar
- [x] 0 Overlaps, 0 Click-Failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)