### PR TITLE
fix(header): Notfall-Button auf Mobile/Tablet sichtbar lassen

### DIFF
--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -2859,7 +2859,27 @@
     letter-spacing: 0.12em;
   }
 
+  /* Audit: Notfall-Button bleibt auf allen Viewports sichtbar (P1-Fix).
+     Vorher per display:none ausgeblendet — Krisenzugang lag dann ausschliesslich
+     hinter dem Hamburger-Menue. Auf <=48rem reduzieren wir den Button auf
+     reines Icon (analog zur Hamburger-Beschriftung), damit Brand + Notfall +
+     Menue-Toggle auch bei 375px-Viewports nebeneinander Platz finden.
+     Die Accessibility-Beschriftung kommt aus aria-label. */
+  .ui-header-compact-actions {
+    /* Da .ui-nav--desktop ausgeblendet ist, landet compact-actions in der
+       breiten 1fr-Grid-Spalte. justify-self: end haelt die Buttons rechts. */
+    justify-self: end;
+  }
+
   .ui-header-compact-actions__emergency {
+    /* Override globale .ui-button { width: 100% } Regel weiter unten in
+       diesem Media-Query — Notfall-Button bleibt intrinsic schmal. */
+    width: auto;
+    padding-inline: 0.7rem;
+    gap: 0;
+  }
+
+  .ui-header-compact-actions__emergency-label {
     display: none;
   }
 
@@ -2889,6 +2909,19 @@
 
   .ui-nav--mobile .ui-nav__item {
     font-size: var(--font-size-xs);
+  }
+}
+
+/* Schmale Viewports (<=40rem / 640px): Brand-Titel ausblenden, damit
+   EB-Mark + Notfall-Button + Hamburger ohne Ueberlagerung Platz finden.
+   Der gesperrte Uppercase-Titel ist breiter als die Buchstabenzahl
+   suggeriert (~348px bei 16px Font + 0.18em letter-spacing) — schon bei
+   500px-Viewports kollidiert er sonst mit den compact-actions.
+   Das EB-Mark traegt die Markenwiedererkennung, der Button bleibt klickbar
+   (aria-label "...zur Startseite wechseln"). */
+@media (max-width: 40rem) {
+  .ui-brand__title {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary

- Der Notfall-Button im kompakten Header war ab Viewports <=48rem (768px) per `display: none` ausgeblendet — Krisenzugang lag dort ausschliesslich hinter dem Hamburger-Menue.
- Button bleibt jetzt auf allen Viewports sichtbar, mit Icon-only-Darstellung auf Mobile (analog zur "Menue"-Beschriftung des Hamburgers). Accessibility-Beschriftung kommt aus `aria-label`.
- Brand-Titel wird auf <=40rem (640px) ausgeblendet, damit das EB-Mark + Notfall-Button + Hamburger ohne Ueberlagerung Platz finden (Uppercase + 0.18em Letter-Spacing macht den Titel ~348px breit).
- Zwei Layout-Korrekturen fuer den Grid-Container, der durch das Audit-13-Hide der Desktop-Nav in einer 1fr-Spalte landet (`justify-self: end`, `width: auto` zum Override der globalen `.ui-button { width: 100% }`-Regel).

## Visuelle Verifikation

| Viewport | Vorher | Nachher |
|---|---|---|
| 375px (iPhone SE) | Nur Hamburger sichtbar; Notfall versteckt | EB + Notfall-Icon + Hamburger, alle klar getrennt |
| 500px | Nur Hamburger; Notfall versteckt | EB + Notfall-Icon + Hamburger |
| 768px (Tablet) | Nur Hamburger | "EB ELTERN IM BERATUNGSKONTEXT" + Notfall-Icon + Hamburger |
| 1280px (Desktop) | unveraendert | unveraendert (Notfall + Menue mit Labels) |

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` gruen (1722 Module)
- [x] Visuelle Pruefung 375 / 500 / 768 / 1280 px
- [x] Notfall-Button bleibt mit korrektem `aria-label="Sofortzugang zu Notfall- und Kriseninformationen"` zugaenglich
- [x] Hamburger-Menue funktioniert weiterhin und enthaelt zusaetzlich den Notfall-Button im Mobile-Dialog (Redundanz beibehalten)

## Hintergrund

Aus dem Design-Audit dieser Session (P1: Notfall-Button auf Tablet/Mobile sichtbar lassen). Verwandte vorherige PRs: #63 (Lernmodule Schritt-Duplikat), #64 (Toolbox CTA-Strip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)