### PR TITLE
fix(netzwerk): Filter-Chips nach Nutzer-Intent gruppieren

### DIFF
--- a/src/data/networkContent.js
+++ b/src/data/networkContent.js
@@ -1,21 +1,40 @@
 // RESOURCE_DATA wurde in Audit 12 zu FACHSTELLEN (src/data/fachstellenContent.js)
 // konsolidiert. Neue Eintraege bitte dort pflegen. Siehe docs/content-pflege.md.
 
+// Audit P2 #13: Die 13 Filter-Chips wurden zuvor flach in einer
+// einzigen Zeile gerendert, obwohl die Intro-Copy bereits eine
+// Gruppierung versprach. Wir sortieren sie nun nach User-Intent
+// (Modell A des Cluster-Vorschlags):
+//
+//   - Erreichbarkeit: wann/wie ist die Stelle ansprechbar
+//   - Lebensphase:    fuer welche Altersgruppe gedacht
+//   - Schwerpunkt:    welche Profil-/Themenmarker hat die Stelle
+//   - Rahmen:         praktische Konditionen (Region, Sprache, Kosten)
+//
+// "Alle" bleibt als separater Reset-Chip ohne Gruppe (group: null)
+// und wird im Template visuell vor den Gruppen platziert.
+export const NETWORK_FILTER_GROUPS = [
+  { id: 'erreichbarkeit', label: 'Erreichbarkeit' },
+  { id: 'lebensphase', label: 'Lebensphase' },
+  { id: 'schwerpunkt', label: 'Schwerpunkt' },
+  { id: 'rahmen', label: 'Rahmen' },
+];
+
 export const NETWORK_FILTERS = [
-  { id: 'all', label: 'Alle' },
-  { id: 'Krise', label: 'Krise' },
-  { id: '24/7', label: '24/7' },
-  { id: 'kostenlos', label: 'kostenlos' },
-  { id: 'anonym', label: 'anonym' },
-  { id: 'Zürich', label: 'Zürich' },
-  { id: 'mehrsprachig', label: 'mehrsprachig' },
-  { id: 'Jugendliche', label: 'Jugendliche' },
-  { id: 'Erwachsene', label: 'Erwachsene' },
-  { id: 'Eltern 0–5', label: 'Eltern 0–5' },
-  { id: 'Sucht', label: 'Sucht' },
-  { id: 'offizielle Stelle', label: 'offizielle Stelle' },
-  { id: 'Selbsthilfe', label: 'Selbsthilfe' },
-  { id: 'Entlastung', label: 'Entlastung' },
+  { id: 'all', label: 'Alle', group: null },
+  { id: 'Krise', label: 'Krise', group: 'erreichbarkeit' },
+  { id: '24/7', label: '24/7', group: 'erreichbarkeit' },
+  { id: 'anonym', label: 'anonym', group: 'erreichbarkeit' },
+  { id: 'Jugendliche', label: 'Jugendliche', group: 'lebensphase' },
+  { id: 'Erwachsene', label: 'Erwachsene', group: 'lebensphase' },
+  { id: 'Eltern 0–5', label: 'Eltern 0–5', group: 'lebensphase' },
+  { id: 'offizielle Stelle', label: 'offizielle Stelle', group: 'schwerpunkt' },
+  { id: 'Selbsthilfe', label: 'Selbsthilfe', group: 'schwerpunkt' },
+  { id: 'Sucht', label: 'Sucht', group: 'schwerpunkt' },
+  { id: 'Entlastung', label: 'Entlastung', group: 'schwerpunkt' },
+  { id: 'Zürich', label: 'Zürich', group: 'rahmen' },
+  { id: 'mehrsprachig', label: 'mehrsprachig', group: 'rahmen' },
+  { id: 'kostenlos', label: 'kostenlos', group: 'rahmen' },
 ];
 
 export const NETWORK_MAP_STEPS = [

--- a/src/sections/NetworkSection.jsx
+++ b/src/sections/NetworkSection.jsx
@@ -3,6 +3,7 @@ import { MapPin, Search } from 'lucide-react';
 import heroIllustration from '../assets/relational-recovery-hero-v3-web.webp';
 import {
   NETWORK_FILTERS,
+  NETWORK_FILTER_GROUPS,
   NETWORK_MAP_LENSES,
   NETWORK_MAP_QUESTIONS,
   NETWORK_MAP_STEPS,
@@ -113,6 +114,7 @@ export default function NetworkSection() {
       ],
     },
     filters: NETWORK_FILTERS,
+    filterGroups: NETWORK_FILTER_GROUPS,
     activeFilter: activeResourceFilter,
     onFilterChange: setActiveResourceFilter,
     searchTerm,

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -2436,6 +2436,38 @@
   align-items: start;
 }
 
+/* Audit P2 #13: Statt einer flachen Chip-Reihe rendern wir vier
+   gruppierte Reihen (Erreichbarkeit, Lebensphase, Schwerpunkt,
+   Rahmen) plus einen Reset-Chip ("Alle") oben. Jede Gruppe hat ein
+   kleines Eyebrow-Label und einen ruhigen Vertikalrhythmus. */
+.ui-network-filter-groups {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.ui-network-filter-reset {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.ui-network-filter-group {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.ui-network-filter-group__label {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.625rem;
+  font-weight: 800;
+  letter-spacing: 0.24em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
 .ui-network-search-label {
   font-size: 0.7rem;
   font-weight: 800;
@@ -2963,9 +2995,13 @@
   /* Audit P2 #10: Innerhalb einer .ui-chip-row (Praxisblöcke-Filter,
      Netzwerk-Filter, Closing-Tags) sollen die Chip-Buttons ihre
      intrinsische Breite behalten, damit flex-wrap sie zu mehreren
-     pro Zeile umbrechen kann. Sonst stapeln sie sich vertikal. */
+     pro Zeile umbrechen kann. Sonst stapeln sie sich vertikal.
+     Audit P2 #13: Der Netzwerk-Filter-Reset-Chip ("Alle") sitzt nicht
+     in einer .ui-chip-row, sondern in einer eigenen Wrapper-Klasse;
+     hier braucht es dieselbe Breitenkorrektur. */
   .ui-chip-row .ui-button,
-  .ui-chip-row .ui-chip {
+  .ui-chip-row .ui-chip,
+  .ui-network-filter-reset .ui-chip {
     width: auto;
   }
 

--- a/src/templates/NetworkPageTemplate.jsx
+++ b/src/templates/NetworkPageTemplate.jsx
@@ -7,8 +7,22 @@ import Section from '../components/ui/Section';
 import SectionHeader from '../components/ui/SectionHeader';
 import SurfaceCard from '../components/ui/SurfaceCard';
 
+function FilterChipButton({ filter, isActive, onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(filter.id)}
+      aria-pressed={isActive}
+      className={`ui-chip ${isActive ? 'ui-chip--active' : ''}`}
+    >
+      {filter.label}
+    </button>
+  );
+}
+
 function FilterToolbar({
   filters = [],
+  filterGroups = [],
   activeFilter,
   onFilterChange,
   searchTerm,
@@ -17,6 +31,15 @@ function FilterToolbar({
   searchStatusText,
   filterStatusText,
 }) {
+  // Audit P2 #13: Filter werden nach Gruppen gerendert (Erreichbarkeit,
+  // Lebensphase, Schwerpunkt, Rahmen) statt flach in einer Reihe.
+  // "Alle" steht als Reset-Chip vor allen Gruppen.
+  const resetFilter = filters.find((filter) => filter.group == null);
+  const groupedFilters = filterGroups.map((group) => ({
+    ...group,
+    items: filters.filter((filter) => filter.group === group.id),
+  }));
+
   return (
     <div className="ui-network-toolbar">
       <div className="ui-stack ui-stack--tight">
@@ -24,30 +47,46 @@ function FilterToolbar({
           <Eyebrow>Filter</Eyebrow>
           <div className="ui-copy">
             <p>
-              Die Filter gruppieren Krisenwege, jugendbezogene Angebote, Entlastung und offizielle Stellen, damit je
-              nach Lage schneller priorisiert werden kann.
+              Die Filter sind nach Erreichbarkeit, Lebensphase, Schwerpunkt und Rahmen gruppiert, damit je nach Lage
+              schneller priorisiert werden kann.
             </p>
           </div>
         </div>
 
         <fieldset>
           <legend className="ui-visually-hidden">Fachstellen filtern</legend>
-          <div className="ui-chip-row">
-            {filters.map((filter) => {
-              const isActive = activeFilter === filter.id;
-
-              return (
-                <button
-                  key={filter.id}
-                  type="button"
-                  onClick={() => onFilterChange(filter.id)}
-                  aria-pressed={isActive}
-                  className={`ui-chip ${isActive ? 'ui-chip--active' : ''}`}
+          <div className="ui-network-filter-groups">
+            {resetFilter ? (
+              <div className="ui-network-filter-reset">
+                <FilterChipButton
+                  filter={resetFilter}
+                  isActive={activeFilter === resetFilter.id}
+                  onClick={onFilterChange}
+                />
+              </div>
+            ) : null}
+            {groupedFilters.map((group) =>
+              group.items.length ? (
+                <div
+                  key={group.id}
+                  className="ui-network-filter-group"
+                  role="group"
+                  aria-label={`Filter: ${group.label}`}
                 >
-                  {filter.label}
-                </button>
-              );
-            })}
+                  <p className="ui-network-filter-group__label">{group.label}</p>
+                  <div className="ui-chip-row">
+                    {group.items.map((filter) => (
+                      <FilterChipButton
+                        key={filter.id}
+                        filter={filter}
+                        isActive={activeFilter === filter.id}
+                        onClick={onFilterChange}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ) : null
+            )}
           </div>
         </fieldset>
         <p className="ui-visually-hidden" role="status" aria-live="polite" aria-atomic="true">
@@ -96,6 +135,7 @@ function ResourceDirectorySection({ directory }) {
   const {
     intro,
     filters,
+    filterGroups,
     activeFilter,
     onFilterChange,
     searchTerm,
@@ -124,6 +164,7 @@ function ResourceDirectorySection({ directory }) {
 
         <FilterToolbar
           filters={filters}
+          filterGroups={filterGroups}
           activeFilter={activeFilter}
           onFilterChange={onFilterChange}
           searchTerm={searchTerm}


### PR DESCRIPTION
## Summary

Audit P2 #13 — die 13 Fachstellen-Filter wurden flach in einer Reihe gerendert, obwohl die Intro bereits eine Gruppierung versprach. In beengtem Layout war kaum erkennbar, worauf ein Chip filtert.

Cluster-Modell A (Nutzer-Intent) mit vier Gruppen:

- **Erreichbarkeit**: Krise · 24/7 · anonym
- **Lebensphase**: Jugendliche · Erwachsene · Eltern 0–5
- **Schwerpunkt**: offizielle Stelle · Selbsthilfe · Sucht · Entlastung
- **Rahmen**: Zürich · mehrsprachig · kostenlos

\"Alle\" bleibt als Reset-Chip vor den Gruppen platziert (schnelle Gesamtansicht). Sucht wandert von Lebensphase nach Schwerpunkt — es beschreibt ein Stellen-Profil, keine Zielgruppe.

## Geänderte Dateien

- `src/data/networkContent.js` — neuer `NETWORK_FILTER_GROUPS`-Export, `group`-Feld pro Filter, Reihenfolge nach Cluster
- `src/sections/NetworkSection.jsx` — Gruppen-Konfiguration ans Template durchgereicht (Hero-Stats unverändert)
- `src/templates/NetworkPageTemplate.jsx` — `FilterChipButton` ausgegliedert, FilterToolbar rendert Reset-Chip + Gruppen-Blöcke mit Eyebrow; Intro-Paragraph spricht neue Aufteilung an
- `src/styles/primitives.css` — `ui-network-filter-groups/-reset/-group/-group__label`; bestehende P2-#10-Mobile-Scoping-Regel um `.ui-network-filter-reset .ui-chip` erweitert (Reset-Chip läuft sonst auf 375 px in volle Breite)

## Verifikation

- ✅ `npm run lint` clean
- ✅ `npm run build` clean (NetworkSection 16.27 kB / gzip 5.03 kB)
- ✅ Desktop 1280 px: Reset-Chip + 4 Gruppen (3/3/4/3 Chips), Eyebrows ERREICHBARKEIT/LEBENSPHASE/SCHWERPUNKT/RAHMEN
- ✅ Klick-Interaktion: Krise → 6 Treffer, Alle → 19 Treffer, `aria-pressed` aktualisiert
- ✅ Mobile 375 px: \"Alle\" jetzt 71 px (nicht 285 px Vollbreite)

## Test plan

- [ ] Visuell prüfen: Gruppen-Eyebrows lesbar, Chips wrappen sauber
- [ ] Filter-Klicks lösen Resource-Filter wie zuvor aus
- [ ] Suche + Filter-Kombination weiterhin funktional
- [ ] Mobile (375 px): \"Alle\"-Chip kompakt, nicht volle Zeilenbreite

🤖 Generated with [Claude Code](https://claude.com/claude-code)