### PR TITLE
fix(lernmodule): Hero-Kachel 'Bereit' statt '0%' als Empty-State

### DIFF
--- a/src/sections/ElearningSection.jsx
+++ b/src/sections/ElearningSection.jsx
@@ -10,6 +10,23 @@ export default function ElearningSection() {
   const completedCount = completedModules.length;
   const totalCount = E_MODULES.length;
   const progressPercent = totalCount ? Math.round((completedCount / totalCount) * 100) : 0;
+  const hasStartedLearning = completedCount > 0;
+
+  // Audit P2 #12: vor dem ersten bearbeiteten Modul wirkt eine "0%"-Kachel
+  // wie ein leerer Score und damit wie eine negative Erstbegegnung.
+  // Stattdessen zeigen wir bei completedCount === 0 einen ruhigen
+  // Empty-State ("Bereit") mit einladendem Hinweis statt einer Quote.
+  const progressStat = hasStartedLearning
+    ? {
+        label: 'Lernfortschritt',
+        value: `${progressPercent}%`,
+        note: `${completedCount} von ${totalCount} Modulen bearbeitet`,
+      }
+    : {
+        label: 'Lernfortschritt',
+        value: 'Bereit',
+        note: `${totalCount} Module warten auf den ersten Lernschritt.`,
+      };
 
   const hero = {
     eyebrow: 'Fachliche Kurzformate',
@@ -22,11 +39,7 @@ export default function ElearningSection() {
     asideCopy:
       'April 2026. Die Lernmodule sind als psychoedukative Orientierung und für ruhige fachliche Reflexion konzipiert, nicht als Ersatz für Supervision, Behandlung oder Krisenentscheidungen.',
     stats: [
-      {
-        label: 'Lernfortschritt',
-        value: `${progressPercent}%`,
-        note: `${completedCount} von ${totalCount} Modulen bearbeitet`,
-      },
+      progressStat,
       {
         label: 'Module',
         value: String(totalCount),


### PR DESCRIPTION
## Summary
- Audit-Befund **P2 #12**: Vor dem ersten bearbeiteten Modul zeigte die Hero-Kachel "Lernfortschritt" prominent "0%" mit Note "0 von 3 Modulen bearbeitet" — als Erstbegegnung psychologisch demotivierend.
- Bei `completedCount === 0` rendert die Kachel jetzt einen ruhigen Empty-State: Wert "Bereit", Note "N Module warten auf den ersten Lernschritt."
- Sobald das erste Modul bearbeitet ist, springt die Kachel auf die numerische Variante (`33%` / `1 von 3 Modulen bearbeitet`) zurück.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — green
- [x] Empty-State (localStorage geleert): zeigt "Bereit" / "3 Module warten auf den ersten Lernschritt."
- [x] Mit `completedModules: ['mod1']`: zeigt "33%" / "1 von 3 Modulen bearbeitet" wie vorher

🤖 Generated with [Claude Code](https://claude.com/claude-code)