### PR TITLE
docs(state): zwei Versionsachsen in appShellContent.js dokumentieren

### DIFF
--- a/src/data/appShellContent.js
+++ b/src/data/appShellContent.js
@@ -101,6 +101,21 @@ export const TAB_ITEMS = [
   },
 ];
 
+// Zwei unabhaengige Versionsachsen -- bewusst nicht synchron:
+//
+// 1. Die `_v5`-Suffixe an `STORAGE_KEYS.appState` und `APP_BROADCAST_CHANNEL`
+//    bezeichnen die *Schluessel-Generation*. Bei jedem groesseren Schema-
+//    Bruch wird der Suffix erhoeht, sodass alte localStorage-Eintraege nicht
+//    mehr aufgegriffen werden (effektive Cache-Invalidierung). Aktuell v5.
+//
+// 2. `APP_STATE_VERSION` ist die *Daten-Version innerhalb* eines persistierten
+//    State-Objekts. Sie steuert die Migrations-Logik in `AppStateContext`,
+//    wenn ein State mit aelterer Versionsnummer geladen wird. Aktuell 2.
+//
+// Bei der naechsten Migration: ueberlegen, ob nur der Daten-Version
+// hochzaehlen reicht (kompatible Erweiterung) oder ob zusaetzlich der
+// Schluessel-Suffix springen muss (inkompatibler Bruch, der alte States
+// nicht migrieren will).
 export const STORAGE_KEYS = {
   appState: 'rr_app_state_v5',
 };


### PR DESCRIPTION
## Summary
- 15-zeiliger Kommentar ueber den drei Token-Definitionen in `src/data/appShellContent.js`
- Erklaert, warum `_v5`-Suffix und `APP_STATE_VERSION = 2` bewusst nicht synchron laufen
- Befund #4 aus der Redundanzen-Audit-Welle

## Hintergrund
Die drei Konstanten zusammen lasen sich wie ein Mismatch:
- `STORAGE_KEYS.appState = 'rr_app_state_v5'`
- `APP_BROADCAST_CHANNEL = 'rr_app_sync_v5'`
- `APP_STATE_VERSION = 2`

Tatsaechlich sind das zwei unabhaengige Versionsachsen:
1. `_v5` = Schluessel-Generation -- haerter Cache-Invalidierungshebel, der alte localStorage-Eintraege ignoriert
2. `APP_STATE_VERSION = 2` = Daten-Version innerhalb des persistierten Objekts, steuert Migrations-Logik

Ohne Erklaerung wuerde bei der naechsten Migration nicht klar sein, welche Achse zu erhoehen ist.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — gruen
- Reine Dokumentation, kein Verhaltensaenderung

🤖 Generated with [Claude Code](https://claude.com/claude-code)