### PR TITLE
fix(toolbox): ScoreBandsSection bekommt H2-Titel und nutzt SectionHeader

### DIFF
--- a/src/sections/ToolboxSection.jsx
+++ b/src/sections/ToolboxSection.jsx
@@ -289,8 +289,14 @@ export default function ToolboxSection({
     steps: PATHWAY_STEPS,
   };
 
+  // Audit A4: ScoreBandsSection rendert(e) eine kopflose Section -- nur
+  // Eyebrow, kein H2. Das bricht den Heading-Rhythmus der Toolbox (alle
+  // Geschwister-Sektionen haben H2 ueber SectionHeader). Wir ergaenzen
+  // titlePrefix/titleAccent und stellen das Template auf SectionHeader um.
   const scoreBandSection = {
     eyebrow: 'Einordnung',
+    titlePrefix: 'Score-Werte als',
+    titleAccent: 'Aufmerksamkeitsmarker lesen',
     description:
       'Die Werte markieren keine Diagnose. Sie helfen lediglich dabei, die Aufmerksamkeit zwischen tragenden Ressourcen, vertiefter Begleitung und möglichem Schutzbedarf zu gewichten.',
     items: SCORE_BANDS,

--- a/src/templates/ToolboxPageTemplate.jsx
+++ b/src/templates/ToolboxPageTemplate.jsx
@@ -158,15 +158,20 @@ function PathwaySection({ pathway }) {
 function ScoreBandsSection({ scoreBands }) {
   if (!scoreBands) return null;
 
+  // Audit A4: Section hatte vorher keinen H2 -- nur Eyebrow + Description als
+  // ad-hoc Stack. Auf SectionHeader umgestellt, damit der Heading-Rhythmus
+  // der Toolbox geschlossen ist. Das Interpretations-Aside bleibt bewusst
+  // im Band-Layout unten neben den Score-Karten -- seine Position dort
+  // gehoert inhaltlich zu den Bands (Lese-Schluessel direkt am Schluessel).
   return (
     <Section spacing="tight" surface="subtle" className="no-print">
       <div className="ui-stack ui-stack--loose">
-        <div className="ui-stack ui-stack--tight">
-          <Eyebrow>{scoreBands.eyebrow}</Eyebrow>
-          <div className="ui-copy">
-            <p>{scoreBands.description}</p>
-          </div>
-        </div>
+        <SectionHeader
+          eyebrow={scoreBands.eyebrow}
+          titlePrefix={scoreBands.titlePrefix}
+          titleAccent={scoreBands.titleAccent}
+          description={scoreBands.description}
+        />
 
         <div className="ui-toolbox-band-layout">
           <div className="ui-card-grid ui-card-grid--3">


### PR DESCRIPTION
## Summary
- Audit-Finding A4: ScoreBandsSection war die einzige Toolbox-Sektion ohne H2 -- nur Eyebrow "Einordnung" + Description als Ad-hoc-Stack
- Heading-Rhythmus der Toolbox war damit gebrochen (alle Geschwister-Sektionen Pathway/Triage/Practice nutzen SectionHeader mit H2)
- Fix: titlePrefix "Score-Werte als" + titleAccent "Aufmerksamkeitsmarker lesen" ergaenzt; Template auf SectionHeader umgestellt

## Begruendung der Wortwahl
Die Description sagt: *"Die Werte markieren keine Diagnose. Sie helfen lediglich dabei, die Aufmerksamkeit ... zu gewichten."* Der H2 nimmt das auf: *"Score-Werte als Aufmerksamkeitsmarker lesen"* -- praezise, nicht redundant zum Eyebrow.

## Layout-Detail
Das Interpretations-Aside bleibt bewusst im Band-Layout unten neben den Score-Karten -- seine Position dort gehoert inhaltlich zu den Bands (Lese-Schluessel direkt am Schluessel). Es wandert NICHT in den SectionHeader.aside-Slot.

## Verifikation
- npm run lint clean
- npm run build clean
- DOM-Recheck Toolbox-Seite: H2 "Score-Werte als Aufmerksamkeitsmarker lesen" jetzt vorhanden, alle 12 Toolbox-H2 vollstaendig

## Test plan
- [ ] Visuelle Stichprobe Toolbox-Seite: ScoreBands-Sektion zeigt jetzt H2 zwischen "Von der ersten Einordnung..." und "Vier kurze Fragen..."
- [ ] Interpretations-Aside steht weiterhin neben den 3 Score-Karten

🤖 Generated with [Claude Code](https://claude.com/claude-code)