### PR TITLE
fix(vignetten): Single-Case-Aside als Empty-State (Audit P3 #18)

### DIFF
--- a/src/sections/VignettenSection.jsx
+++ b/src/sections/VignettenSection.jsx
@@ -39,18 +39,34 @@ export default function VignettenSection() {
     ],
   };
 
+  // Audit P3 #18: 'Fall 1 von 1' liest sich als ausgereizter Zähler
+  // (alles abgearbeitet, nichts mehr da) und entwertet die einzige
+  // verfügbare Vignette unbeabsichtigt. Solange nur ein Fall existiert,
+  // zeigen wir stattdessen einen ruhigen Empty-State-Hinweis: der
+  // aktuelle Fall ist bewusst ausgewählt, weitere sind in Vorbereitung.
+  const isSingleCase = VIGNETTEN.length === 1;
+  const caseStudyAside = isSingleCase
+    ? {
+        label: 'Bestand',
+        value: 'Ausgewählter Fall',
+        copy:
+          'Aktuell steht eine vertieft ausgearbeitete Vignette zur Reflexion bereit. Weitere Fälle zu anderen Entscheidungssituationen werden schrittweise ergänzt.',
+        tone: 'soft',
+      }
+    : {
+        label: 'Status',
+        value: `Fall ${currentIndex + 1} von ${VIGNETTEN.length}`,
+        copy: 'Die Reihenfolge kann jederzeit vor und zurück durchlaufen werden.',
+        tone: 'soft',
+      };
+
   const caseStudy = {
     eyebrow: 'Fallsituation',
     titlePrefix: 'Aktueller',
     titleAccent: 'Kontext',
     description:
       'Jede Vignette verdichtet eine typische Entscheidungssituation aus Familie und Versorgungskontext. Ziel ist eine fachlich nachvollziehbare Einschätzung, nicht eine perfekte Antwort.',
-    aside: {
-      label: 'Status',
-      value: `Fall ${currentIndex + 1} von ${VIGNETTEN.length}`,
-      copy: 'Die Reihenfolge kann jederzeit vor und zurück durchlaufen werden.',
-      tone: 'soft',
-    },
+    aside: caseStudyAside,
     statusLabel: 'Fallsituation',
     title: vignette.title,
     badge: vignette.status,


### PR DESCRIPTION
## Zusammenfassung

Audit-Befund **P3 #18**: Solange nur eine Vignette existiert, las sich die Status-Aside im Aktueller-Kontext-Block als `Status / Fall 1 von 1 / Die Reihenfolge kann jederzeit vor und zurueck durchlaufen werden.` Das wirkte wie ein ausgereizter Zaehler ("alles abgearbeitet, nichts mehr da") und entwertete den einzigen verfuegbaren Fall.

Loesung analog zum P2 #12 Lernmodul-Empty-State (Conditional View-Model im Section-Layer): wenn `VIGNETTEN.length === 1`, zeigen wir einen ruhigen Empty-State-Hinweis mit reframtem Label, beschreibendem Wert und einer Copy, die weitere Faelle ankuendigt:

- **Label**: `Bestand` (statt `Status`)
- **Value**: `Ausgewählter Fall` (statt `Fall 1 von 1`)
- **Copy**: "Aktuell steht eine vertieft ausgearbeitete Vignette zur Reflexion bereit. Weitere Faelle zu anderen Entscheidungssituationen werden schrittweise ergaenzt."

Sobald eine zweite Vignette ergaenzt wird, kippt die View-Model-Logik automatisch zurueck auf die fortlaufende `Fall N von M`-Darstellung mit Navigations-Hinweis. Kein Markup-, Template- oder CSS-Eingriff.

Nur `src/sections/VignettenSection.jsx` (+22/-6).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Vignetten-Seite Desktop (1280px): neue Empty-State-Aside rendert wie erwartet
- [x] DOM-Pruefung: alter Text "Fall 1 von 1" nicht mehr in der Seite
- [x] Logik-Pfad fuer >1 Vignette unveraendert (Fallback im if-else)
- [ ] (Reviewer) Stimmt der Tonfall ("Bestand" / "Ausgewaehlter Fall") mit dem fachlichen Register?