### PR TITLE
ci(actions): lint + format:check + build als Gate auf main einfuehren

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+# CI-Gate fuer Relational Recovery.
+#
+# Laeuft auf jedem PR gegen main und auf direkten Pushes nach main.
+# Ziel: verhindern, dass Lint-, Format- oder Build-Regressions unbemerkt
+# landen. Spiegelt die Checks, die ich lokal vor jedem PR laufe.
+#
+# Node-Version: 22.x (current LTS, maintained bis April 2027). Vite 7
+# verlangt Node 20.19+ oder 22.12+, deshalb keine aelteren Linien.
+#
+# Was NICHT hier drin ist (bewusst):
+# - Playwright-E2E: separater Scope, eigene Entscheidung noetig zu
+#   Browser-Install, Artefakt-Upload und Flakiness-Budget.
+# - Secrets/Netlify-Deploy: Netlify baut eh bei jedem main-Push selbst;
+#   dieser Workflow ist reiner Integritaets-Gate, kein Deploy-Pfad.
+# - VITE_BASE_URL: scripts/replace-env.mjs faengt den fehlenden Wert ab
+#   und ersetzt zur Build-Zeit mit dem Netlify-Default. Deshalb kein
+#   env-Block hier.
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Nebenlaeufige Runs auf demselben Branch abbrechen -- sparst Minuten,
+# wenn schnell hintereinander gepusht wird.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lint, Format, Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: ESLint
+        run: npm run lint
+
+      - name: Prettier format check
+        run: npm run format:check
+
+      - name: Production build
+        run: npm run build


### PR DESCRIPTION
## Summary

- Neuer GitHub-Actions-Workflow `.github/workflows/ci.yml`
- Triggert auf Pull Requests gegen `main` und Pushes nach `main`
- Drei Checks: `npm run lint`, `npm run format:check`, `npm run build`
- Node 22.x (aktuelle LTS), mit npm-Cache gegen `package-lock.json`

## Warum jetzt?

Bis gestern gab es weder CI noch Pre-Commit-Hook. In Folge waren 20 Quelldateien Prettier-seitig gedriftet (repariert in #98). Dieser Workflow macht das Wieder-Driften erkennbar, bevor es auf `main` landet — spiegelt genau die Checks, die ich lokal vor jedem PR manuell laufe.

## Entwurfsentscheidungen

- **Node 22.x**: current LTS (bis April 2027); Vite 7 verlangt ≥22.12 oder ≥20.19
- **`concurrency` mit `cancel-in-progress`**: schnelle Folgepushes brechen den vorherigen Run ab → Minuten-Ersparnis
- **`timeout-minutes: 10`**: Obergrenze gegen hängende Runs
- **Kein Playwright-E2E**: eigener Scope, separate Diskussion nötig (Browser-Install, Artefakt-Upload, Flakiness-Budget)
- **Kein Netlify-Deploy-Schritt**: Netlify baut ohnehin bei jedem `main`-Push selbst; dieser Workflow ist reiner Integritäts-Gate
- **Kein `VITE_BASE_URL`-Secret nötig**: `scripts/replace-env.mjs` hat einen Fallback auf die Netlify-Default-URL

## Bewusst NICHT in diesem PR

- **Branch Protection**: das ist eine GitHub-UI-Einstellung, kein YAML. Empfehlung: aktivieren, sobald der Workflow ein paar Mal grün durchgelaufen ist, damit der Check verbindlich wird.

## Test plan

- [x] YAML strukturell valid (PyYAML parse, alle erwarteten Keys)
- [ ] Der Workflow läuft gegen diesen PR selbst → sollte grün sein (sonst nicht mergen)
- [ ] Nach Merge: Run auf `main`-Push → sollte ebenfalls grün sein

🤖 Generated with [Claude Code](https://claude.com/claude-code)