### PR TITLE
fix(fachstellen): PUK-Karte entdoppeln -- 270 -> 175 Zeichen

### DIFF
--- a/src/data/fachstellenContent.js
+++ b/src/data/fachstellenContent.js
@@ -30,8 +30,15 @@ export const FACHSTELLEN = [
   {
     id: 'puk-angehoerigenberatung',
     name: 'PUK Zürich – offizielle Angehörigenberatung',
+    // Audit-Folge A5 (PUK-Karte): description war 270 Zeichen / drei Saetze und
+    // verdoppelte Info, die ohnehin in `audience` (Zielgruppen-Aufzaehlung) und
+    // `highlight` ("auch ohne PUK-Hospitalisation") sichtbar ist. Die Karte
+    // wuchs dadurch auf ~518px Hoehe und fiel im 3-spaltigen Grid (ab >=1152px)
+    // visuell aus der Reihe. Gekuerzt auf einen Satz / ~175 Zeichen, semantisch
+    // identisch (kostenlos+vertraulich bleibt erhalten, Hospitalisation-Hinweis
+    // wandert vollstaendig in den `highlight`-Badge).
     description:
-      'Kostenlose und vertrauliche Beratung der Fachstelle Angehörigenarbeit für Angehörige und Bezugspersonen psychisch erkrankter Menschen, auch für psychisch erkrankte Eltern und deren minderjährige Kinder. Eine Beratung ist auch ohne Hospitalisation in der PUK möglich.',
+      'Kostenlose, vertrauliche Beratung der Fachstelle Angehörigenarbeit für Angehörige und Bezugspersonen psychisch erkrankter Menschen — auch für betroffene Eltern und ihre Kinder.',
     link: 'https://www.pukzh.ch/patienten-angehoerige/informationen-fuer-angehoerige/',
     tags: ['Klinik', 'Zürich', 'offizielle Stelle'],
     audience: 'Angehörige, Eltern, Kinder, Fachpersonen',


### PR DESCRIPTION
## Summary
- `description` der PUK-Angehoerigenberatung von 270 auf 175 Zeichen gekuerzt (3 Saetze -> 1 Satz)
- Entfernt redundante Information, die parallel im `highlight`-Badge und im `audience`-Feld bereits sichtbar ist
- Audit-Folgearbeit zu PR #81 (A5 Cascade-Fix der Desktop-Spalten)

## Hintergrund
Die PUK-Karte trug Information dreifach:

| Feld | Inhalt | Doppelung |
|---|---|---|
| `description` | "...auch fuer psychisch erkrankte Eltern und deren minderjaehrige Kinder. Eine Beratung ist auch ohne Hospitalisation in der PUK moeglich." | — |
| `highlight` | "kostenlos · auch ohne PUK-Hospitalisation" | wortgleich zu Satz 3 |
| `audience` | "Angehoerige, Eltern, Kinder, Fachpersonen" | wortgleich zur Aufzaehlung in Satz 2 |

Nach dem Cascade-Fix von PR #81 rendert das Fachstellen-Grid wieder konsequent dreispaltig (>=1152px). Im 372px-breiten Raster fiel die PUK-Karte mit ~518px Hoehe sichtbar aus der Reihe (Geschwister-Karten: ~300px).

## Was bleibt erhalten
Alle Kerninfos sind weiterhin auf der Karte sichtbar — nur nicht mehr doppelt im Description-Fliesstext:
- "kostenlos / vertraulich" -> Description
- volle Zielgruppen-Aufzaehlung -> `audience`-Feld
- "auch ohne PUK-Hospitalisation" -> `highlight`-Badge
- offizieller Status -> `official: true` -> Hervorhebung

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — gruen
- [ ] Visuelle Pruefung optional: Fachstellen-/Evidenz-Section, PUK-Karte sollte jetzt in Hoehe zu Geschwistern passen

🤖 Generated with [Claude Code](https://claude.com/claude-code)