### PR TITLE
fix(deps): npm audit clean + tooling-bumps, .npmrc-workaround entfernt

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/e2e/assessment-score.spec.js
+++ b/e2e/assessment-score.spec.js
@@ -12,6 +12,18 @@ function checkboxFor(page, label) {
   return page.locator('label').filter({ hasText: label }).locator('input[type="checkbox"]');
 }
 
+// Click the visible label to toggle the visually-hidden checkbox.
+// Playwright 1.59+ refuses to dispatch `.check({force: true})` on
+// `ui-visually-hidden` inputs reliably; clicking the label is the
+// semantically correct path (matches actual user interaction).
+async function setItemChecked(page, label, desired) {
+  const cb = checkboxFor(page, label);
+  const isChecked = await cb.isChecked();
+  if (isChecked !== desired) {
+    await page.locator('label').filter({ hasText: label }).click();
+  }
+}
+
 test.describe('Assessment Score', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => localStorage.clear());
@@ -26,17 +38,17 @@ test.describe('Assessment Score', () => {
   });
 
   test('checking a single item updates the score', async ({ page }) => {
-    await checkboxFor(page, ITEMS[0].label).check({ force: true });
+    await setItemChecked(page, ITEMS[0].label, true);
 
     await expect(page.locator('.ui-toolbox-score')).toHaveText(String(ITEMS[0].val));
     await expect(page.locator('#assessment-score-status')).toContainText(`Aktueller Assessment-Score: ${ITEMS[0].val}`);
   });
 
   test('unchecking an item decreases the score', async ({ page }) => {
-    await checkboxFor(page, ITEMS[0].label).check({ force: true });
+    await setItemChecked(page, ITEMS[0].label, true);
     await expect(page.locator('.ui-toolbox-score')).toHaveText(String(ITEMS[0].val));
 
-    await checkboxFor(page, ITEMS[0].label).uncheck({ force: true });
+    await setItemChecked(page, ITEMS[0].label, false);
     await expect(page.locator('#assessment-score-status')).toContainText('Aktueller Assessment-Score: 0');
   });
 
@@ -47,24 +59,24 @@ test.describe('Assessment Score', () => {
     await expect(liveRegion).toContainText('Hinweis auf tragende Ressourcen');
 
     // Check crisis(2) → score 2, still supportive
-    await checkboxFor(page, ITEMS[0].label).check({ force: true });
+    await setItemChecked(page, ITEMS[0].label, true);
     await expect(page.locator('.ui-toolbox-score')).toHaveText('2');
     await expect(liveRegion).toContainText('Hinweis auf tragende Ressourcen');
 
     // Check backup(3) → score 5, caution
-    await checkboxFor(page, ITEMS[1].label).check({ force: true });
+    await setItemChecked(page, ITEMS[1].label, true);
     await expect(page.locator('.ui-toolbox-score')).toHaveText('5');
     await expect(liveRegion).toContainText('Hinweis auf vertiefte Begleitung');
 
     // Check shame(2) → score 7, danger
-    await checkboxFor(page, ITEMS[2].label).check({ force: true });
+    await setItemChecked(page, ITEMS[2].label, true);
     await expect(page.locator('.ui-toolbox-score')).toHaveText('7');
     await expect(liveRegion).toContainText('Hinweis auf Schutzabklärung');
   });
 
   test('checking all items gives maximum score of 10', async ({ page }) => {
     for (const item of ITEMS) {
-      await checkboxFor(page, item.label).check({ force: true });
+      await setItemChecked(page, item.label, true);
     }
 
     await expect(page.locator('.ui-toolbox-score')).toHaveText('10');
@@ -73,7 +85,7 @@ test.describe('Assessment Score', () => {
 
   test('reset button clears score and unchecks all items', async ({ page }) => {
     for (const item of ITEMS.slice(0, 2)) {
-      await checkboxFor(page, item.label).check({ force: true });
+      await setItemChecked(page, item.label, true);
     }
     await expect(page.locator('.ui-toolbox-score')).toHaveText('5');
 
@@ -102,7 +114,7 @@ test.describe('Assessment Score', () => {
 
   test('score persists across tab navigation', async ({ page }) => {
     for (const item of ITEMS.slice(0, 2)) {
-      await checkboxFor(page, item.label).check({ force: true });
+      await setItemChecked(page, item.label, true);
     }
     await expect(page.locator('.ui-toolbox-score')).toHaveText('5');
 
@@ -131,7 +143,7 @@ test.describe('Assessment Score Persistence', () => {
 
     // Check items (score = 5)
     for (const item of ITEMS.slice(0, 2)) {
-      await checkboxFor(page, item.label).check({ force: true });
+      await setItemChecked(page, item.label, true);
     }
     await expect(page.locator('.ui-toolbox-score')).toHaveText('5');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,17 +14,17 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@playwright/test": "^1.52.0",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.1.0",
         "@vitejs/plugin-react": "^5.0.2",
         "eslint": "^10.2.0",
         "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "playwright-core": "^1.59.1",
         "prettier": "^3.8.2",
         "tailwindcss": "^4.1.0",
-        "vite": "^7.1.4"
+        "vite": "^7.3.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2060,9 +2060,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2076,7 +2076,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {

--- a/package.json
+++ b/package.json
@@ -22,16 +22,16 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@playwright/test": "^1.52.0",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.1.0",
     "@vitejs/plugin-react": "^5.0.2",
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "playwright-core": "^1.59.1",
     "prettier": "^3.8.2",
     "tailwindcss": "^4.1.0",
-    "vite": "^7.1.4"
+    "vite": "^7.3.2"
   }
 }

--- a/src/context/AppStateContext.jsx
+++ b/src/context/AppStateContext.jsx
@@ -18,6 +18,15 @@ const AppStateContext = createContext(null);
 
 export { AppStateContext };
 
+// Module-scope helper so impure calls (Date.now / Math.random) live outside
+// the component render path — keeps react-hooks/purity happy.
+function generateTabInstanceId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `tab-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
 export function AppStateProvider({ children }) {
   const initialAppStateRef = useRef(null);
   if (!initialAppStateRef.current) {
@@ -39,12 +48,13 @@ export function AppStateProvider({ children }) {
   // Ref shared with App for focus management: updated by navigate() before setActiveTab
   const navigationFocusTargetRef = useRef(initialAppState.activeTab === 'start' ? 'none' : 'heading');
 
-  // Sync/persistence internals
-  const tabInstanceIdRef = useRef(
-    typeof crypto !== 'undefined' && crypto.randomUUID
-      ? crypto.randomUUID()
-      : `tab-${Date.now()}-${Math.random().toString(16).slice(2)}`
-  );
+  // Sync/persistence internals: lazy-initialized, stable across renders.
+  // The impure ID generation lives in a module-scope helper so the
+  // react-hooks/purity rule sees only a normal function call here.
+  const tabInstanceIdRef = useRef(null);
+  if (tabInstanceIdRef.current === null) {
+    tabInstanceIdRef.current = generateTabInstanceId();
+  }
   const latestAppliedTimestampRef = useRef(null);
   if (latestAppliedTimestampRef.current === null) {
     let ts = 0;


### PR DESCRIPTION
## Summary

Schliesst Issue #54. Drei minimale `package.json`-Floor-Bumps + 2 kleine Code-Anpassungen, die durch die Bumps nötig wurden.

- **vite** `^7.1.4 → ^7.3.2` (path traversal / arbitrary file read CVE)
- **@playwright/test** `^1.52.0 → ^1.59.1` (SSL bypass CVE)
- **eslint-plugin-react-hooks** `^7.0.1 → ^7.1.1` (erstmals offizieller ESLint 10 support — beseitigt den Peer-Dep-Konflikt, wegen dem `.npmrc` mit `legacy-peer-deps=true` nötig war)
- **.npmrc gelöscht** (Workaround entfällt durch react-hooks-Bump)

## Code-Anpassungen

**`src/context/AppStateContext.jsx`** — `react-hooks/purity` (neue Regel in plugin v7.1) meckerte über `Date.now()` / `Math.random()` während Render. Fix: ID-Generierung in modul-scope Helper `generateTabInstanceId()` extrahiert. Lazy-Init-Pattern via `useRef + null-guard` bleibt erhalten, ist nur sauberer.

**`e2e/assessment-score.spec.js`** — Playwright 1.59 weigert sich, `.check({ force: true })` auf `ui-visually-hidden` Checkboxen zuverlässig zu dispatchen. Fix: idempotenter Helper `setItemChecked(page, label, desired)`, der via Label-Click toggelt — semantisch korrekter (entspricht dem User-Verhalten) und bereits in einem Test als Pattern dokumentiert.

## Test plan

- [x] `npm audit` → 0 vulnerabilities
- [x] `npm install` ohne `--legacy-peer-deps` und ohne `.npmrc` läuft sauber durch
- [x] `npm run lint` → 0 errors, 0 warnings
- [x] `npm run build` → grün
- [x] `npm run test:e2e` → 29/29 grün (chromium)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)