### PR TITLE
chore: security-headers + README-korrekturen

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Die Hilfsangebote sind bewusst **zürich-zentriert** angelegt und werden punktue
 - lokale Browser-Persistenz für Lern- und Toolzustände
 - Cross-Tab-Synchronisierung per `localStorage` und `BroadcastChannel`
 - tab-basiertes Code-Splitting für grössere Bereiche
-- Hero-Illustration als reduziertes PNG-Asset im Projekt
+- Hero-Illustration als reduziertes WebP-Asset im Projekt
 
 ## Voraussetzungen
 
@@ -44,6 +44,19 @@ Build lokal prüfen:
 
 ```bash
 npm run preview
+```
+
+E2E-Tests (Playwright):
+
+```bash
+npm run test:e2e
+```
+
+Lint und Format:
+
+```bash
+npm run lint
+npm run format
 ```
 
 ## Projektstruktur
@@ -131,14 +144,12 @@ Die Inhalte liegen nicht mehr in einem grossen Einzelmodul, sondern bereichsbezo
 ## Assets und generierte Dateien
 
 - aktive Hero-Datei:
-  `src/assets/relational-recovery-hero-v3-web.png`
-- grössere Originalversion:
-  `src/assets/relational-recovery-hero-v3.png`
+  `src/assets/relational-recovery-hero-v3-web.webp`
 - `output/` ist für generierte Zwischenstände reserviert und via `.gitignore` ausgeschlossen
 
 ## Bekannte Grenzen
 
-- Es gibt aktuell keine automatisierten Tests.
+- Die E2E-Suite (`npm run test:e2e`) deckt Navigation, Hash-Routing, Mobile-Menü, Assessment-Score und Session-Reset ab. Unit-Tests gibt es bewusst nicht — die App ist primär Daten-Rendering ohne komplexe Logik.
 - Der Fokus liegt auf statischer Fachinformation und lokaler Interaktion, nicht auf Backend-Integration.
 - Ein Teil der Lernmodul-Metadaten bleibt bewusst früh verfügbar, weil er für Fortschritt und Zustandsvalidierung benötigt wird.
 - Einige Arbeitsmaterialien werden aktuell als einfache `TXT`-Vorlagen bereitgestellt und nicht als gestaltete PDF-Dokumente.

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,21 @@
   command = "npm run build"
   publish = "dist"
 
+# Security-Header für alle Routen.
+# Hinweise:
+# - kein CSP-Header gesetzt: die App lädt zur Laufzeit keine externen Ressourcen,
+#   aber inline-Styles/SVG kommen aus React/Vite — daher würde eine strikte CSP
+#   ohne sorgfältige Prüfung Build-Output brechen. Lieber bewusst ergänzen.
+# - HSTS preload nicht aktiviert: erst sinnvoll wenn produktive Custom-Domain steht.
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "DENY"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+
 [[headers]]
   for = "/"
   [headers.values]


### PR DESCRIPTION
## Summary
- **netlify.toml**: HSTS, X-Content-Type-Options, X-Frame-Options DENY, Referrer-Policy strict-origin-when-cross-origin, Permissions-Policy (camera/microphone/geolocation/interest-cohort = none) für alle Routen ergänzt. Bewusst kein CSP gesetzt — braucht eigene sorgfältige Prüfung wegen React/Vite-inline-styles.
- **README**: `relational-recovery-hero-v3-web.png` → `.webp` korrigiert (PNG-Datei existiert nicht mehr im Repo)
- **README**: `Es gibt aktuell keine automatisierten Tests` war stale — die Playwright-Suite existiert seit längerem (29 Tests), jetzt korrekt referenziert
- **README**: dev-Sektion um `npm run test:e2e` + `npm run lint` + `npm run format` ergänzt
- **README**: Verweis auf nicht-existierende Original-PNG-Datei entfernt

## Why
Release-Vorbereitung. Beide Änderungen sind reiner Doku-/Config-Fix ohne Anwendungslogik. Kein Build- oder Verhaltens-Risiko.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean (1722 Module, identisches Output)
- [ ] Netlify Deploy-Previews grün auf allen 3 Sites
- [ ] Header-Check via `curl -I` auf einer Preview-URL nach Deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)