### PR TITLE
release: v1.0.0 — version-bump, favicon, CHANGELOG-sektion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,29 @@ Daten in `YYYY-MM-DD` (lokale Schweizer Zeit). Sprache: Deutsch (de-CH).
 
 ## [Unreleased]
 
-Stand 2026-04-19. Noch ohne Tag-Release. Vor dem ersten Release zu klären:
+Offene Punkte für nach 1.0.0:
 
-- Versionsnummer (Vorschlag: `1.0.0` als initialer öffentlicher Release)
 - Custom-Domain für die produktive Site (3 Netlify-Vorschauen aktuell parallel)
-- Optionales `package.json`-Metadaten-Set (`description`, `repository`, `homepage`, `license`, `author`)
-- Bestehender `index.html`-Verweis auf `/favicon.svg` ist tot — Datei existiert nicht im Repo
+- Optionales `package.json`-Metadaten-Set (`description`, `repository`, `homepage`, `license`, `author`) — aktuell nur Pflichtfelder
+- HSTS-`preload`-Aktivierung sobald produktive Custom-Domain steht
+- Optionale CSP-Definition (bewusst noch nicht in `netlify.toml` — braucht eigene Prüfung wegen React/Vite-Inline-Styles)
+
+## [1.0.0] — 2026-04-19
+
+Initialer öffentlicher Release. Schweizer Fachportal «Eltern im Beratungskontext»
+für Fachpersonen, die mit Familien arbeiten, in denen ein Elternteil psychisch
+erkrankt ist.
 
 ### Hinzugefügt
 
+- Brand-Favicon `public/favicon.svg` mit `EB`-Monogramm in Brand-Farben
 - Security-Header in `netlify.toml`: HSTS, X-Content-Type-Options, X-Frame-Options DENY,
   Referrer-Policy, Permissions-Policy ([#59])
 - README-Sektion zu E2E-, Lint- und Format-Befehlen ([#59])
 
 ### Geändert
 
+- `package.json`: Version 0.1.0 → 1.0.0
 - README: Hero-Asset-Referenz auf `.webp` korrigiert ([#59])
 - README: stale Aussage «keine automatisierten Tests» ersetzt durch Verweis auf Playwright-Suite ([#59])
 
@@ -29,6 +37,7 @@ Stand 2026-04-19. Noch ohne Tag-Release. Vor dem ersten Release zu klären:
 
 - A11y: dekorative `lucide-react`-Icons in Buttons/Links durchgängig mit `aria-hidden="true"`
   versehen (30 Stellen über 6 Templates und `ToolboxSection`) ([#58])
+- A11y: toter `index.html`-Verweis auf `/favicon.svg` jetzt mit echtem Asset
 
 ### Sicherheit
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relational-recovery",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Eltern im Beratungskontext">
+  <title>EB</title>
+  <rect width="64" height="64" rx="12" ry="12" fill="#2f2f28"/>
+  <text
+    x="50%"
+    y="50%"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif"
+    font-weight="800"
+    font-size="28"
+    letter-spacing="2"
+    fill="#fffaf6"
+  >EB</text>
+</svg>


### PR DESCRIPTION
## Summary
- **`package.json`**: `0.1.0` → `1.0.0` (initialer öffentlicher Release)
- **`public/favicon.svg`** (neu): Brand-Mark «EB» in den existierenden Brand-Farben (`#2f2f28` Hintergrund, `#fffaf6` Schrift) — matcht das Header-Logo exakt, schliesst den toten `/favicon.svg`-Verweis aus `index.html` (war seit Projektstart broken)
- **`CHANGELOG.md`**: `[Unreleased]` → `[1.0.0] — 2026-04-19` umbenannt, Favicon-Ergänzung dokumentiert, offene Post-1.0.0-Punkte (Custom-Domain, optionale package.json-Metadaten, HSTS-preload, CSP) separiert

## Empfehlung Favicon (zur Erinnerung)
Habe im Chat drei Optionen abgewogen — **Option 1 (eigene SVG matching brand)** gewählt, weil:
- og-image als Favicon-Quelle wäre matschig (1200×630 PNG auf 16×16)
- Verweis löschen würde etablierte Brand-Identität wegwerfen
- Eine 10-Zeilen-SVG matcht den Header-Logo-Mark exakt und skaliert verlustfrei

Falls dir das Favicon nicht gefällt: vor dem Merge einfach `public/favicon.svg` löschen + die 2 CHANGELOG-Zeilen entfernen, der Version-Bump bleibt.

## Nach dem Merge
1. Tag setzen: `git tag -a v1.0.0 -m "v1.0.0 initial release" && git push origin v1.0.0`
2. GitHub-Release aus dem Tag erstellen (CHANGELOG-Block `[1.0.0]` als Body)
3. Custom-Domain wenn vorhanden in Netlify hängen, dann `.env`-`VITE_BASE_URL` aktualisieren

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean (1722 Module, 1.00s, `dist/favicon.svg` 475 B)
- [ ] Netlify Deploy-Previews grün auf allen 3 Sites
- [ ] Browser-Tab-Favicon zeigt `EB` auf einer Preview-URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)