### PR TITLE
fix(lernmodule): Schritt-Label-Duplikat in Aufbau-Karten entfernen

### DIFF
--- a/src/sections/ElearningSection.jsx
+++ b/src/sections/ElearningSection.jsx
@@ -48,18 +48,15 @@ export default function ElearningSection() {
       'Jedes Modul beginnt mit einer fachlichen Leitidee, führt dann durch eine kurze Einordnung und schliesst mit einer Reflexionsfrage ab.',
     steps: [
       {
-        label: 'Schritt 1',
         title: 'Leitidee erfassen',
         copy: 'Zu Beginn wird die fachliche Grundidee sichtbar gemacht, damit das Modul zuerst orientiert und nicht sofort abfragt.',
         tone: 'soft',
       },
       {
-        label: 'Schritt 2',
         title: 'Kurz einordnen',
         copy: 'Die sprachliche und systemische Störungslage bleibt in einem kompakten Format lesbar und anschlussfähig an Fallbesprechungen.',
       },
       {
-        label: 'Schritt 3',
         title: 'Reflexiv antworten',
         copy: 'Erst dann folgt eine einzelne Antwortentscheidung, die zur fachlich tragfähigeren Perspektive zurückführt.',
         tone: 'accent',


### PR DESCRIPTION
## Summary
- Visual-Audit hat aufgedeckt: Auf der Lernmodule-Seite zeigen die drei Aufbau-Karten ("Leitidee erfassen", "Kurz einordnen", "Reflexiv antworten") jeweils **zweimal** den Text "Schritt N" — einmal als auto-generierter Badge (Template), einmal als redundantes Label aus den Section-Daten.
- Fix: `label: 'Schritt N'` aus `src/sections/ElearningSection.jsx` entfernt.
- Template-Conditional (`step.label ? <p>...</p> : null`) bleibt erhalten — andere Templates wie ToolboxPageTemplate nutzen `step.label` weiterhin für semantische Phasenkürzel ("Orientieren", "Sichern", "Planen").

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [ ] Visuell: Lernmodule → Aufbau-Karten zeigen "Schritt 1" nur noch einmal
- [ ] Toolbox-Arbeitsweg-Karten unverändert (Phasenkürzel weiter sichtbar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)