### PR TITLE
refactor(toolbox): scoreBands.aside auf AsideCard umstellen

### DIFF
--- a/src/templates/ToolboxPageTemplate.jsx
+++ b/src/templates/ToolboxPageTemplate.jsx
@@ -1,4 +1,5 @@
 import { ChevronRight } from 'lucide-react';
+import AsideCard from '../components/ui/AsideCard';
 import Container from '../components/ui/Container';
 import Eyebrow from '../components/ui/Eyebrow';
 import Button from '../components/ui/Button';
@@ -182,12 +183,18 @@ function ScoreBandsSection({ scoreBands }) {
               </div>
             ))}
           </div>
-          {scoreBands.aside ? (
-            <SurfaceCard as="aside" tone="default">
-              {scoreBands.aside.label ? <p className="ui-fact-card__label">{scoreBands.aside.label}</p> : null}
-              {scoreBands.aside.copy ? <p className="ui-card__copy">{scoreBands.aside.copy}</p> : null}
-            </SurfaceCard>
-          ) : null}
+          {/* Audit (Aside-Konsolidierung, Welle 1, Schritt 2): Inline
+              SurfaceCard mit `{label, copy}` durch <AsideCard> ersetzt -- die
+              Felder matchen AsideCards API exakt, das gerenderte DOM ist
+              identisch (ui-fact-card__label + ui-card__copy in einer
+              SurfaceCard as="aside" tone="default"). Vorteil: weniger
+              Duplikat, klares "AsideCard rendert hier" statt verstecktes
+              Inline-Markup. */}
+          <AsideCard aside={scoreBands.aside} tone="default" />
+          {/* Hinweis: `assessment.scoreAside` weiter oben (Zeile ~28) bleibt
+              bewusst inline, weil es domain-spezifische Toolbox-Felder traegt
+              (live region, action button, status badge mit ui-toolbox-status-
+              badge-Styling) -- die wuerden AsideCards API ueberladen. */}
         </div>
       </div>
     </Section>


### PR DESCRIPTION
## Summary
- Inline `<SurfaceCard>`-Aside in `ToolboxPageTemplate` (`scoreBands.aside`, ~Zeile 185) auf `<AsideCard>` umgestellt
- `scoreAside` (Zeile ~28) bleibt bewusst inline — domain-spezifisch
- Welle 1, Schritt 2 von 3 (Aside-Konsolidierung)

## Hintergrund

Die ScoreBandsSection rendete `scoreBands.aside` inline:
```jsx
<SurfaceCard as="aside" tone="default">
  {scoreBands.aside.label ? <p className="ui-fact-card__label">{...}</p> : null}
  {scoreBands.aside.copy ? <p className="ui-card__copy">{...}</p> : null}
</SurfaceCard>
```

Die zwei Felder matchen AsideCards Schema exakt — kein API-Anpassen, kein Daten-Refactor noetig. Reine Komponenten-Substitution.

## DOM-Verifikation

| inline | AsideCard |
|---|---|
| `SurfaceCard as="aside" tone="default"` | `SurfaceCard as="aside" tone={aside.tone \|\| 'default'}` ✓ |
| `p.ui-fact-card__label` | `p.ui-fact-card__label` ✓ |
| `p.ui-card__copy` | `p.ui-card__copy` (weil `aside.value` nicht gesetzt) ✓ |

Identisches Markup, identisches Rendering.

## Was bleibt inline

`assessment.scoreAside` weiter oben (Zeile ~28-62) traegt domain-spezifische Felder, die AsideCards API ueberladen wuerden:
- `liveText` mit `aria-live="polite"` und `id={scoreStatusId}` fuer Score-Status
- `action`-Button mit `aria-describedby` Verknuepfung zum live region
- `badge` + `badgeClassName` fuer `ui-toolbox-status-badge`-Styling

Inline-Kommentar dokumentiert die Entscheidung.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — gruen
- [ ] Visuelle Pruefung optional: ScoreBandsSection in Toolbox -- Aside rechts neben den Score-Bands, unveraendert

🤖 Generated with [Claude Code](https://claude.com/claude-code)