### PR TITLE
feat(material): Print / PDF-Export pro Handout (#105)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,22 @@ Rein clientseitige React 19 SPA ohne Backend. Kein Routing-Library — Hash-basi
 - **SectionHeader + AsideCard**: Wiederverwendbare Shared Components für das Split-Layout-Pattern (Eyebrow + Title + Description + Aside-Karte).
 - **Custom Hooks in utils/**: `useMobileMenu`, `useNavigationFocus`, `useDownloadHandlers` — aus App.jsx extrahiert.
 
+### Material-Handouts: Print / PDF-Export
+
+Jedes einzelne Handout im Material-Tab ist druckbar via Print-Button im Handout-Head. Der Browser-Druckdialog deckt auch "Als PDF speichern" ab (keine separate PDF-Bibliothek nötig).
+
+**Wie ein neues Handout print-ready wird:**
+
+1. Handout-Objekt in `src/data/materialContent.js` unter `MATERIAL_HANDOUTS` anlegen (mit `id`, `kind`, etc.).
+2. Im Template (`src/templates/MaterialPageTemplate.jsx`) eine passende Komponente für den neuen `kind` im `MaterialHandoutSwitch` ergänzen. Die Komponente muss:
+   - `data-handout-id={handout.id}` auf dem `<article>` setzen (Voraussetzung für den Scoped-Print-Style),
+   - den `onPrintHandout`-Prop annehmen und als Button-Handler in Nähe des Titels nutzen (Muster: `MaterialCrisisPlan`),
+   - den Print-Button mit `className="ui-material-handout__print-btn no-print"` versehen.
+3. Print-Typografie: Standardregeln für `.ui-material-handout*` im `@media print`-Block in `src/styles/app-global.css` (Abschnitt 9) greifen automatisch. Handout-spezifische Eigenheiten nur ergänzen, wenn ein Format stark abweicht.
+4. Der `useMaterialHandoutPrint`-Hook rendert beim Click einen scoped `<style>`-Block, der beim Druck alle anderen Handouts ausblendet — kein zusätzlicher Code pro Handout-Typ nötig.
+
+Alle Rahmung (Hero, Intro, Index, FAQ-Cluster, ClosingSection) ist im `MaterialPageTemplate` mit `.no-print`-Wrappern versehen, damit beim Druck nur der Handout-Grid übrig bleibt.
+
 ## Zielgruppen
 
 - **Primäradressat aller Tabs: Fachpersonen** (Erwachsenenpsychiatrie und Beratungskontext). Default, sobald ein Tab kein `primaryAudience`-Feld in `appShellContent.js` trägt.

--- a/e2e/navigation.spec.js
+++ b/e2e/navigation.spec.js
@@ -191,6 +191,36 @@ test.describe('Material Handouts', () => {
     await expect(handout).toContainText('144');
     await expect(handout).toContainText('147');
   });
+
+  test('print button triggers window.print and injects scoped style', async ({ page }) => {
+    // Print-Dialog kann in Chromium nicht wirklich geoeffnet werden; wir
+    // mocken window.print und verifizieren Aufruf + den Scoped-<style>, den
+    // der Hook zum Ausblenden anderer Handouts einfuegt (zukunftssicher).
+    await page.addInitScript(() => {
+      window.localStorage.clear();
+      window.__printCount = 0;
+      window.print = () => {
+        window.__printCount += 1;
+      };
+    });
+    await page.goto('/#material');
+
+    const handout = page.locator('#material-handout-mein-notfallplan');
+    await expect(handout).toBeVisible({ timeout: 10_000 });
+
+    const printButton = handout.locator('button[data-action="print"]');
+    await expect(printButton).toBeVisible();
+    await printButton.click();
+
+    // rAF tick: kurz warten, bis window.print aufgerufen wurde.
+    await expect.poll(async () => await page.evaluate(() => window.__printCount), { timeout: 3_000 }).toBe(1);
+
+    // Scoped <style> fuer das Ziel-Handout liegt im head.
+    const styleTag = page.locator('style#material-handout-print-scope-material-handout-mein-notfallplan');
+    await expect(styleTag).toHaveCount(1);
+    const styleContent = await styleTag.textContent();
+    expect(styleContent).toContain('data-handout-id="material-handout-mein-notfallplan"');
+  });
 });
 
 test.describe('Emergency Access', () => {

--- a/src/sections/MaterialSection.jsx
+++ b/src/sections/MaterialSection.jsx
@@ -9,6 +9,7 @@ import {
 import { createClosingSectionModel } from '../utils/closingModel';
 import { getPageHeadingId } from '../utils/appHelpers';
 import { useAppState } from '../context/useAppState';
+import { useMaterialHandoutPrint } from '../utils/useMaterialHandoutPrint';
 
 function mapMaterialDownloads(sharedDownloadResources = []) {
   return sharedDownloadResources
@@ -23,6 +24,7 @@ function mapMaterialDownloads(sharedDownloadResources = []) {
 
 export default function MaterialSection({ sharedDownloadResources = [] }) {
   const { navigate: onNavigateToTab } = useAppState();
+  const printHandout = useMaterialHandoutPrint();
   const closingSection = createClosingSectionModel({
     id: 'material-downloads-anchor',
     eyebrow: 'Weiterarbeiten',
@@ -108,6 +110,7 @@ export default function MaterialSection({ sharedDownloadResources = [] }) {
       handoutsBlock={MATERIAL_HANDOUTS_BLOCK}
       handouts={MATERIAL_HANDOUTS}
       onNavigate={onNavigateToTab}
+      onPrintHandout={printHandout}
       closingSection={closingSection}
     />
   );

--- a/src/styles/app-global.css
+++ b/src/styles/app-global.css
@@ -307,7 +307,90 @@
     letter-spacing: 0.02em;
   }
 
-  /* 9. Vignetten-Print-Hinweis (V1 aus Audit 11) ------------------------ *
+  /* 9. Material-Handouts -------------------------------------------------- *
+   * Issue #105: Pro einzelnes Handout druckbar. Die Rahmung im Tab (Hero,
+   * Intro, Index, FAQ-Cluster, ClosingSection) ist bereits per `.no-print`
+   * ausgeblendet. Hier wird das Handout-Artikel-Layout auf Papier
+   * optimiert: schwarz/weiss, feste Pt-Groessen, Linien als dunkle
+   * Borders, Notfall-Box mit forced color-adjust. Der Scoped-Style aus
+   * useMaterialHandoutPrint blendet zusaetzlich alle Handouts ausser dem
+   * Ziel aus, falls spaetere Tiers mehrere Handouts nebeneinander zeigen.
+   */
+  .ui-material-handout {
+    border: none;
+    background: #fff !important;
+    padding: 0;
+    gap: 6mm;
+    break-inside: avoid;
+  }
+  .ui-material-handout__head {
+    padding-bottom: 3mm;
+    border-bottom: 1pt solid #333;
+    gap: 2mm;
+  }
+  .ui-material-handout__title {
+    font-size: 16pt;
+    color: #000;
+  }
+  .ui-material-handout__lead {
+    font-size: 10pt;
+    color: #000;
+  }
+  .ui-material-handout__usage {
+    padding: 3mm 4mm;
+    border: 1pt solid #666;
+    background: #fff !important;
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+  .ui-material-handout__usage-item > p:last-child {
+    color: #000;
+  }
+  .ui-material-handout__field {
+    border: 1pt solid #999;
+    background: #fff !important;
+    padding: 3mm 4mm;
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+  .ui-material-handout__field-hint,
+  .ui-material-handout__field-example {
+    color: #000;
+  }
+  .ui-material-handout__line {
+    border-bottom: 1pt solid #333;
+  }
+  .ui-material-handout__section-title {
+    font-size: 13pt;
+    margin-top: 2mm;
+  }
+  .ui-material-handout__emergency {
+    background: #fff !important;
+    color: #000;
+    border: 1.2pt solid #000;
+    padding: 3mm 4mm;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+  .ui-material-handout__emergency-number {
+    font-size: 14pt;
+    color: #000;
+  }
+  .ui-material-handout__disclaimer {
+    background: #fff !important;
+    border: 0.5pt solid #999;
+    color: #000;
+    padding: 3mm 4mm;
+    font-size: 9pt;
+  }
+  .ui-material-handout__cross-refs,
+  .ui-material-handout__foot {
+    border-top: 0.5pt solid #999;
+    color: #000;
+    font-size: 9pt;
+  }
+
+  /* 10. Vignetten-Print-Hinweis (V1 aus Audit 11) ------------------------ *
    * Die Vignetten-Seite ist bewusst nicht druckbar. Der Hinweis erscheint
    * zentral und ruhig auf der ansonsten leeren Druckseite.
    */

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -2221,9 +2221,39 @@
 .ui-material-handout__head {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: var(--space-3);
   padding-bottom: var(--space-4);
   border-bottom: 1px solid var(--border-subtle);
+}
+
+.ui-material-handout__head-text {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ui-material-handout__print-btn {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0.55rem 0.9rem;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--surface-app);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.ui-material-handout__print-btn:hover,
+.ui-material-handout__print-btn:focus-visible {
+  background: var(--surface-panel);
+  border-color: var(--accent-primary-strong);
 }
 
 .ui-material-handout__title {
@@ -2632,6 +2662,18 @@
 
   .ui-material-handout__ownership-meta {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ui-material-handout__head {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-5);
+  }
+
+  .ui-material-handout__print-btn {
+    align-self: flex-start;
+    flex-shrink: 0;
   }
 }
 

--- a/src/templates/MaterialPageTemplate.jsx
+++ b/src/templates/MaterialPageTemplate.jsx
@@ -1,3 +1,4 @@
+import { Printer } from 'lucide-react';
 import ClosingSection from '../components/closing/ClosingSection';
 import EditorialIndex from '../components/ui/EditorialIndex';
 import EditorialIntro from '../components/ui/EditorialIntro';
@@ -126,13 +127,27 @@ function MaterialHandoutCrossRefs({ crossRefs, onNavigate }) {
   );
 }
 
-function MaterialCrisisPlan({ handout, onNavigate }) {
+function MaterialCrisisPlan({ handout, onNavigate, onPrintHandout }) {
   return (
-    <article id={handout.id} className="ui-material-handout ui-section-anchor-offset">
+    <article id={handout.id} data-handout-id={handout.id} className="ui-material-handout ui-section-anchor-offset">
       <header className="ui-material-handout__head">
-        <p className="ui-fact-card__label">{handout.eyebrow}</p>
-        <h3 className="ui-material-handout__title">{handout.title}</h3>
-        <p className="ui-material-handout__lead">{handout.description}</p>
+        <div className="ui-material-handout__head-text">
+          <p className="ui-fact-card__label">{handout.eyebrow}</p>
+          <h3 className="ui-material-handout__title">{handout.title}</h3>
+          <p className="ui-material-handout__lead">{handout.description}</p>
+        </div>
+        {onPrintHandout ? (
+          <button
+            type="button"
+            className="ui-material-handout__print-btn no-print"
+            data-action="print"
+            onClick={() => onPrintHandout(handout.id)}
+            aria-label={`${handout.title} drucken oder als PDF speichern`}
+          >
+            <Printer size={14} aria-hidden="true" />
+            <span>Drucken / PDF</span>
+          </button>
+        ) : null}
       </header>
 
       <div className="ui-material-handout__usage" aria-label="Hinweise zur Nutzung">
@@ -208,25 +223,35 @@ function MaterialCrisisPlan({ handout, onNavigate }) {
   );
 }
 
-function MaterialHandoutSwitch({ handout, onNavigate }) {
+function MaterialHandoutSwitch({ handout, onNavigate, onPrintHandout }) {
   switch (handout.kind) {
     case 'crisis-plan':
-      return <MaterialCrisisPlan handout={handout} onNavigate={onNavigate} />;
+      return <MaterialCrisisPlan handout={handout} onNavigate={onNavigate} onPrintHandout={onPrintHandout} />;
     default:
       return null;
   }
 }
 
-function MaterialHandoutsSection({ block, handouts, onNavigate }) {
+function MaterialHandoutsSection({ block, handouts, onNavigate, onPrintHandout }) {
   if (!block || !handouts?.length) return null;
 
   return (
     <Section spacing="tight" surface="plain">
       <div className="ui-stack ui-stack--loose">
-        <SectionHeader eyebrow={block.eyebrow} title={block.title} description={block.description} />
+        {/* SectionHeader gehoert zum Web-Chrome -- beim Druck eines Handouts
+            soll nur das Handout selbst erscheinen, nicht die Rahmung
+            "Material zum Ausfuellen..." darueber. */}
+        <div className="no-print">
+          <SectionHeader eyebrow={block.eyebrow} title={block.title} description={block.description} />
+        </div>
         <div className="ui-material-handouts-grid">
           {handouts.map((handout) => (
-            <MaterialHandoutSwitch key={handout.id} handout={handout} onNavigate={onNavigate} />
+            <MaterialHandoutSwitch
+              key={handout.id}
+              handout={handout}
+              onNavigate={onNavigate}
+              onPrintHandout={onPrintHandout}
+            />
           ))}
         </div>
       </div>
@@ -242,19 +267,31 @@ export default function MaterialPageTemplate({
   handoutsBlock = null,
   handouts = [],
   onNavigate,
+  onPrintHandout,
   closingSection = null,
 }) {
   return (
     <div className="ui-stack">
-      <Container width="wide">
-        <PageHero {...hero} headingId={pageHeadingId} />
-      </Container>
-      <EditorialIntro intro={intro} />
-      <EditorialIndex items={clusters} spacing="tight" surface="subtle" />
-      {clusters.map((cluster) => (
-        <MaterialCluster key={cluster.id} cluster={cluster} />
-      ))}
-      <MaterialHandoutsSection block={handoutsBlock} handouts={handouts} onNavigate={onNavigate} />
+      {/* Rahmung (Hero, Intro, Index, FAQ-Cluster) ist Web-Chrome und
+          verschwindet beim Handout-Druck. Der Handouts-Grid bleibt
+          sichtbar; scoped Styles aus useMaterialHandoutPrint blenden die
+          nicht-angewaehlten Handouts aus. */}
+      <div className="no-print">
+        <Container width="wide">
+          <PageHero {...hero} headingId={pageHeadingId} />
+        </Container>
+        <EditorialIntro intro={intro} />
+        <EditorialIndex items={clusters} spacing="tight" surface="subtle" />
+        {clusters.map((cluster) => (
+          <MaterialCluster key={cluster.id} cluster={cluster} />
+        ))}
+      </div>
+      <MaterialHandoutsSection
+        block={handoutsBlock}
+        handouts={handouts}
+        onNavigate={onNavigate}
+        onPrintHandout={onPrintHandout}
+      />
       {closingSection ? (
         <ClosingSection
           section={closingSection}

--- a/src/utils/useMaterialHandoutPrint.js
+++ b/src/utils/useMaterialHandoutPrint.js
@@ -1,0 +1,57 @@
+import { useCallback } from 'react';
+
+/**
+ * Druckt ein einzelnes Handout aus dem Material-Tab. Der Browser-Druckdialog
+ * erlaubt automatisch auch "Als PDF speichern", sodass dieser Hook beide
+ * Faelle abdeckt (Issue #105, Option A).
+ *
+ * Ansatz: Der Hook bezieht sich auf das Handout via `data-handout-id`. Beim
+ * Click fuegt er einen scoped `<style>`-Block in den Head ein, der im
+ * @media print alle anderen `.ui-material-handout`-Elemente ausblendet. Das
+ * ist zukunftssicher: heute liegt nur der Krisenplan im Grid, aber sobald
+ * Tier 2 / Tier 3 dazukommen, druckt der Button weiterhin nur das Ziel-
+ * Handout.
+ *
+ * Komplementaer dazu sind alle umliegenden Material-Sections (Hero, Intro,
+ * Index, FAQ-Cluster, ClosingSection) mit `.no-print` markiert, damit beim
+ * Druck nur der Handout-Grid uebrig bleibt. Die eigentliche Print-
+ * Typografie / Farb-Adjustments stehen im zentralen @media print-Block in
+ * app-global.css + primitives.css.
+ */
+export function useMaterialHandoutPrint() {
+  return useCallback((handoutId) => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    if (!handoutId) {
+      window.print();
+      return;
+    }
+
+    const styleId = `material-handout-print-scope-${handoutId}`;
+    // Falls der Nutzer zweimal hintereinander klickt, alten Scope entfernen.
+    document.getElementById(styleId)?.remove();
+
+    const styleEl = document.createElement('style');
+    styleEl.id = styleId;
+    styleEl.textContent = `
+      @media print {
+        .ui-material-handout:not([data-handout-id="${handoutId}"]) {
+          display: none !important;
+        }
+      }
+    `;
+    document.head.appendChild(styleEl);
+
+    const cleanup = () => {
+      document.getElementById(styleId)?.remove();
+      window.removeEventListener('afterprint', cleanup);
+    };
+    window.addEventListener('afterprint', cleanup);
+
+    // rAF, damit der neue Stil garantiert im nächsten Paint-Cycle greift,
+    // bevor der Druck-Dialog öffnet (gleiches Muster wie handleToolboxPrint
+    // in App.jsx).
+    window.requestAnimationFrame(() => {
+      window.print();
+    });
+  }, []);
+}


### PR DESCRIPTION
Closes #105.

## Summary

- Jedes Material-Handout bekommt einen **«Drucken / PDF»-Button** im Head. Browser-Druckdialog deckt PDF-Speichern out-of-the-box ab — keine neue Dependency.
- `useMaterialHandoutPrint`-Hook fuegt beim Click einen **scoped `<style>`-Block** in den Head, der beim Druck alle anderen `.ui-material-handout`-Elemente ausblendet. Zukunftssicher, sobald Tier 2/3 mehrere Handouts nebeneinander zeigt.
- Rahmung (Hero, Intro, Index, FAQ-Cluster, ClosingSection) ist im `MaterialPageTemplate` mit `.no-print`-Wrappern markiert — beim Druck bleibt nur das Ziel-Handout.
- Print-Typografie fuer Material-Handouts im zentralen `@media print`-Block in `app-global.css` (Abschnitt 9): schwarz/weiss, feste Pt-Groessen, Notfall-Box mit `print-color-adjust`, Linien als Borders.
- `CLAUDE.md`: Pattern-Doku fuer neue Handouts (data-handout-id + Print-Button-Klasse).

## Entscheidungen aus #105

**Granularitaet:** Pro einzelnes Handout (H3-Variante).
FAQ-Cluster sind Web-Content, nur `MATERIAL_HANDOUTS` sind druckbare Artefakte. Ein Krisenplan = ein PDF; Tier 2/3-Handouts folgen demselben Muster ohne Code-Anpassung.

**Technik:** Option A (CSS `@media print` + Browser-Druck).
- B (jsPDF/html2pdf): verworfen — Bundle + Wartung ohne Mehrwert fuer layoutarme Handouts.
- C (fertige PDFs im Repo): verworfen — redaktioneller Overhead gegen Single-Source-of-Truth.

## Test plan

- [x] `npm run lint` (0/0)
- [x] `npm run format`
- [x] `npm run build` (MaterialSection +1.25 kB, 38.59 kB)
- [x] `npm run test:e2e` (32/32 passed, inkl. neuer `Material Handouts › print button triggers window.print and injects scoped style`)
- [ ] **Visuelle Druckprobe** im Dev-Server: Cmd+P auf `#material` nach Klick auf Print-Button; Druckvorschau zeigt nur das Krisenplan-Handout (schwarz/weiss, Felder als Border-Rahmen, Notfallnummern hervorgehoben), kein Nav-Chrome / kein FAQ / keine ClosingSection.
- [ ] PDF-Speichern via Druck-Dialog funktioniert (Chrome/Safari/Firefox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)