### PR TITLE
fix(toolbox): Arbeitsweg-Karten — Schritt-Pille mit Phasenkürzel zusammenführen

### DIFF
--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -1810,18 +1810,31 @@
 .ui-toolbox-step__header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: var(--space-4);
   margin-bottom: var(--space-4);
 }
 
+/* Audit P2 #11: chip enthält jetzt sowohl die Schritt-Nummer als auch
+   das Phasen-Label ("Schritt 1 · Orientieren") statt zwei nebeneinander
+   freistehender Elemente. Vorher wirkte der separate Chip leer/disabled
+   und das Phasenwort floss frei daneben. Letter-spacing und Padding sind
+   gegenüber dem Default-Chip leicht reduziert, damit die längeren
+   Phasenworte ("Orientieren", "Kooperieren") in der Karten-Spalte ohne
+   Umbruch Platz finden. */
 .ui-toolbox-step__chip {
-  padding: 0.375rem var(--space-3);
-  font-size: 0.65rem;
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: baseline;
+  column-gap: 0.4rem;
+  row-gap: 0.125rem;
+  padding: 0.375rem 0.625rem;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
 }
 
-.ui-toolbox-step__label {
-  color: var(--text-muted);
+.ui-toolbox-step__chip-separator {
+  opacity: 0.55;
 }
 
 .ui-toolbox-step__divider {

--- a/src/templates/ToolboxPageTemplate.jsx
+++ b/src/templates/ToolboxPageTemplate.jsx
@@ -121,8 +121,11 @@ function PathwaySection({ pathway }) {
                 <div key={step.label} className="ui-toolbox-step">
                   <SurfaceCard tone="soft" className="ui-card--full-height">
                     <div className="ui-toolbox-step__header">
-                      <div className="ui-chip ui-chip--active ui-toolbox-step__chip">Schritt {index + 1}</div>
-                      <div className="ui-toolbox-kicker ui-toolbox-step__label">{step.label}</div>
+                      <div className="ui-chip ui-chip--active ui-toolbox-step__chip">
+                        <span className="ui-toolbox-step__chip-index">Schritt {index + 1}</span>
+                        <span className="ui-toolbox-step__chip-separator" aria-hidden="true">·</span>
+                        <span className="ui-toolbox-step__chip-label">{step.label}</span>
+                      </div>
                     </div>
                     <div className="ui-toolbox-step__divider" />
                     <div className="ui-toolbox-kicker ui-toolbox-step__window">Arbeitsfenster</div>


### PR DESCRIPTION
## Summary
- Audit-Befund **P2 #11**: Die kleine "Schritt N"-Pille in den vier Arbeitsweg-Karten wirkte leer/disabled, weil das eigentliche Phasenkürzel ("Orientieren", "Sichern", "Planen", "Kooperieren") als separates Element daneben floss.
- Beide Bestandteile sind jetzt in einer einzigen Pille zusammengefasst — `Schritt 1 · Orientieren` — mit dezentem Trennzeichen (Opacity 55%).
- Letter-Spacing (0.18em → 0.08em) und horizontales Padding (12px → 10px) sind nur für diese Chip-Variante reduziert, damit auch die längeren Phasenworte in der Drei-/Vier-Spalten-Grid ohne Umbruch Platz finden.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — green
- [x] Visuell auf 1440px Desktop verifiziert — alle vier Pillen einzeilig, kein Overflow gegen Karten-Header
- [x] Visuell auf 768px Tablet verifiziert — Pillen passen in Single-Column-Layout
- [x] Visuell auf 375px Mobile verifiziert — Pillen passen in Karten-Header
- [ ] Optional: Quick-Check auf Light/Dark wenn relevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)