### PR TITLE
fix(notfall-banner): Mobile-Layout verdichten — ATF-Hoehe halbiert

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -151,7 +151,52 @@ export default function App() {
       )}
 
       <div className="no-print border-b border-[var(--border-error-soft)] bg-[linear-gradient(180deg,var(--surface-error-soft),var(--surface-muted))]">
-        <div className="mx-auto flex max-w-[86rem] flex-col items-start justify-between gap-3 px-4 py-3 md:flex-row md:items-center md:px-6">
+        {/* Mobile-Variante (<md): kompakte Liste mit Label → Nummer.
+            Spart gegenüber der Desktop-Prosa ~200px ATF. Der CTA-Button
+            entfällt auf Mobile, weil das Notfall-Icon im Header (PR #65)
+            denselben Sprung in die Toolbox auslöst. */}
+        <div className="md:hidden">
+          <div className="mx-auto flex max-w-[86rem] flex-col gap-2 px-4 py-3">
+            <span className="text-[10px] font-extrabold uppercase tracking-[0.18em] text-[var(--text-danger-label)]">
+              Akute Krise
+            </span>
+            <ul className="grid gap-1 text-sm text-[var(--text-danger-strong)]">
+              <li className="flex items-center justify-between gap-3">
+                <span>Lebensgefahr</span>
+                <a
+                  href="tel:144"
+                  aria-label="Sanitätsnotruf 144 anrufen"
+                  className="emergency-tel-link font-extrabold underline decoration-2 underline-offset-2 hover:no-underline"
+                >
+                  144
+                </a>
+              </li>
+              <li className="flex items-center justify-between gap-3">
+                <span>Nicht lebensbedrohlich (ZH)</span>
+                <a
+                  href="tel:+41800336655"
+                  aria-label="AERZTEFON 0800 33 66 55 anrufen"
+                  className="emergency-tel-link whitespace-nowrap font-extrabold underline decoration-2 underline-offset-2 hover:no-underline"
+                >
+                  0800 33 66 55
+                </a>
+              </li>
+              <li className="flex items-center justify-between gap-3">
+                <span>Jugendliche</span>
+                <a
+                  href="tel:147"
+                  aria-label="Beratungstelefon 147 von Pro Juventute anrufen"
+                  className="emergency-tel-link font-extrabold underline decoration-2 underline-offset-2 hover:no-underline"
+                >
+                  147
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Desktop-Variante (md+): unveränderte Prosa-Form mit CTA. */}
+        <div className="mx-auto hidden max-w-[86rem] flex-col items-start justify-between gap-3 px-4 py-3 md:flex md:flex-row md:items-center md:px-6">
           <div className="text-sm leading-relaxed text-[var(--text-danger-strong)]">
             <span className="mr-3 text-[10px] font-extrabold uppercase tracking-[0.18em] text-[var(--text-danger-label)]">
               Akute Krise


### PR DESCRIPTION
## Summary

- Notfall-Banner verbrauchte auf Mobile (<768px) ~370-440px ATF, weil die Desktop-Prosa ueber 5-7 Zeilen umbrach und der CTA-Button darunter wickelte.
- Neue kompakte Mobile-Variante: Liste mit `Label → Tel-Link` (Lebensgefahr/144, Nicht lebensbedrohlich (ZH)/0800 33 66 55, Jugendliche/147). Banner sinkt auf ~145px (gemessen 375x812).
- CTA-Button "Zu Notfallinformationen" entfaellt auf Mobile — das Notfall-Icon im Header (PR #65) loest denselben Sprung aus.
- Desktop (md+) bleibt vollstaendig unveraendert (gleiche Prosa, gleicher CTA).

## Visuelle Verifikation

| Viewport | Banner-Hoehe vorher | Banner-Hoehe nachher |
|---|---|---|
| 375px (iPhone SE) | ~370px | **145px** (-225px) |
| 700px | ~280px | ~120px (-160px) |
| 768px+ (Tablet/Desktop) | ~80-100px | **unveraendert** |

## Erhaltene Garantien

- `emergency-tel-link`-Klasse weiterhin auf jedem Tel-Link → 44x44 Touch-Target gewaehrleistet (Audit-09 R31).
- Alle drei Notfallnummern (144, AERZTEFON 0800 33 66 55, 147) auf jedem Viewport sichtbar und einzeln tappbar.
- aria-labels auf den tel:-Links unveraendert.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` gruen
- [x] Visuelle Pruefung 375 / 500 / 700 / 768 / 1280 px
- [x] Banner-Hoehe via getBoundingClientRect verifiziert (145px @ 375px)
- [x] Tel-Links bleiben mit Schwellen-Padding 44x44 versehen

## Hintergrund

Aus dem Design-Audit dieser Session (P1: Notfall-Banner Mobile-Layout verdichten ~250px ATF). Vorherige PRs derselben Audit-Welle: #63 (Lernmodule Schritt-Duplikat), #64 (Toolbox CTA-Strip), #65 (Notfall-Button Mobile-Sichtbarkeit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)