### PR TITLE
fix(toolbox): doppelte CTA-Anchor-Strip oberhalb der Notfall-Banner entfernen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -128,32 +128,6 @@ export default function App() {
         Zum Inhalt springen
       </a>
 
-      {activeTab === 'toolbox' && (
-        <div className="no-print border-b border-stone-300/60 bg-white/80 px-4 py-3 shadow-[0_8px_20px_rgba(76,55,39,0.04)]">
-          <div className="mx-auto flex max-w-[86rem] flex-col gap-3 md:px-2">
-            <h2 className="text-base font-semibold text-stone-900">Orientierung, Schutz und nächste Schritte</h2>
-            <div className="flex flex-wrap gap-3">
-              <button
-                type="button"
-                onClick={handleDownloadCrisisPlan}
-                className="haptic-btn inline-flex items-center gap-2 rounded-full border border-stone-300/70 bg-white px-4 py-2.5 text-[11px] font-extrabold uppercase tracking-[0.16em] text-stone-700 shadow-[0_10px_24px_rgba(76,55,39,0.06)]"
-                aria-label="Krisenplan herunterladen"
-              >
-                Krisenplan herunterladen
-              </button>
-              <button
-                type="button"
-                onClick={handleToolboxPrint}
-                className="haptic-btn inline-flex items-center gap-2 rounded-full border border-stone-300/70 bg-white px-4 py-2.5 text-[11px] font-extrabold uppercase tracking-[0.16em] text-stone-700 shadow-[0_10px_24px_rgba(76,55,39,0.06)]"
-                aria-label="Arbeitsansicht drucken"
-              >
-                Arbeitsansicht drucken
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
       {showSafeNote && (
         <div className="relative z-[100] border-b border-[var(--border-inverse)] bg-[linear-gradient(180deg,var(--surface-inverse-top),var(--surface-inverse-bottom))] px-3 py-3 text-[var(--text-inverse)] no-print">
           <div className="mx-auto flex max-w-[86rem] flex-col items-start justify-between gap-3 px-2 md:flex-row md:items-center md:px-6">


### PR DESCRIPTION
## Summary
- Visual-Audit hat aufgedeckt: Auf der Toolbox-Seite erscheinen "Krisenplan herunterladen" und "Arbeitsansicht drucken" **dreifach** im ersten Bildschirm:
  1. App-Level-Anchor-Strip (oberhalb von Notfall-Banner und Header)
  2. Schnellzugriff-Karte (mit Eyebrow + Description)
  3. PageHero-CTAs
- Die App-Level-Strip war die optisch intrusivste Wiederholung — sie schob Notfall-Banner und Header weiter nach unten und zeigte Aktions-Buttons noch vor jeder Seitenidentität.
- Fix: nur die App-Level-Strip aus `src/App.jsx` entfernt. Aktionen bleiben über Schnellzugriff-Karte (Schritt 1 nach Notfall-Banner) und PageHero-CTAs (im Hero) vollständig zugänglich.
- Auf Mobile gewinnt die erste Viewport-Höhe damit ~120px Platz für die wirklich neuen Inhalte.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [ ] Visuell: Toolbox-Seite → keine Buttons mehr oberhalb der Notfall-Banner
- [ ] Schnellzugriff-Karte und PageHero-CTAs unverändert funktionsfähig
- [ ] Krisenplan-Download und Arbeitsansicht-Drucken aus Schnellzugriff/Hero weiterhin nutzbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)