### PR TITLE
fix(eyebrow): Tracking auf Mobile reduzieren — lange Eyebrows nur 2-zeilig

### DIFF
--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -2966,6 +2966,18 @@
   .ui-brand__title {
     display: none;
   }
+
+  /* Audit P3 #16: längere Eyebrows wie "Evidenz und klinische Orientierung"
+     brachen mit 0.24em Tracking + 2.5rem ::before-Markierung dreizeilig auf
+     375px-Viewports um. Tracking auf 0.14em und Marker auf 1.75rem reduziert
+     gibt genug Platz für eine zweizeilige (statt dreizeilige) Darstellung. */
+  .ui-eyebrow {
+    letter-spacing: 0.14em;
+  }
+
+  .ui-eyebrow::before {
+    width: 1.75rem;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Audit-Befund **P3 #16**: Längere Eyebrows wie "Evidenz und klinische Orientierung" (~35 Zeichen) brachen mit den Default-Werten (`letter-spacing: 0.24em` + `::before` width `2.5rem`) auf 375px-Viewports dreizeilig um.
- Innerhalb von `@media (max-width: 40rem)`:
  - `letter-spacing: 0.24em → 0.14em`
  - `.ui-eyebrow::before` width `2.5rem → 1.75rem`
- "EVIDENZ UND KLINISCHE ORIENTIERUNG" fällt jetzt sauber auf zwei Zeilen zurück. Kürzere Eyebrows zeigen weiter eine Zeile.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — green
- [x] Mobile (375 px): "Evidenz und klinische Orientierung" rendert 2 Zeilen (war 3 Zeilen).
- [x] Mobile: "Praxisfokus", "Schnellzugriff", "Klinische Orientierung", "Lernmodule" etc. weiterhin 1 Zeile.
- [x] Tablet/Desktop: unverändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)