### PR TITLE
fix(fachstellen): PUK-Karte entdoppeln -- description statt 270 nur 1…

### DIFF
--- a/src/data/fachstellenContent.js
+++ b/src/data/fachstellenContent.js
@@ -30,8 +30,15 @@ export const FACHSTELLEN = [
   {
     id: 'puk-angehoerigenberatung',
     name: 'PUK Zürich – offizielle Angehörigenberatung',
+    // Audit-Folge A5 (PUK-Karte): description war 270 Zeichen / drei Saetze und
+    // verdoppelte Info, die ohnehin in `audience` (Zielgruppen-Aufzaehlung) und
+    // `highlight` ("auch ohne PUK-Hospitalisation") sichtbar ist. Die Karte
+    // wuchs dadurch auf ~518px Hoehe und fiel im 3-spaltigen Grid (ab >=1152px)
+    // visuell aus der Reihe. Gekuerzt auf einen Satz / ~175 Zeichen, semantisch
+    // identisch (kostenlos+vertraulich bleibt erhalten, Hospitalisation-Hinweis
+    // wandert vollstaendig in den `highlight`-Badge).
     description:
-      'Kostenlose und vertrauliche Beratung der Fachstelle Angehörigenarbeit für Angehörige und Bezugspersonen psychisch erkrankter Menschen, auch für psychisch erkrankte Eltern und deren minderjährige Kinder. Eine Beratung ist auch ohne Hospitalisation in der PUK möglich.',
+      'Kostenlose, vertrauliche Beratung der Fachstelle Angehörigenarbeit für Angehörige und Bezugspersonen psychisch erkrankter Menschen — auch für betroffene Eltern und ihre Kinder.',
     link: 'https://www.pukzh.ch/patienten-angehoerige/informationen-fuer-angehoerige/',
     tags: ['Klinik', 'Zürich', 'offizielle Stelle'],
     audience: 'Angehörige, Eltern, Kinder, Fachpersonen',


### PR DESCRIPTION
…75 Zeichen

Die description der PUK-Angehoerigenberatung trug Information dreifach: "auch ohne Hospitalisation" stand im 3. Satz und gleichzeitig im `highlight`-Badge, die volle Zielgruppen-Aufzaehlung stand im 2. Satz und gleichzeitig im `audience`-Feld.

Nach dem Cascade-Fix in PR #81 wurde das Fachstellen-Grid wieder konsequent dreispaltig (>=1152px). In dem Raster fiel die PUK-Karte mit ~518px Hoehe deutlich aus der Reihe (Geschwister: ~300px). Statt das Layout fuer einen Sonderfall zu redesignen, ist hier die saubere Loesung, die redundante Information aus der Description zu entfernen -- das `highlight`-Badge und das `audience`-Feld behalten ihre Kerninfo weiterhin sichtbar.

Semantisch identisch: kostenlos + vertraulich + Zielgruppen-Hinweis + Hospitalisations-Klarstellung sind alle weiterhin auf der Karte sichtbar, nur nicht mehr doppelt im selben Fliesstext.