### PR TITLE
fix(vignetten): doppelten Fallsituation-Label aus Card entfernen

### DIFF
--- a/src/sections/VignettenSection.jsx
+++ b/src/sections/VignettenSection.jsx
@@ -60,6 +60,12 @@ export default function VignettenSection() {
         tone: 'soft',
       };
 
+  // Audit A3: `statusLabel: 'Fallsituation'` wiederholte den Eyebrow der
+  // umgebenden Section eins zu eins -- im DOM standen zwei identische Labels
+  // direkt untereinander. Der Eyebrow setzt den Kontext bereits, im Card
+  // genuegen Titel + Badge (z. B. "Aufnahme / Woche 1"). Das Template
+  // rendert `statusLabel` weiterhin konditional -- spaetere Vignetten
+  // koennten es fuer abweichende Subkontexte re-aktivieren.
   const caseStudy = {
     eyebrow: 'Fallsituation',
     titlePrefix: 'Aktueller',
@@ -67,7 +73,6 @@ export default function VignettenSection() {
     description:
       'Jede Vignette verdichtet eine typische Entscheidungssituation aus Familie und Versorgungskontext. Ziel ist eine fachlich nachvollziehbare Einschätzung, nicht eine perfekte Antwort.',
     aside: caseStudyAside,
-    statusLabel: 'Fallsituation',
     title: vignette.title,
     badge: vignette.status,
     body: vignette.description,


### PR DESCRIPTION
## Summary
- Audit-Finding A3: Auf der Vignetten-Seite stand "Fallsituation" zweimal direkt untereinander -- als Eyebrow der Section und nochmals als `statusLabel` im Card-Header
- Fix: `statusLabel` aus den Daten in `VignettenSection.jsx` entfernt; Eyebrow setzt den Kontext bereits
- Card zeigt jetzt sauber: H3-Titel + Badge ("Aufnahme / Woche 1")

## Verifikation
- npm run lint clean
- npm run build clean
- DOM-Recheck: nur noch ein "Fallsituation"-Treffer (im Eyebrow); Card-Header rendert `<h3>Fall 1: ...</h3><span>Aufnahme / Woche 1</span>`

## Hinweis
Das Template (`VignettenPageTemplate.jsx`) rendert `statusLabel` weiterhin konditional -- spaetere Vignetten koennten es fuer einen abweichenden Subkontext (nicht "Fallsituation") wieder setzen.

## Test plan
- [ ] Visuelle Stichprobe Vignetten-Seite: nur ein "Fallsituation"-Label, Card-Header sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)