### PR TITLE
fix(footer): Brand-Lockup als <p> statt <h2>, Span-Blocks statt <br />

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -22,9 +22,17 @@ const Footer = memo(function Footer() {
         <div className="footer-grid">
           <div className="footer-panel footer-panel--brand">
             <div className="footer-brand-badge">Fachportal Zürich</div>
-            <h2 className="footer-brand-title">
-              Eltern im <br /> Beratungskontext
-            </h2>
+            {/* Audit: Brand-Lockup ist kein topical heading -- vorher als <h2>
+                landete es auf jeder Seite zusaetzlich in der Heading-Outline und
+                konkurrierte mit den inhaltlichen Sektionen. Das `<br />` mit
+                Leerzeichen davor und danach produzierte zudem textContent
+                "Eltern im  Beratungskontext" (Doppel-Leerzeichen) -- schlecht
+                fuer Screen Reader. Loesung: `<p>` statt `<h2>` (Brand-Label
+                statt Ueberschrift) und Span-Block-Lines statt `<br />`. */}
+            <p className="footer-brand-title">
+              <span className="footer-brand-title__line">Eltern im</span>{' '}
+              <span className="footer-brand-title__line">Beratungskontext</span>
+            </p>
             <p className="footer-brand-copy">
               Fachportal für Orientierung, Triage und Weitervermittlung: Arbeitshilfen für Fachpersonen, die mit
               Familien mit psychisch belasteten Eltern arbeiten. Schwerpunkt Kanton Zürich, schweizweite Ergänzungen.

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -3153,6 +3153,13 @@
   line-height: 0.95;
 }
 
+/* Audit-Folge: Footer-Brand-Lockup erzwingt zwei Zeilen ueber Span-Blocks
+   (statt <br />), damit textContent sauber als "Eltern im Beratungskontext"
+   serialisiert -- ohne das frueher entstandene Doppel-Leerzeichen. */
+.footer-brand-title__line {
+  display: block;
+}
+
 .footer-brand-copy {
   margin: var(--space-5) 0 0;
   max-width: 32rem;


### PR DESCRIPTION
## Summary
Zwei Probleme an einer Stelle im Footer-Brand-Lockup, beide ueber alle Seiten sichtbar:

1. **Brand als `<h2>`**: Da der Footer auf jeder Seite eingebunden ist, landete der Brand-Lockup zusaetzlich in jeder Heading-Outline. Semantisch ist das ein Markennamen, kein Kapitel-Titel.
2. **`Eltern im <br /> Beratungskontext`** mit Leerzeichen davor und danach erzeugte textContent `"Eltern im  Beratungskontext"` (Doppel-Leerzeichen) -- problematisch fuer Screen Reader und semantische Outline-Auswertung.

## Fix
- `<h2>` zu `<p>` demoted
- `<br />` ersetzt durch zwei `<span class="footer-brand-title__line">` mit `display: block`
- Optischer Zeilenumbruch bleibt -- textContent serialisiert jetzt sauber als `"Eltern im Beratungskontext"`

## Verifikation (DOM-Recheck)
- `document.querySelector('.footer-brand-title')`: tag = `P`, textContent = `"Eltern im Beratungskontext"` ✓
- Beide Line-Spans haben `display: block` ✓
- Heading-Outline pro Seite hat ein "Geister-H2" weniger:
  - Start: 2 -> 1 H2
  - Vignetten: 3 -> 2 H2
  - Netzwerk: 3 -> 2 H2
  - eLearning: 3 -> 2 H2
  - Glossar: 5 -> 4 H2
  - Evidenz: 7 -> 6 H2
  - Grundlagen: 9 -> 8 H2
  - Toolbox: 13 -> 12 H2

Kein inhaltlich relevantes H2 verschwindet.

## Test plan
- [ ] Footer visuell: "Eltern im" auf Zeile 1, "Beratungskontext" auf Zeile 2 -- gleiche Optik wie vorher
- [ ] Screen-Reader-Test (optional): Brand wird als ein Begriff gelesen, ohne Doppel-Pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)