### PR TITLE
refactor(asidecard): toten aside.note-Pfad entfernen, Logik dokumentieren

### DIFF
--- a/src/components/ui/AsideCard.jsx
+++ b/src/components/ui/AsideCard.jsx
@@ -8,10 +8,16 @@ export default function AsideCard({ aside, tone = 'soft' }) {
       {aside.label ? <p className="ui-fact-card__label">{aside.label}</p> : null}
       {aside.title ? <h3 className="ui-card__title">{aside.title}</h3> : null}
       {aside.value ? <p className="ui-fact-card__value">{aside.value}</p> : null}
+      {/* Audit (Redundanzen-Welle): `aside.note` wurde hier zuvor zusaetzlich
+          gerendert, war aber im gesamten src/-Tree nirgends gesetzt. Drei
+          parallele Felder (`copy`/`note` + value-abhaengige Klassen) loesten
+          effektiv denselben Job mit unklarer Semantik. Verbleibend: `aside.copy`
+          rendert als `ui-card__copy`, faellt aber zu `ui-fact-card__note`
+          herunter, wenn ein `aside.value` darueber steht (kleinere Typo unter
+          der Kennzahl). */}
       {aside.copy ? (
         <p className={aside.value ? 'ui-fact-card__note' : 'ui-card__copy'}>{aside.copy}</p>
       ) : null}
-      {aside.note ? <p className="ui-card__copy">{aside.note}</p> : null}
       {aside.badges?.length ? (
         <div className="ui-badge-row ui-editorial-card__action">
           {aside.badges.map((badge) => (


### PR DESCRIPTION
## Summary
- `aside.note`-Branch aus `AsideCard.jsx` entfernt (Dead Code: kein Aufrufer in src/ setzte das Feld)
- Inline-Kommentar dokumentiert die verbleibende `aside.copy`-Logik mit value-abhaengiger Klassenwahl
- Befund #2 aus der Redundanzen-Audit-Welle

## Hintergrund
Vor dem Fix rendete `AsideCard` drei parallele Pfade fuer Copy-Text:

```jsx
{aside.copy ? (
  <p className={aside.value ? 'ui-fact-card__note' : 'ui-card__copy'}>{aside.copy}</p>
) : null}
{aside.note ? <p className="ui-card__copy">{aside.note}</p> : null}
```

Verifikation per `grep aside\.(copy|note)`: kein einziger Aufrufer in `src/` setzte `aside.note`. Sechs Sections (Grundlagen, Toolbox x3, Elearning, Evidenz x2) nutzen alle nur `aside.copy`.

## Was bleibt
Die value-abhaengige Klassenwahl bleibt erhalten und ist jetzt kommentiert: `aside.copy` rendert als grosser Body-Text (`ui-card__copy`), faellt aber zu kleinerem `ui-fact-card__note` herunter, wenn ein `aside.value` (Kennzahl wie "3/12") darueber steht. Das ist semantisch sinnvoll und in `ElearningSection.jsx:105-110` aktiv genutzt.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — gruen
- [ ] Visuelle Pruefung optional: alle Aside-Karten unveraendert

🤖 Generated with [Claude Code](https://claude.com/claude-code)