### PR TITLE
fix(a11y): aria-hidden auf dekorative lucide-icons ergänzt

### DIFF
--- a/src/components/ui/PageHero.jsx
+++ b/src/components/ui/PageHero.jsx
@@ -8,7 +8,7 @@ function renderActionIcon(icon) {
 
   if (typeof icon === 'function') {
     const Icon = icon;
-    return <Icon size={16} />;
+    return <Icon size={16} aria-hidden="true" />;
   }
 
   if (isValidElement(icon)) {

--- a/src/sections/ToolboxSection.jsx
+++ b/src/sections/ToolboxSection.jsx
@@ -229,13 +229,13 @@ export default function ToolboxSection({
         label: 'Krisenplan herunterladen',
         ariaLabel: 'Krisenplan der Toolbox herunterladen',
         onClick: onDownloadCrisisPlan,
-        icon: <Download size={16} />,
+        icon: <Download size={16} aria-hidden="true" />,
       },
       {
         label: 'Arbeitsansicht drucken',
         ariaLabel: 'Arbeitsansicht drucken',
         onClick: onPrint,
-        icon: <Printer size={16} />,
+        icon: <Printer size={16} aria-hidden="true" />,
         variant: 'secondary',
       },
     ],
@@ -262,7 +262,7 @@ export default function ToolboxSection({
       action: {
         label: 'Assessment zurücksetzen',
         onClick: onResetAssessment,
-        icon: <RotateCcw size={16} />,
+        icon: <RotateCcw size={16} aria-hidden="true" />,
       },
     },
     itemsLabel: 'Assessment-Faktoren',
@@ -272,7 +272,7 @@ export default function ToolboxSection({
       meta: `Wert ${item.val}`,
       checked: score.checked.includes(item.id),
       onChange: () => onToggleAssessment(item.id),
-      checkIcon: <Check size={16} />,
+      checkIcon: <Check size={16} aria-hidden="true" />,
     })),
   };
 
@@ -362,14 +362,14 @@ export default function ToolboxSection({
           {
             label: 'Krisenplan herunterladen',
             onClick: onDownloadCrisisPlan,
-            icon: <Download size={16} />,
+            icon: <Download size={16} aria-hidden="true" />,
             variant: 'primary',
           },
         ],
         listCards: ACUTE_CRISIS_STEPS.map((step, index) => ({
           title: `Sofort-Schritt ${index + 1}`,
           text: step,
-          icon: <AlertTriangle size={18} />,
+          icon: <AlertTriangle size={18} aria-hidden="true" />,
           className: 'ui-toolbox-list-card--plain',
         })),
         disclosureItems: ACUTE_CRISIS_CONTACTS.map((contact) => ({
@@ -380,7 +380,7 @@ export default function ToolboxSection({
           href: contact.link,
           target: contact.link ? '_blank' : undefined,
           rel: contact.link ? 'noreferrer' : undefined,
-          actionIcon: contact.link ? <ExternalLink size={14} /> : null,
+          actionIcon: contact.link ? <ExternalLink size={14} aria-hidden="true" /> : null,
         })),
       },
       {
@@ -397,20 +397,20 @@ export default function ToolboxSection({
           {
             label: 'Krisenplan herunterladen',
             onClick: onDownloadCrisisPlan,
-            icon: <Download size={16} />,
+            icon: <Download size={16} aria-hidden="true" />,
             variant: 'primary',
           },
           {
             label: 'Druckansicht öffnen',
             onClick: onPrint,
-            icon: <Printer size={16} />,
+            icon: <Printer size={16} aria-hidden="true" />,
             variant: 'secondary',
           },
         ],
         listCards: SAFETY_PLAN_POINTS.map((item, index) => ({
           title: `Baustein ${index + 1}`,
           text: item,
-          icon: <ShieldCheck size={18} />,
+          icon: <ShieldCheck size={18} aria-hidden="true" />,
           className: 'ui-toolbox-list-card--plain',
         })),
         gridCards: SAFETY_PLAN_TEMPLATE_FIELDS.map((field) => ({
@@ -443,7 +443,7 @@ export default function ToolboxSection({
         listCards: CHILD_PROTECTION_TIPS.map((tip, index) => ({
           title: `Leitfrage ${index + 1}`,
           text: tip,
-          icon: <CheckCircle2 size={18} />,
+          icon: <CheckCircle2 size={18} aria-hidden="true" />,
           className: 'ui-toolbox-list-card--panel',
         })),
       },
@@ -464,7 +464,7 @@ export default function ToolboxSection({
         listCards: ADDICTION_TIPS.map((tip, index) => ({
           title: `Leitlinie ${index + 1}`,
           text: tip,
-          icon: <ChevronRight size={18} />,
+          icon: <ChevronRight size={18} aria-hidden="true" />,
           className: 'ui-toolbox-list-card--plain',
         })),
       },
@@ -610,7 +610,7 @@ export default function ToolboxSection({
         actionLabel: 'Vorlage herunterladen',
         ariaLabel: 'Krisenplan als Textvorlage aus der Toolbox herunterladen',
         onClick: onDownloadCrisisPlan,
-        actionIcon: <Download size={14} />,
+        actionIcon: <Download size={14} aria-hidden="true" />,
       },
       {
         kind: 'custom',
@@ -620,7 +620,7 @@ export default function ToolboxSection({
         actionLabel: 'Druckansicht öffnen',
         ariaLabel: 'Druckansicht der Toolbox-Arbeitsansicht öffnen',
         onClick: onPrint,
-        actionIcon: <Printer size={14} />,
+        actionIcon: <Printer size={14} aria-hidden="true" />,
       },
     ],
   });

--- a/src/templates/EditorialPageTemplate.jsx
+++ b/src/templates/EditorialPageTemplate.jsx
@@ -29,7 +29,7 @@ function ContentSection({ section }) {
                     rel={action.rel}
                   >
                     {action.label}
-                    {action.icon ? <action.icon size={16} /> : null}
+                    {action.icon ? <action.icon size={16} aria-hidden="true" /> : null}
                   </Button>
                 ))}
               </div>

--- a/src/templates/LearningPageTemplate.jsx
+++ b/src/templates/LearningPageTemplate.jsx
@@ -52,7 +52,7 @@ function ModuleCard({ module }) {
             {module.duration ? <span className="ui-badge">{module.duration}</span> : null}
             {module.completed ? (
               <div className="ui-badge ui-badge--soft">
-                <Check size={14} /> Bearbeitet
+                <Check size={14} aria-hidden="true" /> Bearbeitet
               </div>
             ) : null}
           </div>
@@ -65,7 +65,7 @@ function ModuleCard({ module }) {
 
         <div className="ui-card__section--push ui-card__section--panel">
           <div className="ui-note-panel__label ui-note-panel__label--with-icon">
-            <Brain size={16} /> Reflexionsfrage
+            <Brain size={16} aria-hidden="true" /> Reflexionsfrage
           </div>
           <fieldset aria-describedby={module.result ? feedbackId : undefined}>
             <legend className="learning-module-quiz__legend">{module.quiz}</legend>
@@ -92,7 +92,7 @@ function ModuleCard({ module }) {
                         .filter(Boolean)
                         .join(' ')}
                     >
-                      <Circle size={16} className="ui-choice-card__control" />
+                      <Circle size={16} className="ui-choice-card__control" aria-hidden="true" />
                       <span>{option}</span>
                     </span>
                   </label>

--- a/src/templates/NetworkPageTemplate.jsx
+++ b/src/templates/NetworkPageTemplate.jsx
@@ -60,7 +60,7 @@ function FilterToolbar({
           Fachstelle suchen
         </label>
         <div className="ui-network-search">
-          <Search className="ui-network-search__icon" size={18} />
+          <Search className="ui-network-search__icon" size={18} aria-hidden="true" />
           <input
             id="network-resource-search"
             type="text"
@@ -82,7 +82,7 @@ function FilterToolbar({
         </p>
         {(searchTerm.trim() || activeFilter !== 'all') && (
           <Button variant="secondary" className="ui-button--fit-content" onClick={onReset}>
-            <XCircle size={14} /> Suche und Filter zurücksetzen
+            <XCircle size={14} aria-hidden="true" /> Suche und Filter zurücksetzen
           </Button>
         )}
       </div>
@@ -150,7 +150,7 @@ function ResourceDirectorySection({ directory }) {
                 <p className="ui-card__copy">{resource.description}</p>
                 <div className="ui-editorial-card__action">
                   <Button href={resource.link} target="_blank" rel="noopener noreferrer" variant="subtle" aria-label={`${resource.name} – Webseite öffnen (neues Fenster)`}>
-                    Webseite öffnen <ExternalLink size={16} />
+                    Webseite öffnen <ExternalLink size={16} aria-hidden="true" />
                   </Button>
                 </div>
               </SurfaceCard>
@@ -168,7 +168,7 @@ function ResourceDirectorySection({ directory }) {
                 </p>
               </div>
               <Button type="button" onClick={onReset} variant="secondary">
-                <XCircle size={16} /> Zurücksetzen
+                <XCircle size={16} aria-hidden="true" /> Zurücksetzen
               </Button>
             </div>
           </SurfaceCard>
@@ -373,7 +373,7 @@ function NetworkMapSection({ mapping }) {
 
           <SurfaceCard as="aside" tone="default">
             <div className="ui-note-panel__label ui-note-panel__label--with-icon">
-              <MapPin size={16} /> Leitfragen für die Exploration
+              <MapPin size={16} aria-hidden="true" /> Leitfragen für die Exploration
             </div>
             <div className="ui-network-question-list">
               {questions.map((question) => (

--- a/src/templates/ToolboxPageTemplate.jsx
+++ b/src/templates/ToolboxPageTemplate.jsx
@@ -133,7 +133,7 @@ function PathwaySection({ pathway }) {
                     <>
                       <div className="ui-toolbox-step__connector" />
                       <div className="ui-toolbox-step__connector-mobile">
-                        <ChevronRight size={16} />
+                        <ChevronRight size={16} aria-hidden="true" />
                       </div>
                     </>
                   ) : null}
@@ -237,7 +237,7 @@ function TriageSection({ triage }) {
                     onClick={() => prompt.recommendation.onJump(prompt.recommendation.target)}
                   >
                     {prompt.recommendation.targetLabel}
-                    <ChevronRight size={14} />
+                    <ChevronRight size={14} aria-hidden="true" />
                   </Button>
                 </div>
               ) : null}
@@ -263,7 +263,7 @@ function TriageSection({ triage }) {
               onClick={() => triage.primaryPriority.onJump(triage.primaryPriority.target)}
             >
               {triage.primaryPriority.targetLabel}
-              <ChevronRight size={14} />
+              <ChevronRight size={14} aria-hidden="true" />
             </Button>
           </div>
         ) : null}
@@ -319,7 +319,7 @@ function PracticeBlocksSection({ practice }) {
                 onClick={() => item.onJump(item.target)}
               >
                 {item.targetLabel}
-                <ChevronRight size={14} />
+                <ChevronRight size={14} aria-hidden="true" />
               </Button>
             </SurfaceCard>
           ))}
@@ -422,7 +422,7 @@ function ClusterSection({ cluster }) {
                       {item.meta ? <p className="ui-fact-card__label ui-editorial-card__action">{item.meta}</p> : null}
                     </div>
                   </div>
-                  <span className="ui-toolbox-disclosure__toggle">+</span>
+                  <span className="ui-toolbox-disclosure__toggle" aria-hidden="true">+</span>
                 </summary>
                 <div className="ui-copy ui-toolbox-disclosure__content">
                   {Array.isArray(item.content) ? (

--- a/src/templates/VignettenPageTemplate.jsx
+++ b/src/templates/VignettenPageTemplate.jsx
@@ -146,10 +146,10 @@ function VignettenNavigationSection({ navigation }) {
               disabled={navigation.disablePrevious}
               variant="secondary"
             >
-              <ChevronLeft size={16} /> {navigation.previousLabel}
+              <ChevronLeft size={16} aria-hidden="true" /> {navigation.previousLabel}
             </Button>
             <Button type="button" onClick={navigation.onNext} disabled={navigation.disableNext} variant="primary">
-              {navigation.nextLabel} <ChevronRight size={16} />
+              {navigation.nextLabel} <ChevronRight size={16} aria-hidden="true" />
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- 30 Mikro-Edits in 7 Dateien: dekorative lucide-Icons direkt neben sichtbarem Text tragen jetzt durchgängig `aria-hidden="true"`
- Vereinheitlicht den bereits bestehenden Pattern aus `App.jsx`, `Footer.jsx`, `VignettenPageTemplate.jsx` und `PageHero.renderActionIcon`
- Verhindert doppelte Screenreader-Ankündigung („Pfeil rechts, Krisenplan herunterladen")

## Geänderte Dateien

| Datei | Edits |
|---|---|
| `src/templates/NetworkPageTemplate.jsx` | 5 |
| `src/templates/VignettenPageTemplate.jsx` | 2 |
| `src/templates/LearningPageTemplate.jsx` | 3 |
| `src/templates/ToolboxPageTemplate.jsx` | 5 (4× Chevron + `+`-Toggle) |
| `src/templates/EditorialPageTemplate.jsx` | 1 |
| `src/sections/ToolboxSection.jsx` | 14 |
| `src/components/ui/PageHero.jsx` | 1 (Funktions-Fallback) |

Reine Mikro-Hygiene — keine Logikänderung, keine neuen Dependencies, keine Style-Änderungen.

Closes #57

## Test plan

- [x] `npm run lint` → 0 Warnings
- [x] `npm run build` → grün (1722 modules, prerender ok)
- [ ] Netlify Deploy-Previews grün
- [ ] Bestehende E2E-Suite läuft weiter (kein Verhaltensunterschied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)