### PR TITLE
refactor(evidence): toten zone.aside-Inline-Renderer entfernen

### DIFF
--- a/src/templates/EvidencePageTemplate.jsx
+++ b/src/templates/EvidencePageTemplate.jsx
@@ -140,13 +140,15 @@ function ZoneSection({ zone, defaultOpen = false }) {
 
         <div className="ui-stack ui-stack--loose ui-chapter-disclosure__body">
           {zone.paragraphs?.length ? <RichCopy paragraphs={zone.paragraphs} /> : null}
-          {zone.aside ? (
-            <SurfaceCard tone="soft">
-              {zone.aside.eyebrow ? <p className="ui-fact-card__label">{zone.aside.eyebrow}</p> : null}
-              <h3 className="ui-card__title">{zone.aside.title}</h3>
-              {zone.aside.description ? <p className="ui-card__copy">{zone.aside.description}</p> : null}
-            </SurfaceCard>
-          ) : null}
+          {/* Audit (Aside-Konsolidierung, Welle 1, Schritt 3): Hier stand
+              zuvor ein inline SurfaceCard-Renderer fuer `zone.aside` mit
+              eigenem Schema (`{eyebrow, title, description}`). Verifiziert,
+              dass keine der vier Zonen in `EvidenceSection.zones` ein
+              `aside:`-Feld setzt -- der Renderer war seit unbekannt langem
+              Dead Code. Falls einmal ein Zone-Aside gebraucht wird:
+              <AsideCard aside={zone.aside} tone="soft" /> mit dem regulaeren
+              `{label, title, value, copy, badges}`-Schema, NICHT wieder ein
+              eigenes Inline-Schema einfuehren. */}
 
           {zone.highlightList ? (
             <BulletList items={zone.highlightList.items} tone={zone.highlightList.tone} icon={zone.highlightList.icon} />


### PR DESCRIPTION
## Summary
- 7-zeiligen Inline `<SurfaceCard>`-Renderer fuer `zone.aside` aus `EvidencePageTemplate.ZoneSection` entfernt
- Verifiziert: keine der vier Zonen in `EvidenceSection.zones` setzt jemals `aside:` -- der Renderer war Dead Code
- Welle 1, Schritt 3 von 3 (Aside-Konsolidierung) -- abschliessend

## Hintergrund

Bei der Aside-Konsolidierungs-Welle (Schritte 1-2 in PRs #95, #96) als nicht migrationsbeduerftiger Inline-Renderer geflaggt -- aber bei genauerer Pruefung der Daten zeigte sich: er ist nie aktiv. Die vier Zonen in `EvidenceSection.zones` (Lines 189-384) tragen alle `eyebrow`, `title`, `accent`, `paragraphs`, `subsections`, `cards`, `cardColumns`, `callout` -- aber **keine** `aside:`.

Bonus-Schaden des Renderers: Sein eigenes Schema (`{eyebrow, description}`) divergierte von AsideCards Schema (`{label, copy}`) -- haette also bei kuenftiger Aktivierung die gerade konsolidierte Aside-API ein drittes Mal gespalten.

## Was zurueckbleibt

Inline-Kommentar mit klarer Migrations-Anweisung: falls eine Zone irgendwann tatsaechlich einen Aside braucht, **AsideCard** mit dem regulaeren `{label, title, value, copy, badges}`-Schema verwenden -- NICHT wieder ein eigenes Inline-Schema einfuehren.

## Drei verbleibende Inline-Aside-Stellen (bewusst nicht migriert)

1. `ToolboxPageTemplate.jsx:28-62` (`assessment.scoreAside`) -- domain-spezifische Toolbox-Felder (`liveText` mit `aria-live`, `action`-Button mit `aria-describedby`, `badge` mit `ui-toolbox-status-badge`)
2. `NetworkPageTemplate.jsx:415-427` (Leitfragen-Block) -- domain-spezifische Network-Felder (MapPin-Icon im Label, `ui-network-question-list`-Styling)

Diese beiden tragen Felder, die AsideCards generische API ueberladen wuerden. In den jeweiligen Templates dokumentiert (Toolbox: PR #96).

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — gruen
- [ ] Visuelle Pruefung optional: Evidenz-Zonen rendern unveraendert (Code war ohnehin tot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)