### PR TITLE
fix(css): 72rem-Breakpoint ans Cascade-Ende -- Desktop-Spalten greifen wieder

### DIFF
--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -1677,17 +1677,6 @@
   text-align: left;
 }
 
-@media (min-width: 72.001rem) {
-  .ui-card-grid--3,
-  .ui-closing-collection-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .ui-card-grid--5 {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-  }
-}
-
 /* Audit-13-Nachlauf, Option A: Desktop-Nav und Desktop-Header-Actions sind
    auf allen Viewports ausgeblendet. Nur das Burger-Menue (compact-actions)
    ist aktiv. Grund: Die Desktop-Nav hatte ab 1152px sichtbare Overlap-
@@ -2426,6 +2415,23 @@
     flex-direction: row;
     align-items: end;
     justify-content: space-between;
+  }
+}
+
+/* Audit A5: Dieser Block stand vorher VOR dem 48rem-Block oben in der Datei
+   und wurde dadurch im Cascade-Tie ueberschrieben (gleiche Spezifitaet,
+   spaeterer Source-Position-Sieg). Dadurch rendete --3 ueberall als 2-col,
+   --5 ueberall als 2-col, ui-closing-collection-grid ueberall als 2-col --
+   selbst auf Viewports >= 1152px. Nach Verschiebung ans Cascade-Ende
+   greifen die Desktop-Spaltenzahlen wieder. */
+@media (min-width: 72.001rem) {
+  .ui-card-grid--3,
+  .ui-closing-collection-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .ui-card-grid--5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- Audit-Finding A5 (massiver visueller Bug, viel groesser als initial gedacht): Der `@media (min-width: 72.001rem)`-Block fuer `.ui-card-grid--3`, `.ui-card-grid--5` und `.ui-closing-collection-grid` stand in `primitives.css` VOR dem `@media (min-width: 48rem)`-Block.
- Bei Viewports >= 1152px matchen beide Media Queries -- im Cascade-Tie (gleiche Spezifitaet) gewinnt die spaeter im Source stehende Regel. Damit wurden alle Desktop-Spaltenzahlen von der 2-Spalten-Tablet-Regel ueberschrieben.

## Auswirkung (vor dem Fix, @1280px verifiziert)
| Seite | Grid | Items | Soll | Ist |
|---|---|---|---|---|
| Toolbox | `ui-card-grid--3` (Score-Bands) | 3 | 3 | **2** (3. Karte alleine in Reihe 2) |
| Toolbox | `ui-card-grid--3` (Sucht) | 6 | 3 | **2** |
| Evidenz | `ui-card-grid--3` (5x Instanzen, 7-18 Items) | 7-18 | 3 | **2** |
| Evidenz | `ui-card-grid--5` | 5 | 5 | **2** (2+2+1!) |
| Evidenz | `ui-closing-collection-grid` (4x, 5-15 Items) | 5-15 | 3 | **2** |
| Grundlagen | `ui-card-grid--3` + `ui-closing-collection-grid` | 3-4 | 3 | **2** |

**13 Grid-Instanzen ueber die App betroffen.**

## Fix
Der ≥72.001rem-Block wurde ans Cascade-Ende verschoben (nach dem ≥64rem-Block). Keine Inhaltsaenderung, keine Spezifitaetshacks (`!important`, doppelte Klassen) -- nur Reihenfolge.

## Verifikation (DOM-Recheck @1280px)
- `ui-card-grid--3` = 3 cols ueberall ✓
- `ui-card-grid--5` = 5 cols ✓
- `ui-closing-collection-grid` = 3 cols ueberall ✓
- Score-Bands: 3 Karten je 270px nebeneinander, alle Tops identisch ✓

## Test plan
- [ ] Desktop (>= 1280px) Stichprobe: Toolbox-Score-Bands (3 nebeneinander), Evidenz-Closing-Collections (3-spaltig statt 2), Evidenz-Lernziel-Grid (5-spaltig)
- [ ] Tablet (768-1151px): unveraendert 2-spaltig
- [ ] Mobile (< 768px): unveraendert 1-spaltig

🤖 Generated with [Claude Code](https://claude.com/claude-code)