### PR TITLE
fix(content): vier Audit-Welle-2-Defekte (Priority 1) bereinigen

### DIFF
--- a/src/data/fachstellenContent.js
+++ b/src/data/fachstellenContent.js
@@ -117,7 +117,7 @@ export const FACHSTELLEN = [
     name: 'SafeZone',
     description: 'Kostenlose und anonyme Online-Suchtberatung für Betroffene, Angehörige und Nahestehende.',
     link: 'https://www.safezone.ch/de/',
-    tags: ['Sucht', 'anonym', 'kostenlos', 'online'],
+    tags: ['Sucht', 'anonym', 'kostenlos'],
   },
   {
     id: 'stiftung-windlicht',
@@ -152,7 +152,7 @@ export const FACHSTELLEN = [
     description:
       'Schweizer Jugendportal mit Informationen, Hilfsangeboten und Orientierung für psychische Gesundheit und Krisen.',
     link: 'https://www.feel-ok.ch/de_CH/jugendliche/uebersicht.cfm',
-    tags: ['Jugendliche', 'online', 'kostenlos'],
+    tags: ['Jugendliche', 'kostenlos'],
   },
   {
     id: 'selbsthilfe-zh',

--- a/src/data/glossaryContent.js
+++ b/src/data/glossaryContent.js
@@ -213,7 +213,7 @@ export const GLOSSARY_GROUPS = [
         definition:
           'Wenn nach einer ersten Klärung oder Behandlung die passende weiterführende Stelle gefunden und der Übergang organisiert wird.',
         practice:
-          'Tragfaehig wird Weitervermittlung erst, wenn Ansprechpartner, Schwelle, Erreichbarkeit und nächster Schritt konkret benannt sind.',
+          'Tragfähig wird Weitervermittlung erst, wenn Ansprechpartner, Schwelle, Erreichbarkeit und nächster Schritt konkret benannt sind.',
       },
       {
         id: 'netzwerkkarte',

--- a/src/data/grundlagenContent.js
+++ b/src/data/grundlagenContent.js
@@ -102,7 +102,7 @@ export const GRUNDLAGEN_CLUSTERS = [
       {
         question: 'Hilft es, alles möglichst ruhig zu halten, damit nichts eskaliert?',
         answer:
-          'Kurzfristig kann Deeskalation sinnvoll sein. Langfristig führt ein dauerhaftes Ausweichen jedoch oft dazu, dass Angehörige immer mehr Spannung mittragen, während wichtige Themen unbesprechbar werden. Tragfaehiger ist meist eine Kombination aus ruhigem Ton, klaren Grenzen und kleinen, konkret vereinbarten Schritten.',
+          'Kurzfristig kann Deeskalation sinnvoll sein. Langfristig führt ein dauerhaftes Ausweichen jedoch oft dazu, dass Angehörige immer mehr Spannung mittragen, während wichtige Themen unbesprechbar werden. Tragfähiger ist meist eine Kombination aus ruhigem Ton, klaren Grenzen und kleinen, konkret vereinbarten Schritten.',
       },
     ],
   },
@@ -221,6 +221,7 @@ export const GRUNDLAGEN_CLUSTERS = [
           'Am hilfreichsten ist, das Kind zu bitten, das Gehörte in eigenen Worten wiederzugeben — nicht als Test, sondern als Einladung: «Magst du mir erzählen, was du jetzt verstanden hast?» Dabei nicht nur auf den Inhalt achten, sondern auch auf Mimik, Tonfall und Körpersprache. Wenn das Kind echohaft nachspricht oder ausweicht, braucht es vielleicht eine Pause oder eine andere Erklärung. Wichtig: Psychoedukation ist kein einmaliges Gespräch, sondern ein fortlaufender Prozess — Kinder kommen mit neuen Fragen zurück, wenn sie bereit sind.',
       },
       {
+        question: 'Was tue ich, wenn mein Kind sich für meine Erkrankung schuldig fühlt?',
         answer:
           'Viele Kinder vermuten, dass sie durch ihr Verhalten die Erkrankung verursacht oder verschlimmert haben — insbesondere jüngere Kinder mit stark magischem Denken. Es ist wichtig, dem Kind klar zu sagen, dass es nicht schuld ist. Auch wenn es sich schlecht benommen hat, einen Streit ausgelöst hat oder zu wenig geholfen hat: die Krankheit hat andere Ursachen.',
       },


### PR DESCRIPTION
## Summary

Drei mechanische Content-Fixes aus dem Content-Audit Wave 1 (Breiter Sweep über alle `data/`-Dateien). Ursprünglich vier Baustellen gemeldet, **A3 nach Verifikation als Agent-Halluzination verworfen** — Elternnotruf hat `audience`+`category` gesetzt und ist in `SUPPORT_OFFER_IDS` enthalten.

## Fixes

### A1 · FAQ ohne Frage-Feld

**`grundlagenContent.js` Z. 222** — ein FAQ-Eintrag zu Schuldgefühlen des Kindes hatte nur `answer:`, kein `question:`. Vermutlich beim Redigieren verloren gegangen. Rendering war potenziell kaputt (Antwort ohne Frage darüber).

Neue Frage: *„Was tue ich, wenn mein Kind sich für meine Erkrankung schuldig fühlt?"* — folgt dem Muster der Nachbar-FAQs (Angehörigen-Ich-Perspektive) und adressiert genau den Inhalt der Antwort (magisches Denken, Entlastung).

### A2 · Encoding-Fehler "Tragfaehig"

Zwei Stellen mit fehlendem Umlaut, vermutlich Rest aus einer früheren ASCII-Konversion:
- `grundlagenContent.js` Z. 105: *„Tragfaehiger"* → *„Tragfähiger"*
- `glossaryContent.js` Z. 216: *„Tragfaehig"* → *„Tragfähig"*

### A4 · Tote `'online'`-Tags

`fachstellenContent.js` — zwei Einträge (SafeZone Z. 120, feel-ok Z. 155) trugen Tag `'online'`, der in `NETWORK_FILTERS` (networkContent.js Z. 23–38) nicht definiert ist. Filter greift nicht, Tag ist toter Ballast.

Entfernt, statt neu als Filter-Chip einzuführen — letzteres wäre UX-Entscheidung, nicht Cleanup. Die Online-Natur beider Angebote steht ohnehin im `description`-Feld.

## Diff-Umfang

3 Dateien, +5/-4. Kein einziger Dependency-/Config-Touch. Minimal möglich.

## Nicht in diesem PR (bewusst zurückgestellt)

Aus Wave 1 weiterhin offen, nach Priorität:

**Priorität 2 — Content-Wellen mit Auftraggeberin-Rücksprache:**
- Geografische Zürich-Lastigkeit des Fachstellen-Verzeichnisses (12 von 19 Einträgen)
- Stub-Vignetten V2/V3 in `learningContent.js`
- Fachvokabular-Drift im Grundlagen-Tab („Trialog", „Fallkoordination", „Psychoedukation" ohne Erklärung)

**Priorität 3 — IA-Refaktor:**
- Pro-Mente-Sana/147-Cross-Tab-Doppelung zwischen `networkContent.js` und `fachstellenContent.js`
- Grundlagen-Cluster 4/5/6-Redundanz (Kinder-Aufklärung aus drei Perspektiven)
- Evidenz-4-Listen-Dualität (`PARENT_EXPERIENCE_PANELS/POINTS/PRACTICE_POINTS/SELF_HELP_POINTS`)
- Plass/Wiegand-Grefe Duplikation (bereits dokumentiert als wartend auf Auftraggeberin)

## Test plan

- [x] `npm run lint` → 0 Warnings
- [x] `npm run format:check` → clean
- [x] `npm run build` → erfolgreich
- [ ] CI-Gate (Workflow läuft auf diesen PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)