### PR TITLE
fix(toolbox): Sucht/Komorbidität — Grid 3-spaltig erst ab 1024px

### DIFF
--- a/src/sections/ToolboxSection.jsx
+++ b/src/sections/ToolboxSection.jsx
@@ -470,6 +470,7 @@ export default function ToolboxSection({
           copy: panel.text,
           tone: 'default',
         })),
+        gridClassName: 'ui-fact-grid ui-fact-grid--prose',
         listCards: ADDICTION_TIPS.map((tip, index) => ({
           title: `Leitlinie ${index + 1}`,
           text: tip,

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -1005,6 +1005,27 @@
   grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
 }
 
+/* Audit P2 #9: Karten mit längeren Fließtext-Titeln (z. B. Sucht und
+   Komorbidität: "Psychische Erkrankung und Substanzkonsum zusammen denken")
+   wirken im Default-`auto-fit`-Grid auf Tablet bereits dreispaltig (210 px
+   pro Spalte) und damit zu eng. Diese Variante hält 2 Spalten bis 1024 px
+   und dehnt erst danach auf 3 Spalten. */
+.ui-fact-grid--prose {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 30rem) {
+  .ui-fact-grid--prose {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 64rem) {
+  .ui-fact-grid--prose {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
 .ui-fact-card {
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-xl);


### PR DESCRIPTION
## Summary
- Audit-Befund **P2 #9**: Im Cluster "Sucht und Komorbidität" rendert das Default-`auto-fit`-Grid (`minmax(12rem, 1fr)`) auf Tablet (768 px) bereits in drei Spalten von je ~210 px. Die Karten enthalten dort vergleichsweise lange Fließtext-Titel (z. B. "Psychische Erkrankung und Substanzkonsum zusammen denken") und werden in 210 px stark zerklopft.
- Neue Modifier-Klasse `.ui-fact-grid--prose`: 1 Spalte, ab 30 rem 2 Spalten, ab 64 rem (1024 px) 3 Spalten.
- Wird ausschliesslich am Sucht-Cluster via `gridClassName` gesetzt — der Default-`.ui-fact-grid` (z. B. im Cluster "Kindeswohl") bleibt unverändert.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — green
- [x] 1024 px Desktop verifiziert: 3 Spalten × 290 px
- [x] 768 px Tablet verifiziert: 2 Spalten × 323 px (deutliche Verbesserung gegenüber 3 × 210 px)
- [x] 375 px Mobile verifiziert: 1 Spalte × 285 px
- [x] Cluster "Kindeswohl" (`#child-protection`) bei 768 px geprüft: weiterhin 3 × 210 px wie vorher (kürzere Titel — funktioniert dort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)