### PR TITLE
fix(toolbox): externe Krisenkontakt-Links mit noopener absichern

### DIFF
--- a/src/sections/ToolboxSection.jsx
+++ b/src/sections/ToolboxSection.jsx
@@ -381,7 +381,7 @@ export default function ToolboxSection({
           actionLabel: contact.link ? 'Kontakt öffnen' : null,
           href: contact.link,
           target: contact.link ? '_blank' : undefined,
-          rel: contact.link ? 'noreferrer' : undefined,
+          rel: contact.link ? 'noopener noreferrer' : undefined,
           actionIcon: contact.link ? <ExternalLink size={14} aria-hidden="true" /> : null,
         })),
       },


### PR DESCRIPTION
## Summary

Live-Audit-Befund A1: Die fünf externen Krisenkontakt-Links auf `#toolbox` (PUK Kinder/Jugend, PUK Erwachsene, Aerztefon, 143, 147) hatten `rel=\"noreferrer\"` ohne `noopener` — damit fehlte der Tabnabbing-Schutz, den die in CLAUDE.md festgelegte Konvention (\"Alle externen Links: `target=\"_blank\" rel=\"noopener noreferrer\"`\") vorschreibt.

Andere Stellen (`NetworkPageTemplate`, `ClosingSection`) waren bereits korrekt — der Verstoss war isoliert auf `src/sections/ToolboxSection.jsx:384`.

## Diff

\`\`\`diff
-          rel: contact.link ? 'noreferrer' : undefined,
+          rel: contact.link ? 'noopener noreferrer' : undefined,
\`\`\`

## Verifikation

- ✅ \`npm run lint\` clean
- ✅ \`npm run build\` clean (ToolboxSection 33.32 kB / gzip 8.83 kB)
- ✅ Grep-Verifikation: nach dem Fix kein \`'noreferrer'\` mehr ohne \`noopener\` im Source

## Test plan

- [ ] PR-Vorschau: Krisenkontakt-Karte öffnen, einen externen Link klicken — öffnet in neuem Tab, behält Tabnabbing-Schutz

🤖 Generated with [Claude Code](https://claude.com/claude-code)