### PR TITLE
chore(format): npm run format auf gesamten src/-Baum anwenden

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,11 @@ const EvidenceSection = lazy(() => import('./sections/EvidenceSection'));
 
 const SectionLoadingFallback = function SectionLoadingFallback() {
   return (
-    <section aria-busy="true" aria-label="Inhalt wird geladen" className="rounded-[3rem] border border-slate-200 bg-white px-8 py-12 shadow-sm md:px-12 md:py-16">
+    <section
+      aria-busy="true"
+      aria-label="Inhalt wird geladen"
+      className="rounded-[3rem] border border-slate-200 bg-white px-8 py-12 shadow-sm md:px-12 md:py-16"
+    >
       <p className="ui-visually-hidden">Inhalt wird geladen…</p>
       <div className="max-w-2xl">
         <div className="mb-5 h-2 w-20 rounded-full bg-emerald-100" />
@@ -87,10 +91,7 @@ export default function App() {
     toolboxRefs,
   });
 
-  const {
-    handleDownloadCrisisPlan,
-    downloadResources,
-  } = useDownloadHandlers(score.risk);
+  const { handleDownloadCrisisPlan, downloadResources } = useDownloadHandlers(score.risk);
 
   const openPriorityToolboxSection = useCallback(
     (section) => {
@@ -224,8 +225,8 @@ export default function App() {
               className="emergency-tel-link font-extrabold underline decoration-2 underline-offset-2 hover:no-underline"
             >
               147
-            </a>
-            {' '}telefonisch der schnellste Weg.
+            </a>{' '}
+            telefonisch der schnellste Weg.
           </div>
           <button
             type="button"
@@ -258,38 +259,34 @@ export default function App() {
         className="flex-grow max-w-7xl mx-auto w-full px-4 md:px-6 py-8 md:py-10 outline-none page-enter"
       >
         <ErrorBoundary>
-        <Suspense fallback={<SectionLoadingFallback />}>
-          {activeTab === 'start' && (
-            <HomeLandingTemplate pageHeadingId={getPageHeadingId('start')} />
-          )}
+          <Suspense fallback={<SectionLoadingFallback />}>
+            {activeTab === 'start' && <HomeLandingTemplate pageHeadingId={getPageHeadingId('start')} />}
 
-          {activeTab === 'lernmodule' && <ElearningSection />}
+            {activeTab === 'lernmodule' && <ElearningSection />}
 
-          {activeTab === 'vignetten' && <VignettenSection />}
+            {activeTab === 'vignetten' && <VignettenSection />}
 
-          {activeTab === 'glossar' && <GlossarSection />}
+            {activeTab === 'glossar' && <GlossarSection />}
 
-          {activeTab === 'grundlagen' && (
-            <GrundlagenSection sharedDownloadResources={downloadResources} />
-          )}
+            {activeTab === 'grundlagen' && <GrundlagenSection sharedDownloadResources={downloadResources} />}
 
-          {activeTab === 'toolbox' && (
-            <ToolboxSection
-              onPrint={handleToolboxPrint}
-              onDownloadCrisisPlan={handleDownloadCrisisPlan}
-              acuteCrisisSectionRef={acuteCrisisSectionRef}
-              safetyPlanSectionRef={safetyPlanSectionRef}
-              childProtectionSectionRef={childProtectionSectionRef}
-              addictionSectionRef={addictionSectionRef}
-              rightsSectionRef={rightsSectionRef}
-              onJumpToPrioritySection={openPriorityToolboxSection}
-            />
-          )}
+            {activeTab === 'toolbox' && (
+              <ToolboxSection
+                onPrint={handleToolboxPrint}
+                onDownloadCrisisPlan={handleDownloadCrisisPlan}
+                acuteCrisisSectionRef={acuteCrisisSectionRef}
+                safetyPlanSectionRef={safetyPlanSectionRef}
+                childProtectionSectionRef={childProtectionSectionRef}
+                addictionSectionRef={addictionSectionRef}
+                rightsSectionRef={rightsSectionRef}
+                onJumpToPrioritySection={openPriorityToolboxSection}
+              />
+            )}
 
-          {activeTab === 'netzwerk' && <NetworkSection />}
+            {activeTab === 'netzwerk' && <NetworkSection />}
 
-          {activeTab === 'evidenz' && <EvidenceSection downloadResources={downloadResources} />}
-        </Suspense>
+            {activeTab === 'evidenz' && <EvidenceSection downloadResources={downloadResources} />}
+          </Suspense>
         </ErrorBoundary>
       </main>
 

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -24,8 +24,8 @@ export default class ErrorBoundary extends Component {
             <h2 className="text-lg font-bold">Ein Fehler ist aufgetreten</h2>
           </div>
           <p className="text-sm leading-relaxed text-stone-700">
-            Dieser Bereich konnte nicht geladen werden. Bitte laden Sie die Seite neu.
-            Falls das Problem bestehen bleibt, nutzen Sie die Notfallnummern unten.
+            Dieser Bereich konnte nicht geladen werden. Bitte laden Sie die Seite neu. Falls das Problem bestehen
+            bleibt, nutzen Sie die Notfallnummern unten.
           </p>
           <div className="rounded-xl border border-[var(--border-warm-soft)] bg-white/80 px-5 py-4 text-sm leading-relaxed text-[var(--text-danger-strong)]">
             <p className="mb-2 text-[10px] font-extrabold uppercase tracking-[0.18em] text-[var(--text-danger-label)]">
@@ -55,8 +55,8 @@ export default class ErrorBoundary extends Component {
                 className="emergency-tel-link font-extrabold underline decoration-2 underline-offset-2 hover:no-underline"
               >
                 147
-              </a>
-              {' '}telefonisch.
+              </a>{' '}
+              telefonisch.
             </p>
           </div>
           <button

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -88,7 +88,9 @@ const Footer = memo(function Footer() {
                 </p>
               </div>
             </div>
-            <div className="footer-framework-legal">© 2026 Eltern mit psychischen Erkrankungen im Beratungskontext.</div>
+            <div className="footer-framework-legal">
+              © 2026 Eltern mit psychischen Erkrankungen im Beratungskontext.
+            </div>
           </div>
         </div>
 

--- a/src/components/ui/AsideCard.jsx
+++ b/src/components/ui/AsideCard.jsx
@@ -15,9 +15,7 @@ export default function AsideCard({ aside, tone = 'soft' }) {
           rendert als `ui-card__copy`, faellt aber zu `ui-fact-card__note`
           herunter, wenn ein `aside.value` darueber steht (kleinere Typo unter
           der Kennzahl). */}
-      {aside.copy ? (
-        <p className={aside.value ? 'ui-fact-card__note' : 'ui-card__copy'}>{aside.copy}</p>
-      ) : null}
+      {aside.copy ? <p className={aside.value ? 'ui-fact-card__note' : 'ui-card__copy'}>{aside.copy}</p> : null}
       {aside.badges?.length ? (
         <div className="ui-badge-row ui-editorial-card__action">
           {aside.badges.map((badge) => (
@@ -41,9 +39,7 @@ export default function AsideCard({ aside, tone = 'soft' }) {
         <div className="ui-stack ui-stack--tight ui-card__section--spaced">
           {aside.items.map((item, i) => (
             <div key={i} className="ui-bullet-panel__item">
-              {item.icon ? (
-                <span className="ui-bullet-panel__marker ui-toolbox-inline-icon">{item.icon}</span>
-              ) : null}
+              {item.icon ? <span className="ui-bullet-panel__marker ui-toolbox-inline-icon">{item.icon}</span> : null}
               <p className="ui-bullet-panel__copy">{item.text}</p>
             </div>
           ))}

--- a/src/components/ui/Section.jsx
+++ b/src/components/ui/Section.jsx
@@ -50,7 +50,7 @@ const Section = forwardRef(function Section(
     children,
     ...props
   },
-  ref,
+  ref
 ) {
   const revealRef = useRevealRef();
 

--- a/src/components/ui/SectionHeader.jsx
+++ b/src/components/ui/SectionHeader.jsx
@@ -13,9 +13,7 @@ function RichCopy({ description, paragraphs }) {
   return (
     <div className="ui-copy">
       {description ? <p>{description}</p> : null}
-      {paragraphs
-        ? paragraphs.map((paragraph, i) => <p key={i}>{paragraph}</p>)
-        : null}
+      {paragraphs ? paragraphs.map((paragraph, i) => <p key={i}>{paragraph}</p>) : null}
     </div>
   );
 }
@@ -40,7 +38,7 @@ export default function SectionHeader({
   if (import.meta.env?.DEV && eyebrow && hasTitle && (description || paragraphs) && aside) {
     console.warn(
       '[SectionHeader] Alle vier Felder aktiv (eyebrow, title, description/paragraphs, aside). ' +
-        'Konvention: maximal 3 Ebenen pro Sektion. Prüfen, ob der aside wirklich Zusatzinhalt trägt.',
+        'Konvention: maximal 3 Ebenen pro Sektion. Prüfen, ob der aside wirklich Zusatzinhalt trägt.'
     );
   }
 

--- a/src/context/AppStateContext.jsx
+++ b/src/context/AppStateContext.jsx
@@ -1,10 +1,5 @@
 import { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  APP_BROADCAST_CHANNEL,
-  APP_STATE_VERSION,
-  DEFAULT_SCORE,
-  STORAGE_KEYS,
-} from '../data/appShellContent';
+import { APP_BROADCAST_CHANNEL, APP_STATE_VERSION, DEFAULT_SCORE, STORAGE_KEYS } from '../data/appShellContent';
 import { ASSESSMENT_ITEMS } from '../data/learningContent';
 import {
   getDefaultAppState,
@@ -177,7 +172,17 @@ export function AppStateProvider({ children }) {
       score,
       completedModules,
     }),
-    [activeTab, currentVignette, selectedOption, searchTerm, activeResourceFilter, quizState, showSafeNote, score, completedModules]
+    [
+      activeTab,
+      currentVignette,
+      selectedOption,
+      searchTerm,
+      activeResourceFilter,
+      quizState,
+      showSafeNote,
+      score,
+      completedModules,
+    ]
   );
 
   // BroadcastChannel + cross-tab storage sync
@@ -193,18 +198,12 @@ export function AppStateProvider({ children }) {
       if (payload.updatedAt <= latestAppliedTimestampRef.current) return;
 
       // Preserve the current tab if it was explicitly set via URL hash
-      const rawHash = typeof window !== 'undefined'
-        ? String(window.location.hash || '').replace(/^#/, '')
-        : '';
+      const rawHash = typeof window !== 'undefined' ? String(window.location.hash || '').replace(/^#/, '') : '';
       const explicitTabHash = rawHash && rawHash !== 'main-content' ? rawHash : null;
 
       latestAppliedTimestampRef.current = payload.updatedAt;
       skipNextPersistRef.current = true;
-      applyAppStateRef.current(
-        explicitTabHash
-          ? { ...payload.data, activeTab: explicitTabHash }
-          : payload.data
-      );
+      applyAppStateRef.current(explicitTabHash ? { ...payload.data, activeTab: explicitTabHash } : payload.data);
     };
 
     const handleStorage = (event) => {
@@ -275,11 +274,27 @@ export function AppStateProvider({ children }) {
       resetAppState,
     }),
     [
-      activeTab, currentVignette, selectedOption, searchTerm, activeResourceFilter,
-      quizState, showSafeNote, score, completedModules, isResetting,
-      navigate, setActiveTab, setCurrentVignette, setSearchTerm, setActiveResourceFilter,
-      setShowSafeNote, handleQuizAnswer, handleScoreChange, resetScore,
-      handleSelectVignetteOption, resetAppState,
+      activeTab,
+      currentVignette,
+      selectedOption,
+      searchTerm,
+      activeResourceFilter,
+      quizState,
+      showSafeNote,
+      score,
+      completedModules,
+      isResetting,
+      navigate,
+      setActiveTab,
+      setCurrentVignette,
+      setSearchTerm,
+      setActiveResourceFilter,
+      setShowSafeNote,
+      handleQuizAnswer,
+      handleScoreChange,
+      resetScore,
+      handleSelectVignetteOption,
+      resetAppState,
     ]
   );
 

--- a/src/data/evidenceContent.js
+++ b/src/data/evidenceContent.js
@@ -189,9 +189,6 @@ export const COLLABORATION_FOUR_AS = [
   'Abmachungen: Was ist unser nächster Schritt, und wer übernimmt was?',
 ];
 
-
-
-
 // Orientierung für Fachpersonen: was sie Eltern als konkrete Handlungsfelder
 // aufzeigen können. Ressourcen-orientiert statt rein krisenbezogen.
 // Stauber Kap. 4.3 + Lenz & Brockmann 2013.
@@ -289,10 +286,6 @@ export const CHILD_EXPERIENCE_PRACTICE_POINTS = [
   'kindliche Perspektive in Krisenplanung, Entlastung und Gesprächsführung mitdenken',
 ];
 
-
-
-
-
 // Spezifische Schutzfaktoren nach Stauber et al. (2018), Kap. 2.5 — die
 // Resilienzforschung identifiziert genau diese zwei Punkte als evidenzbasiert
 // protektiv speziell für Kinder psychisch kranker Eltern (über allgemeine
@@ -336,7 +329,6 @@ export const PSYCHOEDUCATION_AGE_GROUPS = [
     text: 'Jugendliche möchten meist genauer verstehen, was los ist, und fragen häufiger nach Vererbbarkeit, Verantwortung und eigener Abgrenzung. Hier helfen ehrliche Gespräche auf Augenhöhe, ohne die Jugendlichen zu Erwachsenenrollen zu drängen.',
   },
 ];
-
 
 export const PSYCHOEDUCATION_PRACTICE_POINTS = [
   'einfach, ehrlich und entlastend sprechen – nicht beschönigen, aber auch nicht überfordern',
@@ -444,9 +436,6 @@ export const CLINICAL_PRACTICE_POINTS = [
   'Krisen- und Übergangssituationen brauchen schriftliche, einfache und alltagstaugliche Absprachen statt nur guter Absichten.',
 ];
 
-
-
-
 // Strategie-Trias zur Aktivierung sozialer Ressourcen. Quelle: Lenz (2014),
 // referenziert in Stauber et al. (2018), Kap. 6.2. Während Netzwerkkarte
 // und Netzwerkzeichnung soziale Ressourcen sichtbar machen, beschreiben
@@ -522,7 +511,6 @@ export const INTERVENTION_PROGRAM_POINTS = [
 // SUPPORT_OFFERS wurde in Audit 12 zu FACHSTELLEN (src/data/fachstellenContent.js)
 // konsolidiert. Die Evidenz-Ansicht leitet ihre Teil-Liste ueber SUPPORT_OFFER_IDS
 // ab (dort definiert). Siehe docs/content-pflege.md.
-
 
 export const PUK_CONTEXT_POINTS = [
   'Diese Website ist ein ergänzendes psychoedukatives Informationsangebot und keine offizielle Unterseite der PUK Zürich.',
@@ -630,7 +618,7 @@ export const MEDIA_BOOKS = [
     focus: 'Jugendliche Perspektive auf elterliche Depression und Familienalltag',
   },
   {
-    title: 'Lieber Matz, Dein Papa hat \'ne Meise',
+    title: "Lieber Matz, Dein Papa hat 'ne Meise",
     author: 'Schlösser, S. (2012). Ullstein',
     age: 'ab 12 Jahren',
     disorder: 'depression',
@@ -679,11 +667,8 @@ export const MEDIA_NOTES = [
   'Bücher und digitale Ressourcen wirken oft am besten als Gesprächseinstieg, nicht als alleinige Lösung.',
 ];
 
-
 export const CROSS_DIAGNOSIS_POINTS = [
   'Nicht jede psychische Erkrankung führt automatisch zu einer Kindeswohlgefährdung. Entscheidend ist, wie stark Symptome den Alltag, die Verlässlichkeit und die Versorgung beeinflussen.',
   'Für Kinder zählt weniger die Diagnose als das, was sie im Alltag erleben: Ist der Elternteil erreichbar? Ist der Alltag vorhersagbar? Wird über die Erkrankung gesprochen? Gibt es Unterstützung?',
   'Die Praxis braucht deshalb keine vereinfachenden Urteile, sondern eine differenzierte Einschätzung nach Symptombelastung, Ressourcen, Schutzfaktoren und Netzwerk.',
 ];
-
-

--- a/src/data/fachstellenContent.js
+++ b/src/data/fachstellenContent.js
@@ -75,16 +75,14 @@ export const FACHSTELLEN = [
   {
     id: 'aerztefon',
     name: 'AERZTEFON Kanton Zürich',
-    description:
-      'Telefonische medizinische Triage für nicht lebensbedrohliche Situationen im Kanton Zürich.',
+    description: 'Telefonische medizinische Triage für nicht lebensbedrohliche Situationen im Kanton Zürich.',
     link: 'https://www.aerztefon.ch/',
     tags: ['24/7', 'Triage', 'Zürich', 'Krise'],
   },
   {
     id: '143-dargebotene-hand',
     name: '143 – Die Dargebotene Hand',
-    description:
-      'Anonyme und vertrauliche Krisenhilfe für Erwachsene per Telefon, Chat oder Mail.',
+    description: 'Anonyme und vertrauliche Krisenhilfe für Erwachsene per Telefon, Chat oder Mail.',
     link: 'https://www.143.ch/',
     tags: ['24/7', 'Erwachsene', 'Krise', 'anonym'],
   },
@@ -117,8 +115,7 @@ export const FACHSTELLEN = [
   {
     id: 'safezone',
     name: 'SafeZone',
-    description:
-      'Kostenlose und anonyme Online-Suchtberatung für Betroffene, Angehörige und Nahestehende.',
+    description: 'Kostenlose und anonyme Online-Suchtberatung für Betroffene, Angehörige und Nahestehende.',
     link: 'https://www.safezone.ch/de/',
     tags: ['Sucht', 'anonym', 'kostenlos', 'online'],
   },
@@ -135,8 +132,7 @@ export const FACHSTELLEN = [
   {
     id: 'mvb-zh',
     name: 'Mütter- und Väterberatung Kanton Zürich',
-    description:
-      'Kostenlose, vertrauliche und mehrsprachige Beratung für Familien mit Kindern von 0 bis 5 Jahren.',
+    description: 'Kostenlose, vertrauliche und mehrsprachige Beratung für Familien mit Kindern von 0 bis 5 Jahren.',
     link: 'https://mvb.zh.ch/beratungsangebot/',
     tags: ['Eltern 0–5', 'kostenlos', 'mehrsprachig', 'offizielle Stelle', 'Zürich'],
   },

--- a/src/data/glossaryContent.js
+++ b/src/data/glossaryContent.js
@@ -220,8 +220,7 @@ export const GLOSSARY_GROUPS = [
         term: 'Netzwerkkarte',
         definition:
           'Eine Übersicht, die zeigt, welche Fachstellen es gibt, wer wofür zuständig ist und wie Hilfewege in der Region zusammenhängen.',
-        practice:
-          'Hilft zu klären, wer informieren, abklären, entlasten oder in einer Krise eingreifen kann.',
+        practice: 'Hilft zu klären, wer informieren, abklären, entlasten oder in einer Krise eingreifen kann.',
       },
       {
         id: 'trialog',

--- a/src/data/sourcesContent.js
+++ b/src/data/sourcesContent.js
@@ -81,7 +81,8 @@ export const SOURCES = {
     year: 2020,
     title: 'Psychisch kranke Eltern im Beratungskontext. Was stärkt psychisch kranke Eltern und deren Kinder?',
     journal: null,
-    publisher: 'Praxisforschung der Erziehungsberatung des Kantons Bern, Band 25. Bern: Erziehungsberatung des Kantons Bern',
+    publisher:
+      'Praxisforschung der Erziehungsberatung des Kantons Bern, Band 25. Bern: Erziehungsberatung des Kantons Bern',
     type: 'report',
     doi: null,
     link: 'https://www.eb.bkd.be.ch/content/dam/eb_bkd/bilder/de/themen/praxisforschung/eb-pf-band-25-psychisch-kranke-eltern-im-beratungskontext.pdf',
@@ -233,7 +234,8 @@ export const SOURCES = {
     id: 'leijdesdorff-2017',
     author: 'Leijdesdorff, S., van Doesum, K., Popma, A., Klaassen, R. & van Amelsvoort, T.',
     year: 2017,
-    title: 'Prevalence of psychopathology in children of parents with mental illness and/or addiction: an up to date narrative review',
+    title:
+      'Prevalence of psychopathology in children of parents with mental illness and/or addiction: an up to date narrative review',
     journal: 'Current Opinion in Psychiatry, 30(4), 312-317',
     publisher: null,
     type: 'journal-article',

--- a/src/sections/ToolboxSection.jsx
+++ b/src/sections/ToolboxSection.jsx
@@ -170,7 +170,6 @@ const TRIAGE_PROMPTS = [
   },
 ];
 
-
 export default function ToolboxSection({
   onPrint,
   onDownloadCrisisPlan,

--- a/src/sections/VignettenSection.jsx
+++ b/src/sections/VignettenSection.jsx
@@ -4,7 +4,12 @@ import { getPageHeadingId } from '../utils/appHelpers';
 import { useAppState } from '../context/useAppState';
 
 export default function VignettenSection() {
-  const { currentVignette: currentIndex, setCurrentVignette: setCurrentIndex, selectedOption, handleSelectVignetteOption: onSelectOption } = useAppState();
+  const {
+    currentVignette: currentIndex,
+    setCurrentVignette: setCurrentIndex,
+    selectedOption,
+    handleSelectVignetteOption: onSelectOption,
+  } = useAppState();
   const vignette = VIGNETTEN[currentIndex];
 
   if (!vignette) return null;
@@ -49,8 +54,7 @@ export default function VignettenSection() {
     ? {
         label: 'Bestand',
         value: 'Ausgewählter Fall',
-        copy:
-          'Aktuell steht eine vertieft ausgearbeitete Vignette zur Reflexion bereit. Weitere Fälle zu anderen Entscheidungssituationen werden schrittweise ergänzt.',
+        copy: 'Aktuell steht eine vertieft ausgearbeitete Vignette zur Reflexion bereit. Weitere Fälle zu anderen Entscheidungssituationen werden schrittweise ergänzt.',
         tone: 'soft',
       }
     : {

--- a/src/styles/app-global.css
+++ b/src/styles/app-global.css
@@ -54,7 +54,6 @@
   animation: pageEnter var(--motion-slow) var(--motion-curve-standard) forwards;
 }
 
-
 @keyframes pageEnter {
   from {
     opacity: 0;
@@ -231,13 +230,13 @@
    * nachvollziehen koennen. tel:-Links sind ausgenommen, weil der
    * sichtbare Text bereits die Nummer ist.
    */
-  a[href^="http"]:not([href*="eltern-angehoerige-fa.netlify.app"])::after {
-    content: " (" attr(href) ")";
+  a[href^='http']:not([href*='eltern-angehoerige-fa.netlify.app'])::after {
+    content: ' (' attr(href) ')';
     font-size: 9pt;
     color: #333;
     word-break: break-all;
   }
-  a[href^="tel:"]::after {
+  a[href^='tel:']::after {
     content: none;
   }
 
@@ -273,7 +272,7 @@
    * Sinn.
    */
   button[aria-expanded],
-  .ui-chip[role="button"] {
+  .ui-chip[role='button'] {
     display: none !important;
   }
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -7,7 +7,12 @@
   --surface-accent-soft: #f1f3ce; /* use with --text-primary or --text-secondary; not for inverse text */
   --surface-info-soft: #edf3f8; /* use with --text-primary for informational highlights */
   --surface-danger-soft: #fff1eb; /* use with --text-danger for urgent but low-arousal states */
-  --surface-elevated: rgba(255, 250, 246, 0.86); /* nur auf hellen Flächen mit Luminanz > 0.7; sonst --surface-app nutzen */
+  --surface-elevated: rgba(
+    255,
+    250,
+    246,
+    0.86
+  ); /* nur auf hellen Flächen mit Luminanz > 0.7; sonst --surface-app nutzen */
 
   /* Inverse surfaces (dunkle Streifen wie Emergency-Banner). Gradient-Paar + Border-Partner. */
   --surface-inverse-top: #3f322b;

--- a/src/templates/EvidencePageTemplate.jsx
+++ b/src/templates/EvidencePageTemplate.jsx
@@ -113,7 +113,6 @@ function ChapterOverview({ chapterOverview }) {
           ) : null}
         </div>
       </Section>
-
     </>
   );
 }
@@ -130,11 +129,7 @@ function ZoneSection({ zone, defaultOpen = false }) {
     >
       <details className="ui-chapter-disclosure" open={defaultOpen || undefined}>
         <summary className="ui-chapter-disclosure__summary">
-          <SectionHeader
-            eyebrow={zone.eyebrow}
-            title={zone.title}
-            titleAccent={zone.accent}
-          />
+          <SectionHeader eyebrow={zone.eyebrow} title={zone.title} titleAccent={zone.accent} />
           <span className="ui-chapter-disclosure__indicator" aria-hidden="true" />
         </summary>
 
@@ -151,7 +146,11 @@ function ZoneSection({ zone, defaultOpen = false }) {
               eigenes Inline-Schema einfuehren. */}
 
           {zone.highlightList ? (
-            <BulletList items={zone.highlightList.items} tone={zone.highlightList.tone} icon={zone.highlightList.icon} />
+            <BulletList
+              items={zone.highlightList.items}
+              tone={zone.highlightList.tone}
+              icon={zone.highlightList.icon}
+            />
           ) : null}
           {zone.metrics?.length ? <MetricGrid items={zone.metrics} /> : null}
           {zone.cards?.length ? <CardGrid items={zone.cards} columns={zone.cardColumns} tone={zone.cardTone} /> : null}

--- a/src/templates/GlossarPageTemplate.jsx
+++ b/src/templates/GlossarPageTemplate.jsx
@@ -24,7 +24,9 @@ function GlossarGroup({ group }) {
                   <p className="ui-fact-card__label">Begriff</p>
                   <h3 className="ui-card__title">{entry.term}</h3>
                 </div>
-                <span className="ui-disclosure-card__toggle" aria-hidden="true">+</span>
+                <span className="ui-disclosure-card__toggle" aria-hidden="true">
+                  +
+                </span>
               </summary>
               <div className="ui-disclosure-card__content">
                 <p className="ui-card__copy">{entry.definition}</p>

--- a/src/templates/NetworkPageTemplate.jsx
+++ b/src/templates/NetworkPageTemplate.jsx
@@ -190,7 +190,13 @@ function ResourceDirectorySection({ directory }) {
                 <h3 className="ui-card__title">{resource.name}</h3>
                 <p className="ui-card__copy">{resource.description}</p>
                 <div className="ui-editorial-card__action">
-                  <Button href={resource.link} target="_blank" rel="noopener noreferrer" variant="subtle" aria-label={`${resource.name} – Webseite öffnen (neues Fenster)`}>
+                  <Button
+                    href={resource.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    variant="subtle"
+                    aria-label={`${resource.name} – Webseite öffnen (neues Fenster)`}
+                  >
                     Webseite öffnen <ExternalLink size={16} aria-hidden="true" />
                   </Button>
                 </div>
@@ -354,7 +360,11 @@ function NetworkMapSection({ mapping }) {
 
             <div className="ui-network-map-shell">
               <div>
-                <div className="ui-card--outline ui-network-map-stage is-desktop" role="img" aria-label="Netzwerkkarte: visuelle Darstellung der Bezugspersonen rund um Kind und Familie">
+                <div
+                  className="ui-card--outline ui-network-map-stage is-desktop"
+                  role="img"
+                  aria-label="Netzwerkkarte: visuelle Darstellung der Bezugspersonen rund um Kind und Familie"
+                >
                   <div className="ui-network-map-center-shell" aria-hidden="true" />
                   <div className="ui-network-map-center-orbit" aria-hidden="true" />
                   <div className="ui-network-map-ring" aria-hidden="true" />

--- a/src/templates/ToolboxPageTemplate.jsx
+++ b/src/templates/ToolboxPageTemplate.jsx
@@ -124,7 +124,9 @@ function PathwaySection({ pathway }) {
                     <div className="ui-toolbox-step__header">
                       <div className="ui-chip ui-chip--active ui-toolbox-step__chip">
                         <span className="ui-toolbox-step__chip-index">Schritt {index + 1}</span>
-                        <span className="ui-toolbox-step__chip-separator" aria-hidden="true">·</span>
+                        <span className="ui-toolbox-step__chip-separator" aria-hidden="true">
+                          ·
+                        </span>
                         <span className="ui-toolbox-step__chip-label">{step.label}</span>
                       </div>
                     </div>
@@ -242,7 +244,11 @@ function TriageSection({ triage }) {
               </div>
 
               {prompt.recommendation ? (
-                <div role="status" aria-live="polite" className={`ui-toolbox-feedback ui-editorial-card__action ${prompt.recommendation.className}`}>
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className={`ui-toolbox-feedback ui-editorial-card__action ${prompt.recommendation.className}`}
+                >
                   <div className="ui-note-panel__label">Einordnung</div>
                   <h4 className="ui-toolbox-feedback__title">{prompt.recommendation.title}</h4>
                   <p className="ui-toolbox-feedback__copy">{prompt.recommendation.text}</p>
@@ -437,7 +443,9 @@ function ClusterSection({ cluster }) {
                       {item.meta ? <p className="ui-fact-card__label ui-editorial-card__action">{item.meta}</p> : null}
                     </div>
                   </div>
-                  <span className="ui-toolbox-disclosure__toggle" aria-hidden="true">+</span>
+                  <span className="ui-toolbox-disclosure__toggle" aria-hidden="true">
+                    +
+                  </span>
                 </summary>
                 <div className="ui-copy ui-toolbox-disclosure__content">
                   {Array.isArray(item.content) ? (
@@ -499,9 +507,7 @@ function ClusterSection({ cluster }) {
           </div>
         ) : null}
 
-        {cluster.legalDisclaimer ? (
-          <LegalDisclaimer showCantonalNote={cluster.legalDisclaimerCantonal} />
-        ) : null}
+        {cluster.legalDisclaimer ? <LegalDisclaimer showCantonalNote={cluster.legalDisclaimerCantonal} /> : null}
       </div>
     </Section>
   );
@@ -544,9 +550,7 @@ export default function ToolboxPageTemplate({
               <div className="ui-card--outline ui-toolbox-quick-access">
                 <div className="ui-stack ui-stack--tight">
                   <Eyebrow>Schnellzugriff</Eyebrow>
-                  <h2 className="ui-hero__title ui-section-title--compact">
-                    Krisenplan und Arbeitsansicht
-                  </h2>
+                  <h2 className="ui-hero__title ui-section-title--compact">Krisenplan und Arbeitsansicht</h2>
                   <p className="ui-card__copy">
                     Die wichtigsten Arbeitsaktionen der Toolbox direkt erreichbar — auch für Tastatur- und
                     Screenreader-Nutzung.

--- a/src/utils/useDownloadHandlers.js
+++ b/src/utils/useDownloadHandlers.js
@@ -209,46 +209,55 @@ Aktueller Assessment-Score: ${scoreRisk}
     downloadTextFile('krisenplan-kompakt.txt', template);
   }, [scoreRisk]);
 
-  const downloadResources = useMemo(() => [
-    {
-      title: 'Gesprächsleitfaden für Fachpersonen',
-      description:
-        'Kurzblatt für Erstgespräch, Verlaufsgespräch oder Supervision mit Fokus auf Elternrolle, Versorgung, Netzwerk und nächsten Schritt.',
-      meta: ['TXT editierbar', 'Gespräch / Supervision'],
-      actionLabel: 'Leitfaden herunterladen',
-      onDownload: handleDownloadConversationGuide,
-    },
-    {
-      title: 'Netzwerkkarte als Arbeitsvorlage',
-      description:
-        'Strukturierte Vorlage für private Kontakte, Alltagsstützen, Fachstellen, Mitwissende und Versorgungslücken.',
-      meta: ['TXT editierbar', 'Vernetzung / Mapping'],
-      actionLabel: 'Netzwerkkarte herunterladen',
-      onDownload: handleDownloadNetworkMap,
-    },
-    {
-      title: 'Psychoedukations-Hilfe',
-      description:
-        'Kurzhilfe für Fachpersonen zum Sprechen mit Kindern über die psychische Erkrankung eines Elternteils.',
-      meta: ['TXT editierbar', 'Gespräch mit Kindern'],
-      actionLabel: 'Kurzhilfe herunterladen',
-      onDownload: handleDownloadPsychoeducationGuide,
-    },
-    {
-      title: 'Schutzfaktoren-Check',
-      description: 'Einseitige Versorgungsübersicht für Fallreflexion, Verlaufsbeobachtung und Supervision.',
-      meta: ['TXT editierbar', 'Schutz / Verlauf'],
-      actionLabel: 'Check herunterladen',
-      onDownload: handleDownloadProtectionChecklist,
-    },
-    {
-      title: 'Krisenplan kompakt',
-      description: 'Reduzierte Kurzvorlage für Mitgabe, Besprechung oder schnelle gemeinsame Krisenvorsorge.',
-      meta: ['TXT editierbar', 'Krise / Mitgabe'],
-      actionLabel: 'Kurzvorlage herunterladen',
-      onDownload: handleDownloadCompactCrisisSheet,
-    },
-  ], [handleDownloadConversationGuide, handleDownloadNetworkMap, handleDownloadPsychoeducationGuide, handleDownloadProtectionChecklist, handleDownloadCompactCrisisSheet]);
+  const downloadResources = useMemo(
+    () => [
+      {
+        title: 'Gesprächsleitfaden für Fachpersonen',
+        description:
+          'Kurzblatt für Erstgespräch, Verlaufsgespräch oder Supervision mit Fokus auf Elternrolle, Versorgung, Netzwerk und nächsten Schritt.',
+        meta: ['TXT editierbar', 'Gespräch / Supervision'],
+        actionLabel: 'Leitfaden herunterladen',
+        onDownload: handleDownloadConversationGuide,
+      },
+      {
+        title: 'Netzwerkkarte als Arbeitsvorlage',
+        description:
+          'Strukturierte Vorlage für private Kontakte, Alltagsstützen, Fachstellen, Mitwissende und Versorgungslücken.',
+        meta: ['TXT editierbar', 'Vernetzung / Mapping'],
+        actionLabel: 'Netzwerkkarte herunterladen',
+        onDownload: handleDownloadNetworkMap,
+      },
+      {
+        title: 'Psychoedukations-Hilfe',
+        description:
+          'Kurzhilfe für Fachpersonen zum Sprechen mit Kindern über die psychische Erkrankung eines Elternteils.',
+        meta: ['TXT editierbar', 'Gespräch mit Kindern'],
+        actionLabel: 'Kurzhilfe herunterladen',
+        onDownload: handleDownloadPsychoeducationGuide,
+      },
+      {
+        title: 'Schutzfaktoren-Check',
+        description: 'Einseitige Versorgungsübersicht für Fallreflexion, Verlaufsbeobachtung und Supervision.',
+        meta: ['TXT editierbar', 'Schutz / Verlauf'],
+        actionLabel: 'Check herunterladen',
+        onDownload: handleDownloadProtectionChecklist,
+      },
+      {
+        title: 'Krisenplan kompakt',
+        description: 'Reduzierte Kurzvorlage für Mitgabe, Besprechung oder schnelle gemeinsame Krisenvorsorge.',
+        meta: ['TXT editierbar', 'Krise / Mitgabe'],
+        actionLabel: 'Kurzvorlage herunterladen',
+        onDownload: handleDownloadCompactCrisisSheet,
+      },
+    ],
+    [
+      handleDownloadConversationGuide,
+      handleDownloadNetworkMap,
+      handleDownloadPsychoeducationGuide,
+      handleDownloadProtectionChecklist,
+      handleDownloadCompactCrisisSheet,
+    ]
+  );
 
   return {
     handleDownloadCrisisPlan,


### PR DESCRIPTION
## Summary

- Reine Prettier-Angleichung von 20 Dateien im `src/`-Baum (+186/-165, keine Semantik-Änderung)
- Anlass: `npm run format:check` zeigte 20 Drifter — mehrere Stellen waren unnötig auf 3 Zeilen umbrochen, obwohl sie `printWidth: 120` unterschreiten
- Ziel: sauberer Baseline-Zustand, damit künftige PRs nur ihre eigenen Diffs erzeugen und `format:check` als Grundlage für ein späteres CI- oder Pre-Commit-Gate taugt

## Scope

20 Dateien unter `src/`: `App.jsx`, `ErrorBoundary.jsx`, `Footer.jsx`, `ui/AsideCard.jsx`, `ui/Section.jsx`, `ui/SectionHeader.jsx`, `context/AppStateContext.jsx`, `data/{evidence,fachstellen,glossary,sources}Content.js`, `sections/{Toolbox,Vignetten}Section.jsx`, `styles/{app-global,tokens}.css`, `templates/{Evidence,Glossar,Network,Toolbox}PageTemplate.jsx`, `utils/useDownloadHandlers.js`

Ausserhalb von `src/`: nichts (prerender-HTML, Konfigs, Docs unberührt).

## Test plan

- [x] `npm run lint` → 0 Warnings
- [x] `npm run format:check` → "All matched files use Prettier code style!"
- [x] `npm run build` → erfolgreich (1722 Module, 3.45s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)