### PR TITLE
fix(ui): SectionHeader rendert title als Prefix wenn titleAccent gesetzt

### DIFF
--- a/src/components/ui/SectionHeader.jsx
+++ b/src/components/ui/SectionHeader.jsx
@@ -44,18 +44,25 @@ export default function SectionHeader({
     );
   }
 
+  // Audit A2: Bisher wurde `title` stillschweigend verworfen, sobald `titleAccent`
+  // gesetzt war (ohne `titlePrefix`). Das hinterliess fragmentarische H2 wie
+  // "passende Unterstützung." -- schlecht für Screenreader-Outline und SEO.
+  // Neue Regel:
+  //   - `titlePrefix` (falls gesetzt) wird wörtlich als Prefix verwendet
+  //   - sonst dient `title` als Prefix, sobald ein Accent existiert
+  //   - ohne Accent bleibt `title` der einzige, vollständige H2-Text
+  const prefix = titlePrefix ?? (titleAccent ? title : null);
+  const standalone = !titleAccent && !titlePrefix ? title : null;
+
   return (
     <div className="ui-split">
       <div className="ui-stack ui-stack--tight">
         {eyebrow ? <Eyebrow>{eyebrow}</Eyebrow> : null}
         {hasTitle ? (
           <HeadingTag className={headingClassName}>
-            {titlePrefix ? <>{titlePrefix} </> : null}
-            {titleAccent ? (
-              <span className="ui-hero__accent">{titleAccent}</span>
-            ) : !titlePrefix ? (
-              title
-            ) : null}
+            {prefix ? <>{prefix} </> : null}
+            {standalone ? standalone : null}
+            {titleAccent ? <span className="ui-hero__accent">{titleAccent}</span> : null}
           </HeadingTag>
         ) : null}
         <RichCopy description={description} paragraphs={paragraphs} />


### PR DESCRIPTION
## Summary
- Audit-Finding A2: SectionHeader hat den `title`-Wert stillschweigend verworfen, wenn `titleAccent` ohne expliziten `titlePrefix` gesetzt war
- Folge: fragmentarische H2 wie *"passende Unterstützung."* oder *"lesbare Versorgungslage."* (Screenreader-Outline und SEO-Hierarchie unvollständig)
- Neue Regel: `title` dient automatisch als Prefix, sobald `titleAccent` existiert und kein expliziter `titlePrefix` gesetzt ist; bestehende `titlePrefix`+`titleAccent`-Aufrufer (Toolbox-Cluster, Vignetten) bleiben unverändert

## Betroffene Aufrufer (alle bereits semantisch korrekt strukturiert)
- `NetworkPageTemplate` (Directory-Intro, Mapping-Intro)
- `EvidencePageTemplate` (Chapter-Overview, Materials-Intro)
- `ClosingSection`

## Verifikation
- npm run lint clean
- npm run build clean
- Programmatischer DOM-Recheck über alle 8 Seiten: alle H2 sind jetzt vollständige Sätze (z. B. *"Schneller in die passende Unterstützung."*, *"Warum das Thema früh in die Behandlung gehört"*)

## Test plan
- [ ] Visuelle Stichprobe Netzwerk-Seite (Directory + Karte): vollständige H2 mit Prefix in Standardschrift + Accent in Hervorhebung
- [ ] Visuelle Stichprobe Evidenz-Zonen 1–4: alle Kapitel-Überschriften vollständig
- [ ] Toolbox-Cluster (`titlePrefix`+`titleAccent`) unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)