### PR TITLE
fix(evidence): tote hero.aside-Daten in EvidenceSection entfernen

### DIFF
--- a/src/sections/EvidenceSection.jsx
+++ b/src/sections/EvidenceSection.jsx
@@ -125,13 +125,18 @@ export default function EvidenceSection({ downloadResources = [] }) {
       'praxisnahe Brücke zwischen Evidenz, Gesprächsführung und Vernetzung',
     ],
     badges: ['Verstehen', 'Mit Kindern sprechen', 'Mit Eltern arbeiten', 'Handeln & vernetzen'],
-    aside: {
-      eyebrow: 'Praxisfokus',
-      title: 'Nicht nur Krankheit sehen, sondern Beziehung und Versorgung.',
-      description:
-        'Die Inhalte übersetzen Forschung und klinische Erfahrung in konkrete Fragen für Anamnese, Gesprächsführung, Entlastung und nächste Schritte im familiären Alltag.',
-      meta: ['Psychoedukation', 'Elternarbeit', 'Schutzfaktoren', 'Vernetzung'],
-    },
+    // Audit (Aside-Konsolidierung, Welle 1, Schritt 1): Hier stand zuvor ein
+    // `aside`-Objekt mit `{eyebrow, title, description, meta}`. PageHero liest
+    // aber nur die flachen Props `asideTitle`/`asideCopy` und ignoriert ein
+    // `aside`-Objekt komplett -- das Objekt war also stillschweigend tote
+    // Daten und wurde nirgends gerendert. Bewusste Entscheidung gegen ein
+    // Re-Aktivieren des Asides: die Hero traegt mit eyebrow + title + lead +
+    // description + supportingPoints + badges bereits sechs Inhaltsebenen,
+    // und die Aside-Copy (`Beziehung und Versorgung sehen`) war im Kern eine
+    // dritte Paraphrase dessen, was Description und SupportingPoints schon
+    // sagen. Die anderen sechs Sections haben einen Hero-Aside, weil ihre
+    // Hero sonst schlanker ist -- die Evidenz-Hero ist die begruendete
+    // Ausnahme.
   };
 
   const chapterOverview = {


### PR DESCRIPTION
## Summary
- 7-zeiliges `hero.aside`-Objekt aus `EvidenceSection.jsx` entfernt — wurde von PageHero nie gelesen, war stillschweigend tote Daten
- Inline-Kommentar dokumentiert die bewusste Entscheidung gegen ein Re-Aktivieren
- Welle 1, Schritt 1 von 3 (Aside-Konsolidierung)

## Hintergrund

Bei der Kartografie der drei parallelen Aside-Patterns aufgefallen: das `hero`-Objekt von EvidenceSection trug ein vierfeldiges `aside`-Objekt (`{eyebrow, title, description, meta}`). PageHero liest aber **nur** die flachen Props `asideTitle`/`asideCopy` und ignoriert jedes `aside`-Objekt komplett. Die Daten wurden also nirgends gerendert.

## Warum loeschen statt rendern

Die Evidenz-Hero traegt schon **sechs Inhaltsebenen**: eyebrow + title + lead + description + supportingPoints + badges. Ein zusaetzlicher Aside wuerde sie auf sieben Ebenen bringen — keine andere Hero traegt annaehernd so viel.

Zusaetzlich: die Aside-Copy ("Beziehung und Versorgung sehen", "Inhalte uebersetzen Forschung in konkrete Fragen…") war eine dritte Paraphrase dessen, was Description und SupportingPoints bereits sagen. Aktivieren wuerde dieselbe Doppelungs-Optik erzeugen, die wir bei der PUK-Karte (#84) gerade weggeraeumt haben.

Empirisches Argument: Aside ist seit unbekannt vielen Wochen tot, und niemandem ist es aufgefallen.

## Was bleibt

Substanz ("systemischer Blick", "Forschung in Praxis uebersetzen") steht woertlich in `description` und `supportingPoints` — geht nichts verloren.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — gruen
- [ ] Visuelle Pruefung optional: Evidenz-Hero unveraendert (war ja so schon vor dem Fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)