### PR TITLE
content(evidenz, glossar, toolbox): Band 25 Erweiterungen — gesunder Elternteil, Strategie-Trias, Patenschaften, Frühwarnzeichen

### DIFF
--- a/src/data/evidenceContent.js
+++ b/src/data/evidenceContent.js
@@ -447,6 +447,42 @@ export const CLINICAL_PRACTICE_POINTS = [
 
 
 
+// Strategie-Trias zur Aktivierung sozialer Ressourcen. Quelle: Lenz (2014),
+// referenziert in Stauber et al. (2018), Kap. 6.2. Während Netzwerkkarte
+// und Netzwerkzeichnung soziale Ressourcen sichtbar machen, beschreiben
+// diese drei Strategie-Familien, wie Ressourcen aktiv mobilisiert oder
+// neu aufgebaut werden — sie ergänzen sich, sind nicht hierarchisch.
+export const SOCIAL_RESOURCES_INTRO_POINTS = [
+  'Eine Netzwerkkarte zeigt, wer im Umfeld einer Familie da ist. Wenn Bindungs- und Kontaktbedürfnisse durch die bestehenden Kontakte nicht ausreichend abgedeckt werden, ist der nächste Schritt, soziale Ressourcen gezielt zu aktivieren.',
+  'Die drei Strategie-Familien — personenbezogen, kontextbezogen und gruppenbezogen — ergänzen sich. Welche im Vordergrund steht, hängt davon ab, ob bestehende Beziehungen mobilisiert, strukturelle Bedingungen verändert oder neue Schutzräume aufgebaut werden müssen.',
+  'Familiäre Tabuisierung und die Angst vor Stigmatisierung sind die häufigsten Hürden. Ohne Bearbeitung dieser inneren Erlaubnis bleiben auch sichtbare soziale Ressourcen ungenutzt.',
+];
+
+export const SOCIAL_RESOURCES_ACTIVATION = [
+  {
+    title: 'Personenbezogene Strategien',
+    text: 'Familienmitglieder ermutigen, auf andere Menschen im sozialen Beziehungsgefüge zuzugehen. Bei Kindern: Aktivitäten mit Freundinnen, Verwandten, Klassenkameraden oder Nachbarschaftskindern bestärken. Voraussetzung ist, dass die Familie Probleme nach aussen sichtbar machen darf — Ängste, Scham und Bedenken der Eltern und Kinder ernst nehmen und sie für die Frage sensibilisieren, wem sie was erzählen möchten.',
+  },
+  {
+    title: 'Kontextbezogene Strategien',
+    text: 'Unmittelbare Netzwerkförderung: unterstützende Interaktionen zwischen Personen oder Gruppen verbessern, Kontaktintensität verändern, strukturelle Bedingungen anpassen. Für die Arbeit mit psychisch kranken Eltern besonders zentral: ein gemeinsam erarbeiteter Krisenplan mit benannten Vertrauenspersonen sowie Patenschaften als verlässliches Beziehungsangebot ausserhalb der Kernfamilie.',
+  },
+  {
+    title: 'Gruppen-Interventionen',
+    text: 'Gruppenangebote für Kinder oder Eltern in ähnlichen Situationen schaffen einen Schutzraum, in dem Sicherheit und Zugehörigkeit erlebbar werden. Kinder können Erfahrungen austauschen, sich emotional öffnen und neue Bewältigungsmöglichkeiten kennenlernen. Eltern werden für eigene Erkrankung und Auswirkungen auf die Kinder sensibilisiert und in alters- und kindgerechter Kommunikation gestärkt.',
+  },
+];
+
+// Patenschaften als eigene kontextbezogene Intervention. Quelle: Lenz (2014),
+// referenziert in Stauber et al. (2018), Kap. 6.2. Insbesondere für isolierte
+// Familien und alleinerziehende belastete Eltern relevant. Eigenständig
+// als Panel-Block, weil Konzept und Wirkung über das hinausgehen, was
+// in der Strategie-Trias kompakt erklärt werden kann.
+export const PATENSCHAFTEN_PANEL = {
+  title: 'Patenschaften und verlässliche Drittbeziehungen',
+  text: 'Patenschaften stellen für Kinder und Jugendliche eine verlässliche und dauerhafte Beziehungserfahrung ausserhalb der Kernfamilie her. Sie entlasten die Eltern, fördern den Familienzusammenhalt und schützen die Eltern-Kind-Beziehung. Eine Patenfamilie kann den Kindern Orientierung geben, Ablenkung von der familiären Überforderung schaffen und einen Ort, an dem Gefühle ausgedrückt werden dürfen, die gegenüber dem kranken Elternteil nicht aussprechbar sind. In Krisenphasen können Pat:innen intensivere Betreuung über längere Zeit übernehmen. Besonders wichtig für isolierte Familien und alleinerziehende belastete Eltern.',
+};
+
 // Rolle des gesunden Elternteils. Quelle: Stauber et al. (2018), Kap. 7
 // (Synthese, S. 47). Eigenständiger Schwerpunkt, weil in der Beratung
 // häufig der gesunde Elternteil das Anliegen einbringt — gleichzeitig

--- a/src/data/evidenceContent.js
+++ b/src/data/evidenceContent.js
@@ -447,6 +447,36 @@ export const CLINICAL_PRACTICE_POINTS = [
 
 
 
+// Rolle des gesunden Elternteils. Quelle: Stauber et al. (2018), Kap. 7
+// (Synthese, S. 47). Eigenständiger Schwerpunkt, weil in der Beratung
+// häufig der gesunde Elternteil das Anliegen einbringt — gleichzeitig
+// neigt er zur Verharmlosung und holt sich selbst kaum Hilfe.
+export const HEALTHY_PARENT_PANELS = [
+  {
+    title: 'Bedeutende Ressource',
+    text: 'Der gesunde Elternteil ist oft die zentrale Stütze des Familiensystems: er trägt Routinen, sichert Versorgung, hält die Beziehung zum Kind und ermöglicht häufig überhaupt erst die Zusammenarbeit mit Fachpersonen. Sein Einbezug in beraterische und therapeutische Arbeit ist für alle Familien zentral.',
+  },
+  {
+    title: 'Typisches Muster: Verharmlosung',
+    text: 'Gesunde Elternteile neigen oft dazu, die Erkrankung zu umschreiben — als vorübergehend, als Reaktion auf eine besondere Belastung oder als somatische Krankheit. Diese Deutung kann kurzfristig entlasten, hält aber langfristig Hilfesuche, Krankheitsverstehen beim Kind und offene Familienkommunikation zurück.',
+  },
+  {
+    title: 'Eigene Belastung wird übersehen',
+    text: 'Trotz Bedarf und deutlicher Belastung holt sich der gesunde Elternteil meist selbst keine Hilfe — weil er „ja gesund" ist. Vielfach fehlt die Einsicht in die familiäre Problematik und in die eigene Erschöpfung. Die Dynamiken unterscheiden sich je nach Familie deutlich.',
+  },
+  {
+    title: 'Konsequenz für die Beratung',
+    text: 'Den gesunden Elternteil von Beginn an als eigenständige Person mit eigenem Belastungs- und Hilfebedarf adressieren — nicht nur als Ko-Therapeut der erkrankten Person. Das eigene Wahrnehmen der Belastung kann Voraussetzung dafür sein, die Erkrankung im Familiensystem realistisch einordnen zu können.',
+  },
+];
+
+export const HEALTHY_PARENT_PRACTICE_POINTS = [
+  'gesunden Elternteil als eigenständige Person mit eigenem Hilfebedarf adressieren, nicht nur als Co-Versorger',
+  'Tendenz zur Verharmlosung („das geht vorbei") respektvoll, aber explizit ansprechbar machen',
+  'eigene Erschöpfung und emotionale Belastung benennen — auch wenn keine Diagnose vorliegt',
+  'konkrete Hilfsangebote auch für den gesunden Elternteil aufzeigen (Angehörigenberatung, Gruppe, Entlastung)',
+];
+
 export const INTERVENTION_PROGRAM_POINTS = [
   'Familienorientierte Interventionen wirken besonders dann plausibel, wenn sie nicht nur Symptome, sondern Kommunikation, Beziehung, Alltag und soziale Ressourcen gemeinsam betrachten.',
   'Das Vortragsmaterial von Lenz verweist auf multimodale Programme wie Beardslee, CHIMPs, Kindergruppen und mentalisierungsorientierte Elternprogramme als anschlussfähige Interventionsmodelle.',

--- a/src/data/glossaryContent.js
+++ b/src/data/glossaryContent.js
@@ -247,6 +247,16 @@ export const GLOSSARY_GROUPS = [
         practice:
           'Gelingensbedingungen: gegenseitige Kenntnis der Aufgabenprofile, gleichberechtigter Austausch ohne Statusgefälle, personelle Kontinuität und realistisches Zeitbudget. Frühzeitig die Fallführung klären.',
       },
+      // Quelle: Lenz (2014), referenziert in Stauber et al. (2018), Kap. 6.2.
+      // Patenschaften als kontextbezogene Strategie zur Ressourcen-Aktivierung.
+      {
+        id: 'patenschaften',
+        term: 'Patenschaften',
+        definition:
+          'Verlässliche, dauerhafte Beziehungsangebote ausserhalb der Kernfamilie — meist über organisierte Vermittlungsstellen. Patenfamilien oder Einzelpat:innen begleiten Kinder und Jugendliche regelmässig, geben Orientierung, schaffen Ablenkung von der familiären Belastung und können in Krisenphasen intensivere Betreuung übernehmen.',
+        practice:
+          'Besonders relevant für isolierte Familien und alleinerziehende belastete Eltern. Patenschaften entlasten die Eltern, fördern den Familienzusammenhalt und schützen die Eltern-Kind-Beziehung — gerade weil sie nicht in die elterliche Rolle eingreifen, sondern ergänzend wirken. Im Kanton Zürich u.a. über Patenschafts-Vermittlungen wie «zeitundwir» oder «Patenschaft Plus» zugänglich.',
+      },
     ],
   },
 ];

--- a/src/data/toolboxContent.js
+++ b/src/data/toolboxContent.js
@@ -47,6 +47,66 @@ export const SAFETY_PLAN_POINTS = [
   'Nachsorge: Wer kümmert sich um Anschluss an Beratung oder Behandlung?',
 ];
 
+// Frühwarnzeichen für drohende Verschlechterung — als gemeinsame Sprache
+// zwischen Eltern, Kind und Fachperson. Quelle: Lenz & Brockmann (2010),
+// referenziert in Stauber et al. (2018), Kap. 6.2 (Krisenplan). Die Liste
+// ist als Anstoss für die individuelle Erarbeitung gedacht, nicht als
+// abzuhakende Checkliste — Frühwarnzeichen sind familien- und
+// erkrankungsspezifisch.
+export const EARLY_WARNING_SIGN_DOMAINS = [
+  {
+    domain: 'Schlaf und Energie',
+    examples: [
+      'deutlich weniger oder mehr Schlaf als sonst',
+      'früh erschöpft trotz wenig Aktivität',
+      'Antriebslosigkeit ab dem Morgen, schwer aus dem Bett kommen',
+    ],
+  },
+  {
+    domain: 'Stimmung und Reizbarkeit',
+    examples: [
+      'häufiger gereizt, weinerlich oder dünnhäutig',
+      'plötzliche Hoffnungslosigkeit oder Gefühl von Leere',
+      'Angst vor Alltagssituationen, die vorher unproblematisch waren',
+    ],
+  },
+  {
+    domain: 'Kontakt und Rückzug',
+    examples: [
+      'Termine werden abgesagt oder vergessen',
+      'Telefon, E-Mail oder Nachrichten bleiben unbeantwortet',
+      'Rückzug ins Schlafzimmer, weniger Kontakt mit Kindern und Partnerin oder Partner',
+    ],
+  },
+  {
+    domain: 'Versorgung und Alltag',
+    examples: [
+      'Mahlzeiten fallen aus oder werden nur noch unregelmässig zubereitet',
+      'Hygiene, Wäsche oder Haushalt bleiben über mehrere Tage liegen',
+      'Routinen mit den Kindern (Schule, Zubettgehen) werden brüchig',
+    ],
+  },
+  {
+    domain: 'Substanzen und Medikamente',
+    examples: [
+      'mehr Alkohol, Cannabis oder andere Substanzen als sonst',
+      'verordnete Medikamente werden eigenmächtig reduziert oder abgesetzt',
+      'Beschaffung von Substanzen rückt in den Vordergrund',
+    ],
+  },
+  {
+    domain: 'Gefährdungssignale',
+    examples: [
+      'Suizidgedanken werden geäussert oder angedeutet',
+      'Sätze wie „Es geht ohne mich besser" oder „Es hat keinen Sinn mehr"',
+      'Verteilen oder Weggeben persönlicher Dinge, plötzliche Abschiedsgesten',
+    ],
+  },
+];
+
+export const EARLY_WARNING_NOTE =
+  'Frühwarnzeichen sind individuell. Hilfreich ist, sie gemeinsam mit der erkrankten Person und — altersgerecht — mit dem Kind zu identifizieren und im Sicherheitsplan zu hinterlegen. Je konkreter die Zeichen benannt sind, desto eher kann früh reagiert werden, ohne dass die ganze Beziehung erst in einer Krise verhandelt werden muss.';
+
 export const SAFETY_PLAN_TEMPLATE_FIELDS = [
   {
     title: 'Warnzeichen',

--- a/src/sections/EvidenceSection.jsx
+++ b/src/sections/EvidenceSection.jsx
@@ -12,6 +12,8 @@ import {
   FAMILY_SYSTEM_PANELS,
   FAMILY_SYSTEM_POINTS,
   FAMILY_SYSTEM_PRACTICE_POINTS,
+  HEALTHY_PARENT_PANELS,
+  HEALTHY_PARENT_PRACTICE_POINTS,
   HELP_BARRIER_PANELS,
   HELP_BARRIER_POINTS,
   HELP_BARRIER_PRACTICE_POINTS,
@@ -200,11 +202,21 @@ export default function EvidenceSection({ downloadResources = [] }) {
           paragraphs: CHILD_EXPERIENCE_POINTS,
           points: CHILD_EXPERIENCE_PRACTICE_POINTS,
         },
+        {
+          label: 'Gesunder Elternteil',
+          title: 'Der gesunde Elternteil ist tragende Ressource und zugleich oft selbst belastet.',
+          paragraphs: [
+            'In vielen Familien stützt der gesunde Elternteil das System: Routinen, Versorgung, Beziehungspflege, Verbindung zu Fachpersonen. Gleichzeitig neigt er dazu, die Erkrankung zu umschreiben und sich selbst keine Hilfe zu holen — „ich bin ja gesund".',
+            'Fachlich entscheidend ist, ihn von Beginn an als eigenständige Person mit eigenem Belastungs- und Hilfebedarf zu adressieren — nicht nur als Co-Versorger der erkrankten Person.',
+          ],
+          points: HEALTHY_PARENT_PRACTICE_POINTS,
+        },
       ],
       cards: [
         ...panelCards(PARENT_EXPERIENCE_PANELS),
         ...panelCards(FAMILY_SYSTEM_PANELS),
         ...panelCards(CHILD_EXPERIENCE_PANELS),
+        ...panelCards(HEALTHY_PARENT_PANELS),
       ],
       cardColumns: 'three',
       callout: {

--- a/src/sections/EvidenceSection.jsx
+++ b/src/sections/EvidenceSection.jsx
@@ -28,6 +28,7 @@ import {
   PARENT_PRACTICE_POINTS,
   PARENT_ROLE_EVIDENCE_POINTS,
   PARENT_SELF_HELP_POINTS,
+  PATENSCHAFTEN_PANEL,
   PUK_CONTEXT_POINTS,
   PSYCHOEDUCATION_AGE_GROUPS,
   PSYCHOEDUCATION_BENEFITS,
@@ -39,6 +40,8 @@ import {
   PARENT_GUIDING_PRINCIPLE,
   RELEVANCE_POINTS,
   RELEVANCE_STATS,
+  SOCIAL_RESOURCES_ACTIVATION,
+  SOCIAL_RESOURCES_INTRO_POINTS,
   SPECIFIC_PROTECTIVE_FACTORS,
 } from '../data/evidenceContent';
 import { FACHSTELLEN, SUPPORT_OFFER_IDS } from '../data/fachstellenContent';
@@ -344,6 +347,11 @@ export default function EvidenceSection({ downloadResources = [] }) {
           paragraphs: CLINICAL_PRACTICE_POINTS,
         },
         {
+          label: 'Soziale Ressourcen aktivieren',
+          title: 'Drei Strategie-Familien, die Netzwerk- und Patenschaftsarbeit fachlich rahmen.',
+          paragraphs: SOCIAL_RESOURCES_INTRO_POINTS,
+        },
+        {
           label: 'Unterstützungslandschaft',
           title: 'Angebote gewinnen an Wirkung, wenn sie nach Funktion und Zugänglichkeit sortiert werden.',
           paragraphs: [
@@ -351,7 +359,12 @@ export default function EvidenceSection({ downloadResources = [] }) {
           ],
         },
       ],
-      cards: [...panelCards(CLINICAL_PRACTICE_PANELS), ...supportOfferCards(SUPPORT_OFFERS)],
+      cards: [
+        ...panelCards(CLINICAL_PRACTICE_PANELS),
+        ...panelCards(SOCIAL_RESOURCES_ACTIVATION),
+        ...panelCards([PATENSCHAFTEN_PANEL]),
+        ...supportOfferCards(SUPPORT_OFFERS),
+      ],
       cardColumns: 'three',
       callout: {
         text: 'Die offizielle Angehörigenberatung der PUK Zürich bleibt im Zürcher Kontext eine zentrale Anlaufstelle, besonders wenn Elternschaft, psychische Belastung und kindliche Mitbetroffenheit gemeinsam in den Blick kommen.',

--- a/src/sections/ToolboxSection.jsx
+++ b/src/sections/ToolboxSection.jsx
@@ -18,6 +18,8 @@ import {
   ADDICTION_TIPS,
   CHILD_PROTECTION_THRESHOLDS,
   CHILD_PROTECTION_TIPS,
+  EARLY_WARNING_NOTE,
+  EARLY_WARNING_SIGN_DOMAINS,
   PRACTICE_BLOCKS,
   PRACTICE_BLOCK_FILTERS,
   RIGHTS_FAQ,
@@ -392,6 +394,7 @@ export default function ToolboxSection({
         description: [
           'Ein schriftlicher Plan reduziert Entscheidungsdruck in belasteten Phasen und schafft eine gemeinsame Sprache für Warnzeichen, Kontakte und Übergaben.',
           'Besonders wichtig ist der Kinder-Schutzteil: Wer übernimmt Betreuung, Information und sichere Orte, wenn Symptome eskalieren?',
+          EARLY_WARNING_NOTE,
         ],
         actions: [
           {
@@ -412,6 +415,12 @@ export default function ToolboxSection({
           text: item,
           icon: <ShieldCheck size={18} aria-hidden="true" />,
           className: 'ui-toolbox-list-card--plain',
+        })),
+        disclosureItems: EARLY_WARNING_SIGN_DOMAINS.map((domain) => ({
+          title: `Frühwarnzeichen — ${domain.domain}`,
+          summaryAriaLabel: `Frühwarnzeichen im Bereich ${domain.domain}`,
+          icon: <AlertTriangle size={18} aria-hidden="true" />,
+          content: domain.examples,
         })),
         gridCards: SAFETY_PLAN_TEMPLATE_FIELDS.map((field) => ({
           label: 'Leitfrage',


### PR DESCRIPTION
## Zusammenfassung

Vier inhaltliche Erweiterungen aus der PDF-Analyse von Band 25 «Psychisch kranke Eltern im Beratungskontext» (Stauber/Nyffeler/Gosteli 2018), umgesetzt als drei thematisch sauber geschnittene Commits.

### AP4 — Frühwarnzeichen in der Toolbox (Commit 1: `30e6a7f`)
Sechs Bereiche (Schlaf/Energie, Stimmung/Reizbarkeit, Kontakt/Rückzug, Versorgung/Alltag, Substanzen/Medikamente, Gefährdungssignale) als collapsible Disclosures unterhalb der Krisenplan-Vorlage. Ergänzt durch einen Hinweis-Paragraphen, dass Frühwarnzeichen individuell sind und gemeinsam mit der erkrankten Person und altersgerecht mit dem Kind identifiziert werden.
**Quelle:** Lenz & Brockmann (2010), referenziert in Stauber et al. (2018), Kap. 6.2.

### AP3 — Rolle des gesunden Elternteils in Evidenz Kapitel 1 (Commit 2: `27182e7`)
Vier Panels (Bedeutende Ressource / Verharmlosung / Eigene Belastung / Konsequenz für die Beratung) plus eigene Subsection mit vier Praxispunkten in Kapitel 1 «Verstehen». Adressiert den gesunden Elternteil als tragende Ressource UND als eigenständig belastete Person — nicht nur als Co-Versorger.
**Quelle:** Stauber et al. (2018), Kap. 7 (Synthese, S. 47).

### AP1 + AP2 — Strategie-Trias und Patenschaften in Evidenz Kapitel 4 (Commit 3: `05a848b`)
- **Strategie-Trias** (personenbezogen / kontextbezogen / Gruppen-Interventionen) als drei Panels plus Subsection «Soziale Ressourcen aktivieren» — rahmt die Netzwerk- und Patenschaftsarbeit fachlich ein, wo bisher nur die Netzwerkkarte stand.
- **Patenschaften** als eigenes Panel in Kapitel 4 plus neuer Glossar-Eintrag im Cluster «Netzwerk und Koordination» — verlässliche Drittbeziehungen, besonders relevant für isolierte Familien und alleinerziehende belastete Eltern.

**Quelle:** Lenz (2014), referenziert in Stauber et al. (2018), Kap. 6.2.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — alle 1722 Module transformiert, Bundle-Sizes plausibel (Evidenz +0kb gzip, Toolbox +0kb gzip)
- [x] `npm run test:e2e` — 29 Tests grün
- [x] Inhaltsprüfung: alle vier neuen Begriffe (Patenschaft, Strategie-Familien, gesunder Elternteil, Frühwarnzeichen) erscheinen in den korrekten produzierten JS-Bundles
- [ ] Manueller Sichtprüfung in `/#evidenz` (Kapitel 1 Subsection «Gesunder Elternteil»; Kapitel 4 Subsection «Soziale Ressourcen aktivieren» + Patenschaften-Panel)
- [ ] Manueller Sichtprüfung in `/#toolbox` (Krisenplan-Cluster, neue Disclosures aufklappbar)
- [ ] Manueller Sichtprüfung in `/#glossar` (Cluster 3, neuer «Patenschaften»-Eintrag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)