### PR TITLE
fix(start-hero): Audience-Note visuell verankern (Audit P3 #17)

### DIFF
--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -917,9 +917,19 @@
 /* Schmaler Angehoerigen-Nebenpfad-Hinweis unter den Hero-Actions.
    Ersatz fuer die frueher zweigliedrige Audience-Row (Audit-Phase-1,
    Audience-Cut-Strategie: Fachpersonen-Fokus mit Angehoerigen als
-   markiertem Nebenpfad). */
+   markiertem Nebenpfad).
+
+   Audit P3 #17: zuvor schwebte der Hinweis bei symmetrischem Abstand
+   (24px oben und unten) zwischen Actions und Stats-Grid und wirkte
+   "visuell unverbunden". Loesung: negativer margin-top zieht den Hinweis
+   naeher zu den Actions (asymmetrischer Rhythmus = Kopplung nach oben),
+   eine schmale Akzent-Linie links verankert ihn als bewussten Nebenpfad,
+   und der Pfeil vor dem Link spiegelt das Audience-Entry-Glyph. */
 .ui-hero__audience-note {
   margin: 0;
+  margin-top: calc(var(--space-3) - var(--space-5));
+  padding-inline-start: var(--space-3);
+  border-inline-start: 2px solid var(--accent-primary-soft);
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -942,6 +952,15 @@
   text-decoration: underline;
   text-underline-offset: 0.2em;
   text-decoration-thickness: 1px;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35em;
+}
+
+.ui-hero__audience-note-link::before {
+  content: '\2192';
+  text-decoration: none;
+  font-weight: 600;
 }
 
 .ui-hero__audience-note-link:hover,


### PR DESCRIPTION
## Zusammenfassung

Audit-Befund **P3 #17**: Der `Sie sind Angehoerige? Zur Grundlagen-FAQ`-Hinweis im Start-Hero schwebte mit symmetrischen 24px Abstand (oben und unten) zwischen Actions-Block und Stats-Grid und las sich als visuell unverbundenes Element.

Drei kleine, additive CSS-Anpassungen ohne Markup-Aenderung:

- **Negativer `margin-top` (`--space-3 - --space-5 = -12px`)** zieht den Hinweis naeher an die Actions oben (12px statt 24px). Stats-Grid behaelt 24px Abstand unten. Asymmetrie koppelt den Hinweis sichtbar mit dem CTA-Block.
- **Schmale Akzentlinie links** (`2px solid var(--accent-primary-soft)`) verankert den Hinweis als bewussten Nebenpfad, ohne Karten-/Pill-Geometrie ins Hero zu bringen.
- **Leitendes `->` Pfeil-Glyph** vor dem Link spiegelt das gleiche Glyph-Pattern wie die Audience-Entries oben und liest sich als Wegweiser-Link.

Nur `src/styles/primitives.css` (+20/-1).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Desktop (1280px): gapAbove=12px, gapBelow=24px, h=21px (1 Zeile)
- [x] Mobile (375px): gapAbove=12px, gapBelow=24px, h=50px (Prefix+Link wrap), Akzentlinie sichtbar
- [x] `prefers-reduced-motion` nicht betroffen (kein Animation-Code)
- [ ] (Reviewer) Visuelle Pruefung: liest sich der Hinweis jetzt als bewusster Nebenpfad statt als schwebende Prosa?