### PR TITLE
fix(chips): .ui-chip-row Buttons auf Tablet umbrechen statt stapeln

### DIFF
--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -2941,6 +2941,15 @@
     width: 100%;
   }
 
+  /* Audit P2 #10: Innerhalb einer .ui-chip-row (Praxisblöcke-Filter,
+     Netzwerk-Filter, Closing-Tags) sollen die Chip-Buttons ihre
+     intrinsische Breite behalten, damit flex-wrap sie zu mehreren
+     pro Zeile umbrechen kann. Sonst stapeln sie sich vertikal. */
+  .ui-chip-row .ui-button,
+  .ui-chip-row .ui-chip {
+    width: auto;
+  }
+
   .ui-nav--mobile .ui-nav__item {
     font-size: var(--font-size-xs);
   }


### PR DESCRIPTION
## Summary
- Audit-Befund **P2 #10**: Praxisblöcke-Filter (sowie Netzwerk-Filter und Closing-Tags) zeigten auf Tablet (768 px) jede Filter-Pille auf eigener Zeile gestapelt statt mehrerer Pillen pro Zeile.
- Ursache: globale Mobile-Regel `.ui-button, .ui-chip { width: 100% }` im `@media (max-width: 48rem)` Block (für Mobile-Dialog-Actions / Hero-Single-Column gedacht) hat die Filter-Pillen mitgenommen.
- Fix: scoped Override `.ui-chip-row .ui-button, .ui-chip-row .ui-chip { width: auto }` direkt im selben Media-Query.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — green
- [x] 768 px Tablet: 7 Praxisblöcke-Filter brechen jetzt 5 + 2 über zwei Zeilen um (statt 7-fach gestapelt)
- [x] 375 px Mobile: Pillen brechen unregelmäßig je nach Inhaltsbreite um (`Alle + Krise` zusammen, `Elternrolle + Sucht` zusammen, etc.)
- [x] Mobile-Dialog-Actions, `.ui-button-row`, `.ui-hero__actions` bleiben unverändert (nicht innerhalb `.ui-chip-row`)

## Nebeneffekt
Der Fix wirkt automatisch auch auf Netzwerk-Filter (P2 #13) und Closing-Tags. P2 #13 bleibt aber als separates Audit-Item bestehen — dort geht es zusätzlich um Gruppenrhythmus, Sublabels und Trenner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)