### PR TITLE
feat(material): Cluster nach Zielgruppe trennen (#102 + #103)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,15 @@ Jedes einzelne Handout im Material-Tab ist druckbar via Print-Button im Handout-
 
 Alle Rahmung (Hero, Intro, Index, FAQ-Cluster, ClosingSection) ist im `MaterialPageTemplate` mit `.no-print`-Wrappern versehen, damit beim Druck nur der Handout-Grid übrig bleibt.
 
+### Material-Cluster: Zielgruppen-Blöcke
+
+Die FAQ-Cluster im Material-Tab adressieren zwei Gruppen: Cluster 1–3 Angehörige, Cluster 4–6 betroffene Eltern. Die Gliederung wird im Template über zwei Eingaben gesteuert:
+
+- **`audience`** pro Cluster in `MATERIAL_CLUSTERS` (`'angehoerige'` | `'eltern'`) — rendert das `.ui-badge--soft`-Label im Cluster-Header.
+- **`MATERIAL_CLUSTER_AUDIENCES`** — Array mit einem Eintrag pro Gruppe (`id`, `badge`, `title`, `description`). Jede Gruppe bekommt einen eigenen Block-Header (H2). Cluster-Titel rutschen dadurch auf H3 (Outline-Regel: H1 Page → H2 Block → H3 Cluster).
+
+Neue Cluster hinzufügen: `audience`-Feld nicht vergessen. Wenn eine neue Zielgruppe dazukommt, einen weiteren Eintrag in `MATERIAL_CLUSTER_AUDIENCES` anlegen und ggf. eine Badge-Variante in `primitives.css` unter `.ui-badge[data-audience='…']` ergänzen.
+
 ## Zielgruppen
 
 - **Primäradressat aller Tabs: Fachpersonen** (Erwachsenenpsychiatrie und Beratungskontext). Default, sobald ein Tab kein `primaryAudience`-Feld in `appShellContent.js` trägt.

--- a/e2e/navigation.spec.js
+++ b/e2e/navigation.spec.js
@@ -177,6 +177,43 @@ test.describe('Logo / Home Navigation', () => {
   });
 });
 
+test.describe('Material Cluster Audience Blocks', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.clear());
+    await page.goto('/#material');
+  });
+
+  test('renders two audience block headers (Angehörige + Eltern)', async ({ page }) => {
+    const angehoerige = page.getByRole('heading', { level: 2, name: /Material für Angehörige/ });
+    const eltern = page.getByRole('heading', { level: 2, name: /Material für betroffene Eltern/ });
+
+    await expect(angehoerige).toBeVisible({ timeout: 10_000 });
+    await expect(eltern).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('each cluster carries an audience badge matching its group', async ({ page }) => {
+    // Cluster 1-3 (Angehoerige)
+    for (const id of ['material-verstehen', 'material-grenzen', 'material-zusammenarbeit']) {
+      const badge = page.locator(`#${id} .ui-badge[data-audience="angehoerige"]`);
+      await expect(badge).toBeVisible({ timeout: 10_000 });
+      await expect(badge).toContainText(/Für Angehörige/);
+    }
+    // Cluster 4-6 (betroffene Eltern)
+    for (const id of ['material-kinder', 'material-altersgerecht', 'material-formulierungshilfen']) {
+      const badge = page.locator(`#${id} .ui-badge[data-audience="eltern"]`);
+      await expect(badge).toBeVisible({ timeout: 10_000 });
+      await expect(badge).toContainText(/Für betroffene Eltern/);
+    }
+  });
+
+  test('cluster titles are h3 so block headers stay the h2 layer', async ({ page }) => {
+    // Block-Header ist h2, Cluster-Titel werden zu h3 (Outline-Hygiene).
+    const clusterTitle = page.locator('#material-verstehen h3').first();
+    await expect(clusterTitle).toBeVisible({ timeout: 10_000 });
+    await expect(clusterTitle).toContainText(/Belastung verstehen/);
+  });
+});
+
 test.describe('Material Handouts', () => {
   test('crisis-plan handout renders on Material tab', async ({ page }) => {
     await page.addInitScript(() => localStorage.clear());

--- a/src/data/materialContent.js
+++ b/src/data/materialContent.js
@@ -205,9 +205,37 @@ export const MATERIAL_HANDOUTS = [
   },
 ];
 
+// Zielgruppen-Blöcke fuer die Material-Cluster (Issues #102 + #103). Die sechs
+// FAQ-Cluster adressieren zwei verschiedene Lesergruppen — Cluster 1-3
+// richten sich an Angehoerige (Partner:innen / Familie der erkrankten Person),
+// Cluster 4-6 an betroffene Eltern selbst (Ich-Form-Fragen zum Gespraech mit
+// dem Kind). Frueher lagen alle sechs Cluster in einer linearen Liste;
+// inzwischen wird die Grenze im Template durch einen Block-Header mit H2 +
+// Audience-Badge sichtbar gemacht. Die Meta-Texte hier (title / description)
+// steuern diesen Block-Header, der `badge`-Text wird zusaetzlich auf jedem
+// einzelnen Cluster angezeigt, damit die Adressat-Zuordnung auch beim Scrollen
+// erhalten bleibt.
+export const MATERIAL_CLUSTER_AUDIENCES = [
+  {
+    id: 'angehoerige',
+    badge: 'Für Angehörige',
+    title: 'Material für Angehörige',
+    description:
+      'Die nächsten drei Cluster richten sich an Partner:innen und Familie der erkrankten Person — mit Fragen zu Belastung, Grenzen und Zusammenarbeit im Helfersystem.',
+  },
+  {
+    id: 'eltern',
+    badge: 'Für betroffene Eltern',
+    title: 'Material für betroffene Eltern',
+    description:
+      'Die folgenden drei Cluster richten sich an psychisch erkrankte Eltern selbst — mit Fragen zum Gespräch mit dem Kind: was sagen, wie altersgerecht erklären und mit welchen Formulierungen je Störungsbild.',
+  },
+];
+
 export const MATERIAL_CLUSTERS = [
   {
     id: 'material-verstehen',
+    audience: 'angehoerige',
     eyebrow: 'Cluster 1',
     title: 'Belastung verstehen, ohne sich vorschnell schuldig zu machen',
     description:
@@ -243,6 +271,7 @@ export const MATERIAL_CLUSTERS = [
   },
   {
     id: 'material-grenzen',
+    audience: 'angehoerige',
     eyebrow: 'Cluster 2',
     title: 'Grenzen, Verantwortung und legitimer Selbstschutz',
     description:
@@ -278,6 +307,7 @@ export const MATERIAL_CLUSTERS = [
   },
   {
     id: 'material-zusammenarbeit',
+    audience: 'angehoerige',
     legalDisclaimer: true,
     eyebrow: 'Cluster 3',
     title: 'Zusammenarbeit, Mitsprache und der nächste sinnvolle Schritt',
@@ -320,6 +350,7 @@ export const MATERIAL_CLUSTERS = [
     // Bern. Insbesondere Tabelle 1 (Lenz, 2010, S. 187) und Kapitel 2.5
     // (spezifische Schutzfaktoren: Krankheitswissen + offener Umgang).
     id: 'material-kinder',
+    audience: 'eltern',
     eyebrow: 'Cluster 4',
     title: 'Mit Kindern über die Erkrankung sprechen',
     description:
@@ -378,6 +409,7 @@ export const MATERIAL_CLUSTERS = [
     // «Altersspezifische Aspekte bei der Psychoedukation». Schliesst direkt
     // an Cluster 4 an, das Grundlagen der Kinder-Aufklärung behandelt.
     id: 'material-altersgerecht',
+    audience: 'eltern',
     eyebrow: 'Cluster 5',
     title: 'Altersgerecht erklären — was Kinder in welchem Alter brauchen',
     description:
@@ -423,6 +455,7 @@ export const MATERIAL_CLUSTERS = [
     // Kap. 5.3.1 / Tabelle 2 (Lenz 2010, S. 207–208) und Wunderer (2008).
     // Eigenständig formuliert, keine wörtliche Übernahme.
     id: 'material-formulierungshilfen',
+    audience: 'eltern',
     eyebrow: 'Cluster 6',
     title: 'Formulierungshilfen — psychische Erkrankungen kindgerecht erklären',
     description:

--- a/src/sections/MaterialSection.jsx
+++ b/src/sections/MaterialSection.jsx
@@ -1,6 +1,7 @@
 import MaterialPageTemplate from '../templates/MaterialPageTemplate';
 import {
   MATERIAL_CLUSTERS,
+  MATERIAL_CLUSTER_AUDIENCES,
   MATERIAL_HANDOUTS,
   MATERIAL_HANDOUTS_BLOCK,
   MATERIAL_HERO,
@@ -107,6 +108,7 @@ export default function MaterialSection({ sharedDownloadResources = [] }) {
       pageHeadingId={getPageHeadingId('material')}
       intro={MATERIAL_INTRO}
       clusters={MATERIAL_CLUSTERS}
+      clusterAudiences={MATERIAL_CLUSTER_AUDIENCES}
       handoutsBlock={MATERIAL_HANDOUTS_BLOCK}
       handouts={MATERIAL_HANDOUTS}
       onNavigate={onNavigateToTab}

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -680,6 +680,40 @@
   gap: var(--space-4);
 }
 
+/* Material-Cluster nach Zielgruppe (Issues #102 + #103).
+   Pro Audience-Gruppe (Angehoerige / betroffene Eltern) wird ein Block mit
+   Block-Header (H2 + Badge + Description) + Cluster 1-3 bzw. 4-6 darunter
+   gerendert. Die bestehenden ui-section--tight-Abstaende greifen; hier nur
+   audience-spezifische Badge-Farben + eine leicht abgesetzte Data-Attribute-
+   Variante pro Block-Hintergrund. */
+.ui-material-cluster-block {
+  display: contents;
+}
+
+.ui-material-cluster-block__title {
+  margin: 0;
+}
+
+.ui-material-cluster-block__header {
+  max-width: 52rem;
+}
+
+.ui-material-cluster__audience {
+  margin-bottom: calc(-1 * var(--space-2));
+}
+
+.ui-badge[data-audience='angehoerige'] {
+  border-color: color-mix(in srgb, var(--accent-primary) 22%, white 78%);
+  background: color-mix(in srgb, var(--accent-primary) 8%, white 92%);
+  color: var(--accent-primary-strong);
+}
+
+.ui-badge[data-audience='eltern'] {
+  border-color: color-mix(in srgb, var(--accent-secondary) 42%, white 58%);
+  background: color-mix(in srgb, var(--accent-secondary) 14%, white 86%);
+  color: var(--accent-info-strong);
+}
+
 .learning-flow-grid {
   display: grid;
   gap: var(--space-4);

--- a/src/templates/MaterialPageTemplate.jsx
+++ b/src/templates/MaterialPageTemplate.jsx
@@ -27,15 +27,23 @@ function MaterialFaqItem({ item, index }) {
   );
 }
 
-function MaterialCluster({ cluster }) {
+function MaterialCluster({ cluster, audienceBadge }) {
   return (
     <Section spacing="tight" surface={cluster.surface || 'plain'}>
       <div id={cluster.id} className="ui-stack ui-stack--loose ui-section-anchor-offset">
+        {audienceBadge ? (
+          <div className="ui-badge-row ui-material-cluster__audience">
+            <span className="ui-badge ui-badge--soft" data-audience={cluster.audience}>
+              {audienceBadge}
+            </span>
+          </div>
+        ) : null}
         <SectionHeader
           eyebrow={cluster.eyebrow}
           title={cluster.title}
           description={cluster.description}
           aside={cluster.aside}
+          headingTag="h3"
         />
 
         {cluster.faqs?.length ? (
@@ -47,6 +55,33 @@ function MaterialCluster({ cluster }) {
         ) : null}
 
         {cluster.legalDisclaimer ? <LegalDisclaimer /> : null}
+      </div>
+    </Section>
+  );
+}
+
+/**
+ * Block-Header fuer eine Zielgruppen-Gruppe (Issue #103). Trennt die
+ * Cluster visuell in "Material fuer Angehoerige" (Cluster 1-3) und
+ * "Material fuer betroffene Eltern" (Cluster 4-6). Badge wiederholt den
+ * Adressat-Text, den auch die Einzel-Cluster tragen, damit die Zuordnung
+ * beim Scrollen nicht verlorengeht.
+ */
+function MaterialClusterBlockHeader({ audience, surface = 'subtle' }) {
+  return (
+    <Section spacing="tight" surface={surface}>
+      <div className="ui-stack ui-stack--tight ui-material-cluster-block__header">
+        <div className="ui-badge-row">
+          <span className="ui-badge ui-badge--soft" data-audience={audience.id}>
+            {audience.badge}
+          </span>
+        </div>
+        <h2 className="ui-section-title ui-material-cluster-block__title">{audience.title}</h2>
+        {audience.description ? (
+          <div className="ui-copy">
+            <p>{audience.description}</p>
+          </div>
+        ) : null}
       </div>
     </Section>
   );
@@ -264,12 +299,30 @@ export default function MaterialPageTemplate({
   pageHeadingId,
   intro,
   clusters = [],
+  clusterAudiences = [],
   handoutsBlock = null,
   handouts = [],
   onNavigate,
   onPrintHandout,
   closingSection = null,
 }) {
+  // Zielgruppen-Gruppierung (Issues #102 + #103): sofern clusterAudiences
+  // gesetzt ist, werden Cluster pro Audience in einem eigenen Block
+  // gerendert (Block-Header + Audience-Badge auf jedem Einzel-Cluster).
+  // Fallback: flache Liste, falls keine Audiences uebergeben wurden.
+  const audienceLookup = new Map(clusterAudiences.map((a) => [a.id, a]));
+  const orderedAudiences = clusterAudiences.length
+    ? clusterAudiences
+        .map((audience) => ({
+          audience,
+          items: clusters.filter((c) => c.audience === audience.id),
+        }))
+        .filter((group) => group.items.length > 0)
+    : [];
+  const ungroupedClusters = clusterAudiences.length
+    ? clusters.filter((c) => !c.audience || !audienceLookup.has(c.audience))
+    : clusters;
+
   return (
     <div className="ui-stack">
       {/* Rahmung (Hero, Intro, Index, FAQ-Cluster) ist Web-Chrome und
@@ -282,7 +335,15 @@ export default function MaterialPageTemplate({
         </Container>
         <EditorialIntro intro={intro} />
         <EditorialIndex items={clusters} spacing="tight" surface="subtle" />
-        {clusters.map((cluster) => (
+        {orderedAudiences.map(({ audience, items }) => (
+          <div key={audience.id} className="ui-material-cluster-block" data-audience={audience.id}>
+            <MaterialClusterBlockHeader audience={audience} />
+            {items.map((cluster) => (
+              <MaterialCluster key={cluster.id} cluster={cluster} audienceBadge={audience.badge} />
+            ))}
+          </div>
+        ))}
+        {ungroupedClusters.map((cluster) => (
           <MaterialCluster key={cluster.id} cluster={cluster} />
         ))}
       </div>


### PR DESCRIPTION
## Summary

Cluster 1–3 (Angehörige) und Cluster 4–6 (betroffene Eltern) lagen in einer linearen Liste, obwohl sie zwei Lesergruppen adressieren. Zwei komplementäre Signale lösen das:

- **Block-Header pro Gruppe** — `MATERIAL_CLUSTER_AUDIENCES` liefert Badge + H2-Titel + Description pro Zielgruppe. Cluster-Titel rutschen auf H3 (H1 Page → H2 Block → H3 Cluster).
- **Audience-Badge pro Cluster** — `audience`-Feld (`'angehoerige'` | `'eltern'`) in `MATERIAL_CLUSTERS`. Farbliche Differenzierung über `.ui-badge[data-audience='…']` (accent-primary für Angehörige, accent-secondary für Eltern).

Dokumentation in CLAUDE.md ergänzt, damit beim Hinzufügen neuer Cluster klar ist, dass `audience` gesetzt werden muss.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx prettier --check` auf allen angefassten Dateien — clean
- [x] `npm run build` — erfolgreich (MaterialSection bundle 40.46 kB → 13.58 kB gzip)
- [x] `npm run test:e2e` — alle 35 Tests grün, davon 3 neu:
  - renders two audience block headers (Angehörige + Eltern)
  - each cluster carries an audience badge matching its group
  - cluster titles are h3 so block headers stay the h2 layer
- [ ] Visuell abnehmen: Material-Tab öffnen, zwei Blöcke mit Block-H2 + Badges, Cluster-Titel H3, EditorialIndex oben unverändert

## Was nicht geändert wurde (bewusst)

- `EditorialIndex` bleibt mit allen 6 Clustern in einer Reihe (reiner Sprungnavigator). Wenn visuell auch dort Gruppierung gewünscht ist, als separates Issue.
- `MATERIAL_INTRO.cards` (6 Cluster-Preview-Karten) bleibt unverändert. Adressat-Signal passiert erst bei den Cluster-Blöcken selbst.

Closes #102
Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)