### PR TITLE
feat(material): Krisenplan-Handout + Hybrid-Block-Struktur

### DIFF
--- a/e2e/navigation.spec.js
+++ b/e2e/navigation.spec.js
@@ -177,6 +177,22 @@ test.describe('Logo / Home Navigation', () => {
   });
 });
 
+test.describe('Material Handouts', () => {
+  test('crisis-plan handout renders on Material tab', async ({ page }) => {
+    await page.addInitScript(() => localStorage.clear());
+    await page.goto('/#material');
+
+    // Handout-Artikel muss sichtbar sein (Tier-1: Krisenplan "Mein Notfallplan")
+    const handout = page.locator('#material-handout-mein-notfallplan');
+    await expect(handout).toBeVisible({ timeout: 10_000 });
+    await expect(handout).toContainText('Mein Notfallplan');
+
+    // Notfallnummern müssen als Handout-Anker enthalten sein
+    await expect(handout).toContainText('144');
+    await expect(handout).toContainText('147');
+  });
+});
+
 test.describe('Emergency Access', () => {
   test('emergency button exists and navigates to Toolbox', async ({ page }) => {
     await page.addInitScript(() => localStorage.clear());

--- a/src/data/materialContent.js
+++ b/src/data/materialContent.js
@@ -70,6 +70,141 @@ export const MATERIAL_INTRO = {
   ],
 };
 
+// Handout-Block: neue Gliederungsebene unterhalb der FAQ-Cluster, eingefuehrt
+// nach Issue #104 (Handout-Offensive) + #107 (Krisenplan als Tier-1). Hybrid-
+// Pfad: FAQ-Anker bleibt, Handouts kommen als zweiter Block darunter. Block-
+// Rahmung bewusst ruhig, damit das erste Handout (Krisenplan) visuell fuehrt
+// und nicht in einer generischen Ueberschrift untergeht.
+export const MATERIAL_HANDOUTS_BLOCK = {
+  eyebrow: 'Handouts',
+  title: 'Material zum Ausfüllen, Mitgeben und Besprechen',
+  description:
+    'Diese Vorlagen begleiten konkrete Gespräche in der Familie. Sie sind als Struktur gedacht, nicht als Checkliste — und werden am besten gemeinsam ausgefüllt.',
+};
+
+// Tier-1-Handout: Kind-orientierter Krisenplan als Gegenstueck zum fachlichen
+// Toolbox-Sicherheitsplan (SAFETY_PLAN_TEMPLATE_FIELDS). Perspektive: Kind
+// (Ich-Form), eine Seite, altersgerechte Felder. Inhaltlich fundiert auf
+// FAQ 4.8 (Cluster 4 Krisenplan-Empfehlung) und evidenceContent.js (Abschnitt
+// "Krisenplan / Notfallplan"). Quellenbindung: Lenz & Brockmann (2010),
+// referenziert in Stauber et al. (2018) Kap. 6.2 -- identisch mit der Quellen-
+// grundlage des Toolbox-Sicherheitsplans, bewusst geteilt.
+export const MATERIAL_HANDOUTS = [
+  {
+    id: 'material-handout-mein-notfallplan',
+    kind: 'crisis-plan',
+    eyebrow: 'Handout für Kinder',
+    title: 'Mein Notfallplan',
+    description:
+      'Ein einseitiger Plan für Kinder in Familien, in denen ein Elternteil psychisch erkrankt ist. Er wird gemeinsam in einer stabilen Phase ausgefüllt und bleibt beim Kind.',
+    usage: {
+      when: 'In einer stabilen Phase — nicht in der Krise. Der Plan ist ein Gespräch, nicht ein Formular.',
+      people:
+        'Kind + ein betreuender Elternteil oder eine Fachperson + die Vertrauensperson, wenn möglich. Die Vertrauensperson muss vorher wissen und zustimmen.',
+      validity:
+        'Ein Krisenplan altert. Mindestens einmal pro Jahr gemeinsam durchgehen. Bei wichtigen Veränderungen (Umzug, neue Vertrauensperson, veränderte Erkrankung) sofort anpassen.',
+      where:
+        'Eine Kopie beim Kind (sichtbar, nicht versteckt). Eine Kopie bei der Vertrauensperson. Optional beim Behandlungsteam des erkrankten Elternteils.',
+    },
+    header: {
+      ownerLabel: 'Dieser Plan gehört',
+      dateLabel: 'Datum der Erstellung',
+      revisedLabel: 'Zuletzt überarbeitet',
+    },
+    sections: [
+      {
+        id: 'material-handout-crisis',
+        title: 'Krisenplan',
+        fields: [
+          {
+            title: 'Wer hilft mir, wenn es zu Hause gerade nicht gut ist?',
+            hint: 'Eine Vertrauensperson ausserhalb des Haushalts. Jemand, den das Kind gut kennt und ohne Angst anrufen kann. Oft Grossmutter, Tante, Göttin, Nachbarin — nicht immer die «offensichtliche» Person, sondern die, zu der das Kind echten Kontakt hat.',
+            example: 'Wenn es zu Hause schwierig wird, kann ich Tante Sara anrufen.',
+          },
+          {
+            title: 'Wie erreiche ich sie?',
+            hint: 'Telefonnummer(n), Adresse, wie das Kind dahin kommt. Mehrere Wege, falls einer nicht funktioniert.',
+            example:
+              'Sara hat die Nummer 079 …. Wenn sie nicht rangeht, schreibe ich ihr eine Nachricht. Ihre Adresse: Musterstrasse 3, das ist zehn Minuten zu Fuss von uns.',
+          },
+          {
+            title: 'Wann rufe ich sie an?',
+            hint: 'Konkrete Beispiele, keine abstrakten Regeln. Je jünger das Kind, desto beobachtbarer müssen die Anlässe sein.',
+            example:
+              'Wenn Mama seit dem Morgen nicht aufsteht und es Mittag ist. Wenn Papa Dinge sagt, die mir Angst machen. Wenn ich alleine bin und nicht weiss, was ich tun soll.',
+          },
+          {
+            title: 'Was tut sie für mich?',
+            hint: 'Was wurde mit der Vertrauensperson vorher besprochen? Was darf das Kind erwarten? Nicht offenlassen, sondern vorab klären.',
+            example:
+              'Sara kommt vorbei oder holt mich ab. Bei ihr kann ich übernachten. Sie ruft Oma an, wenn etwas Wichtiges ist.',
+          },
+          {
+            title: 'Wenn ich meine erste Person nicht erreiche',
+            hint: 'Eine zweite Person als Backup. Mindestens eine Ersatz-Option, falls die erste nicht verfügbar ist. Ohne Backup ist der Plan fragil.',
+            example: 'Dann rufe ich Oma an: 044 ….',
+          },
+        ],
+        emergency: {
+          title: 'Wenn es wirklich dringend ist',
+          intro: 'Diese Nummern gelten immer — auch wenn ich niemanden sonst erreiche:',
+          items: [
+            {
+              number: '144',
+              description: 'wenn jemand in Lebensgefahr ist. Kommt sofort, wie bei einem schlimmen Unfall.',
+            },
+            {
+              number: '147',
+              description: 'wenn ich mit jemandem reden will, der mir zuhört und hilft. Tag und Nacht, gratis.',
+            },
+          ],
+        },
+      },
+      {
+        id: 'material-handout-everyday',
+        title: 'Was mir im Alltag hilft',
+        fields: [
+          {
+            title: 'Was die Schule oder der Kindergarten weiss',
+            hint: 'Vorab-Absprache: Wer an der Schule oder im Kindergarten weiss, dass das Kind in einer belasteten Familiensituation lebt? An wen darf das Kind sich dort wenden? Darf die Vertrauensperson bei Bedarf dort abholen?',
+            example: 'Frau Müller weiss Bescheid. Ich kann zu ihr, wenn etwas ist.',
+          },
+          {
+            title: 'Was mir sonst noch hilft',
+            hint: 'Selbstberuhigung. Was macht das Kind, wenn die Situation noch nicht ganz so schlimm ist, aber schwierig? Eigene Ressourcen sichtbar machen.',
+            example: 'Ich höre meine Lieblingsmusik. Ich gehe zu meinem Plüschtier. Ich atme dreimal langsam.',
+          },
+        ],
+      },
+    ],
+    footer:
+      'Dieser Plan gehört mir. Ich kann ihn lesen, wann ich will. Er wird manchmal angepasst, wenn sich etwas ändert.',
+    disclaimer:
+      'Dieser Plan ist eine Orientierungsvorlage. Er ersetzt weder eine individuelle klinische Einschätzung noch eine Kindeswohlabklärung. In akuten Gefährdungssituationen gilt immer zuerst die Notfallnummer 144. Fachliche Begleitung beim Erstellen bieten z. B. das kjz, die PUK Zürich oder Pro Mente Sana.',
+    crossRefs: {
+      title: 'Verwandte Inhalte',
+      items: [
+        {
+          kind: 'faq',
+          label: 'Aus dem FAQ: «Was braucht mein Kind, wenn ich in einer akuten Krankheitsphase bin?»',
+          anchor: '#material-kinder',
+        },
+        {
+          kind: 'toolbox',
+          label: 'Fachperson-Perspektive: Sicherheitsplan in der Toolbox',
+          target: 'toolbox',
+          anchor: '#safety-plan',
+        },
+        {
+          kind: 'evidence',
+          label: 'Fachlicher Hintergrund: Krisenplan und Schutzfaktoren im Evidenzbereich',
+          target: 'evidenz',
+        },
+      ],
+    },
+  },
+];
+
 export const MATERIAL_CLUSTERS = [
   {
     id: 'material-verstehen',

--- a/src/sections/MaterialSection.jsx
+++ b/src/sections/MaterialSection.jsx
@@ -1,5 +1,11 @@
 import MaterialPageTemplate from '../templates/MaterialPageTemplate';
-import { MATERIAL_CLUSTERS, MATERIAL_HERO, MATERIAL_INTRO } from '../data/materialContent';
+import {
+  MATERIAL_CLUSTERS,
+  MATERIAL_HANDOUTS,
+  MATERIAL_HANDOUTS_BLOCK,
+  MATERIAL_HERO,
+  MATERIAL_INTRO,
+} from '../data/materialContent';
 import { createClosingSectionModel } from '../utils/closingModel';
 import { getPageHeadingId } from '../utils/appHelpers';
 import { useAppState } from '../context/useAppState';
@@ -99,6 +105,9 @@ export default function MaterialSection({ sharedDownloadResources = [] }) {
       pageHeadingId={getPageHeadingId('material')}
       intro={MATERIAL_INTRO}
       clusters={MATERIAL_CLUSTERS}
+      handoutsBlock={MATERIAL_HANDOUTS_BLOCK}
+      handouts={MATERIAL_HANDOUTS}
+      onNavigate={onNavigateToTab}
       closingSection={closingSection}
     />
   );

--- a/src/sections/ToolboxSection.jsx
+++ b/src/sections/ToolboxSection.jsx
@@ -180,7 +180,7 @@ export default function ToolboxSection({
   rightsSectionRef,
   onJumpToPrioritySection,
 }) {
-  const { score, handleScoreChange: onToggleAssessment, resetScore: onResetAssessment } = useAppState();
+  const { score, handleScoreChange: onToggleAssessment, resetScore: onResetAssessment, navigate } = useAppState();
   const pageHeadingId = getPageHeadingId('toolbox');
   const [triageAnswers, setTriageAnswers] = useState({});
   const [activePracticeFilter, setActivePracticeFilter] = useState('all');
@@ -414,6 +414,15 @@ export default function ToolboxSection({
             icon: <Printer size={16} aria-hidden="true" />,
             variant: 'secondary',
           },
+          // Rueckverlink auf das kind-orientierte Pendant im Material-Tab
+          // (`#material-handout-mein-notfallplan`). Der hiesige Sicherheitsplan
+          // ist bewusst fachperson-orientiert; das Material-Handout ist die
+          // Ich-Form-Variante fuer Gespraeche mit Kind und Angehoerigen.
+          {
+            label: 'Kindgerechte Variante im Material-Tab',
+            onClick: () => navigate('material', { focusTarget: 'heading' }),
+            variant: 'subtle',
+          },
         ],
         listCards: SAFETY_PLAN_POINTS.map((item, index) => ({
           title: `Baustein ${index + 1}`,
@@ -509,6 +518,7 @@ export default function ToolboxSection({
       safetyPlanSectionRef,
       onDownloadCrisisPlan,
       onPrint,
+      navigate,
     ]
   );
 

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -2199,6 +2199,249 @@
   border-bottom: 1px solid var(--border-default);
 }
 
+/* Material-Handout: Kind-orientierter Krisenplan und weitere Handouts. Bewusst
+   eigener Namespace (nicht ui-toolbox-template), damit der Material-Handout
+   visuell vom fachlichen Toolbox-Sicherheitsplan unterscheidbar bleibt --
+   weicherer Surface-Mix, ruhigere Abstaende, gemeinsame Linien-Tokens. */
+.ui-material-handouts-grid {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.ui-material-handout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: clamp(var(--space-5), 2.5vw, var(--space-6));
+  border: 1px solid var(--border-subtle);
+  border-radius: calc(var(--radius-xl) + 0.5rem);
+  background: var(--surface-panel);
+}
+
+.ui-material-handout__head {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.ui-material-handout__title {
+  margin: 0;
+  font-size: clamp(1.35rem, 2vw, 1.6rem);
+  line-height: var(--line-height-heading);
+}
+
+.ui-material-handout__lead {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-copy);
+}
+
+.ui-material-handout__usage {
+  display: grid;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  background: var(--surface-app);
+}
+
+.ui-material-handout__usage-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.ui-material-handout__usage-item > p:last-child {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+}
+
+.ui-material-handout__ownership {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.ui-material-handout__ownership-meta {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.ui-material-handout__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.ui-material-handout__section-title {
+  margin: 0;
+  font-size: clamp(1.1rem, 1.6vw, 1.25rem);
+  line-height: var(--line-height-heading);
+}
+
+.ui-material-handout__fields {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.ui-material-handout__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: 1.25rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: calc(var(--radius-lg) + 0.25rem);
+  background: var(--surface-app);
+}
+
+.ui-material-handout__field--inline {
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: 1rem 1.25rem;
+}
+
+.ui-material-handout__field-title {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  line-height: var(--line-height-heading);
+}
+
+.ui-material-handout__field-hint {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+}
+
+.ui-material-handout__field-example {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+}
+
+.ui-material-handout__lines {
+  display: grid;
+  gap: var(--space-3);
+  margin-top: 0.75rem;
+}
+
+.ui-material-handout__line {
+  height: 1.75rem;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.ui-material-handout__emergency {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-4);
+  border-radius: var(--radius-lg);
+  background: var(--surface-note);
+  color: var(--accent-primary-strong);
+}
+
+.ui-material-handout__emergency-title {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: 700;
+  line-height: var(--line-height-heading);
+}
+
+.ui-material-handout__emergency-intro {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+}
+
+.ui-material-handout__emergency-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.ui-material-handout__emergency-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: baseline;
+  gap: var(--space-4);
+}
+
+.ui-material-handout__emergency-number {
+  font-size: clamp(1.4rem, 2vw, 1.6rem);
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.ui-material-handout__emergency-desc {
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+}
+
+.ui-material-handout__foot {
+  margin: 0;
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+}
+
+.ui-material-handout__foot p {
+  margin: 0;
+}
+
+.ui-material-handout__disclaimer {
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  background: var(--surface-app);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+}
+
+.ui-material-handout__disclaimer p {
+  margin: 0;
+}
+
+.ui-material-handout__cross-refs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.ui-material-handout__cross-refs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.ui-material-handout__cross-ref-link {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: var(--accent-primary-strong);
+  font-size: var(--font-size-sm);
+  text-align: left;
+  cursor: pointer;
+}
+
+.ui-material-handout__cross-ref-link:hover,
+.ui-material-handout__cross-ref-link:focus-visible {
+  text-decoration: underline;
+}
+
 .ui-toolbox-quick-access {
   border-radius: calc(var(--radius-xl) + 0.25rem);
   background: var(--surface-app);
@@ -2377,6 +2620,19 @@
   .ui-toolbox-template__grid {
     grid-template-columns: minmax(0, 1.2fr) minmax(17rem, 0.8fr);
   }
+
+  .ui-material-handout__usage {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ui-material-handout__ownership {
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1.8fr);
+    align-items: end;
+  }
+
+  .ui-material-handout__ownership-meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (min-width: 64rem) {
@@ -2416,6 +2672,10 @@
     flex-direction: row;
     align-items: end;
     justify-content: space-between;
+  }
+
+  .ui-material-handout__usage {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }
 

--- a/src/templates/MaterialPageTemplate.jsx
+++ b/src/templates/MaterialPageTemplate.jsx
@@ -51,7 +51,199 @@ function MaterialCluster({ cluster }) {
   );
 }
 
-export default function MaterialPageTemplate({ hero, pageHeadingId, intro, clusters = [], closingSection = null }) {
+function MaterialHandoutField({ field }) {
+  return (
+    <section className="ui-material-handout__field">
+      <h5 className="ui-material-handout__field-title">{field.title}</h5>
+      <p className="ui-material-handout__field-hint">{field.hint}</p>
+      {field.example ? (
+        <p className="ui-material-handout__field-example">
+          <em>Beispiel: {field.example}</em>
+        </p>
+      ) : null}
+      <div aria-hidden="true" className="ui-material-handout__lines">
+        <div className="ui-material-handout__line" />
+        <div className="ui-material-handout__line" />
+        <div className="ui-material-handout__line" />
+      </div>
+    </section>
+  );
+}
+
+function MaterialHandoutEmergency({ emergency }) {
+  return (
+    <section
+      className="ui-material-handout__emergency"
+      aria-labelledby={`${emergency.titleId || 'handout-emergency'}-title`}
+    >
+      <h5 id={`${emergency.titleId || 'handout-emergency'}-title`} className="ui-material-handout__emergency-title">
+        {emergency.title}
+      </h5>
+      <p className="ui-material-handout__emergency-intro">{emergency.intro}</p>
+      <ul className="ui-material-handout__emergency-list">
+        {emergency.items.map((item) => (
+          <li key={item.number} className="ui-material-handout__emergency-item">
+            <span className="ui-material-handout__emergency-number">{item.number}</span>
+            <span className="ui-material-handout__emergency-desc">{item.description}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function MaterialHandoutCrossRefs({ crossRefs, onNavigate }) {
+  if (!crossRefs?.items?.length) return null;
+
+  return (
+    <aside className="ui-material-handout__cross-refs" aria-label={crossRefs.title}>
+      <p className="ui-fact-card__label">{crossRefs.title}</p>
+      <ul className="ui-material-handout__cross-refs-list">
+        {crossRefs.items.map((ref) => {
+          if (ref.target) {
+            return (
+              <li key={ref.label}>
+                <button
+                  type="button"
+                  className="ui-link ui-material-handout__cross-ref-link"
+                  onClick={() => onNavigate?.(ref.target, { focusTarget: 'heading' })}
+                >
+                  {ref.label}
+                </button>
+              </li>
+            );
+          }
+          return (
+            <li key={ref.label}>
+              <a href={ref.anchor} className="ui-link ui-material-handout__cross-ref-link">
+                {ref.label}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </aside>
+  );
+}
+
+function MaterialCrisisPlan({ handout, onNavigate }) {
+  return (
+    <article id={handout.id} className="ui-material-handout ui-section-anchor-offset">
+      <header className="ui-material-handout__head">
+        <p className="ui-fact-card__label">{handout.eyebrow}</p>
+        <h3 className="ui-material-handout__title">{handout.title}</h3>
+        <p className="ui-material-handout__lead">{handout.description}</p>
+      </header>
+
+      <div className="ui-material-handout__usage" aria-label="Hinweise zur Nutzung">
+        <div className="ui-material-handout__usage-item">
+          <p className="ui-fact-card__label">Wann</p>
+          <p>{handout.usage.when}</p>
+        </div>
+        <div className="ui-material-handout__usage-item">
+          <p className="ui-fact-card__label">Mit wem</p>
+          <p>{handout.usage.people}</p>
+        </div>
+        <div className="ui-material-handout__usage-item">
+          <p className="ui-fact-card__label">Wie lange gilt er</p>
+          <p>{handout.usage.validity}</p>
+        </div>
+        <div className="ui-material-handout__usage-item">
+          <p className="ui-fact-card__label">Wohin damit</p>
+          <p>{handout.usage.where}</p>
+        </div>
+      </div>
+
+      <div className="ui-material-handout__ownership">
+        <div className="ui-material-handout__field ui-material-handout__field--inline">
+          <h5 className="ui-material-handout__field-title">{handout.header.ownerLabel}</h5>
+          <div aria-hidden="true" className="ui-material-handout__lines">
+            <div className="ui-material-handout__line" />
+          </div>
+        </div>
+        <div className="ui-material-handout__ownership-meta">
+          <div className="ui-material-handout__field ui-material-handout__field--inline">
+            <h5 className="ui-material-handout__field-title">{handout.header.dateLabel}</h5>
+            <div aria-hidden="true" className="ui-material-handout__lines">
+              <div className="ui-material-handout__line" />
+            </div>
+          </div>
+          <div className="ui-material-handout__field ui-material-handout__field--inline">
+            <h5 className="ui-material-handout__field-title">{handout.header.revisedLabel}</h5>
+            <div aria-hidden="true" className="ui-material-handout__lines">
+              <div className="ui-material-handout__line" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {handout.sections.map((section) => (
+        <section key={section.id} id={section.id} className="ui-material-handout__section">
+          <h4 className="ui-material-handout__section-title">{section.title}</h4>
+          <div className="ui-material-handout__fields">
+            {section.fields.map((field) => (
+              <MaterialHandoutField key={field.title} field={field} />
+            ))}
+          </div>
+          {section.emergency ? (
+            <MaterialHandoutEmergency emergency={{ ...section.emergency, titleId: `${section.id}-emergency` }} />
+          ) : null}
+        </section>
+      ))}
+
+      {handout.footer ? (
+        <footer className="ui-material-handout__foot">
+          <p>{handout.footer}</p>
+        </footer>
+      ) : null}
+
+      {handout.disclaimer ? (
+        <div className="ui-material-handout__disclaimer" role="note">
+          <p>{handout.disclaimer}</p>
+        </div>
+      ) : null}
+
+      <MaterialHandoutCrossRefs crossRefs={handout.crossRefs} onNavigate={onNavigate} />
+    </article>
+  );
+}
+
+function MaterialHandoutSwitch({ handout, onNavigate }) {
+  switch (handout.kind) {
+    case 'crisis-plan':
+      return <MaterialCrisisPlan handout={handout} onNavigate={onNavigate} />;
+    default:
+      return null;
+  }
+}
+
+function MaterialHandoutsSection({ block, handouts, onNavigate }) {
+  if (!block || !handouts?.length) return null;
+
+  return (
+    <Section spacing="tight" surface="plain">
+      <div className="ui-stack ui-stack--loose">
+        <SectionHeader eyebrow={block.eyebrow} title={block.title} description={block.description} />
+        <div className="ui-material-handouts-grid">
+          {handouts.map((handout) => (
+            <MaterialHandoutSwitch key={handout.id} handout={handout} onNavigate={onNavigate} />
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+export default function MaterialPageTemplate({
+  hero,
+  pageHeadingId,
+  intro,
+  clusters = [],
+  handoutsBlock = null,
+  handouts = [],
+  onNavigate,
+  closingSection = null,
+}) {
   return (
     <div className="ui-stack">
       <Container width="wide">
@@ -62,6 +254,7 @@ export default function MaterialPageTemplate({ hero, pageHeadingId, intro, clust
       {clusters.map((cluster) => (
         <MaterialCluster key={cluster.id} cluster={cluster} />
       ))}
+      <MaterialHandoutsSection block={handoutsBlock} handouts={handouts} onNavigate={onNavigate} />
       {closingSection ? (
         <ClosingSection
           section={closingSection}


### PR DESCRIPTION
Tier-1-Handout "Mein Notfallplan" als kind-orientiertes Gegenstueck zum fachlichen Sicherheitsplan in der Toolbox. Hybrid-Pfad im Material-Tab: FAQ-Cluster bleiben, Handouts kommen als zweiter Block darunter.

- materialContent: MATERIAL_HANDOUTS_BLOCK + MATERIAL_HANDOUTS (Krisenplan + "Was mir im Alltag hilft", Beispielsaetze inline)
- MaterialPageTemplate: neue Inline-Komponenten (MaterialCrisisPlan, MaterialHandoutField/Emergency/CrossRefs, MaterialHandoutsSection)
- primitives.css: eigener .ui-material-handout-Namespace, bewusst getrennt vom .ui-toolbox-template, damit beide Artefakte visuell unterscheidbar bleiben
- ToolboxSection: minimaler Rueckverlink im Sicherheitsplan-Cluster auf die kindgerechte Material-Variante
- E2E: Render-Nachweis fuer #material-handout-mein-notfallplan

Quellenbindung: Lenz & Brockmann (2010), referenziert in Stauber et al. (2018) Kap. 6.2. Adressiert #107 (Tier-1-Krisenplan), #104 (Handout- Offensive Bestandsaufnahme).