### PR TITLE
docs(evidence): Lernziele-Items mit Laengenkonvention kommentieren

### DIFF
--- a/src/sections/EvidenceSection.jsx
+++ b/src/sections/EvidenceSection.jsx
@@ -150,6 +150,12 @@ export default function EvidenceSection({ downloadResources = [] }) {
         'Kapitel 5 Materialien',
       ],
     },
+    // Konvention (Audit-Folge A5): `note`-Felder moeglichst <= ~80 Zeichen halten.
+    // Diese fuenf Items rendern als `ui-card-grid--5` und stehen ab Viewport
+    // >= 1152px nebeneinander -- pro Karte bleiben rund 217px Breite. Laengere
+    // Notes brechen mehrfach um und lassen die Reihe optisch gequetscht wirken.
+    // Aktuell laengste Note: 84 Zeichen ("Unterstuetzungsangebote, klinische
+    // Schritte und naechste Interventionen") -- gerade noch im Rahmen.
     items: [
       {
         id: 'evidenz-verstehen',


### PR DESCRIPTION
## Summary
- Erklaerender Kommentar ueber dem `items`-Array der Lernziele-Section in `EvidenceSection.jsx`
- Dokumentiert die Schwelle von ~80 Zeichen pro `note`-Feld und begruendet sie aus dem Layout (`ui-card-grid--5`, ~217px pro Karte ab Viewport >= 1152px)
- Folgearbeit zu Audit A5 (Cascade-Fix der Desktop-Spalten in PR #81): seit dort die Reihe wieder konsequent fuenfspaltig wird, ist die Schwelle relevant

## Hintergrund
Die fuenf Lernziele rendern auf Desktop in einer einzigen Reihe. Pro Karte bleibt nur ein schmaler Streifen Breite. Ohne dokumentierte Konvention koennen kuenftige Bearbeitende laengere Texte einstellen, die in dem engen Raum mehrfach umbrechen und die Reihe optisch quetschen. Aktuell laengste Note: 84 Zeichen — gerade noch im Rahmen.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — gruen
- [ ] Visuelle Pruefung optional: Lernziele-Section bei >=1152px (sollte unveraendert sein, nur Kommentar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)