### PR TITLE
feat(material): Tier-1-Handouts "Erstes Gespräch" + "Wann Fachstelle?"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,14 @@ Jedes einzelne Handout im Material-Tab ist druckbar via Print-Button im Handout-
 
 Alle Rahmung (Hero, Intro, Index, FAQ-Cluster, ClosingSection) ist im `MaterialPageTemplate` mit `.no-print`-Wrappern versehen, damit beim Druck nur der Handout-Grid übrig bleibt.
 
+**Bekannte Handout-`kind`-Werte und ihre Daten-Schemata:**
+
+- `'crisis-plan'` — Notfallplan-Vorlage mit Eigentumsfeldern, Sektionen, Notfallnummern (`MaterialCrisisPlan`).
+- `'conversation-script'` — Tier-1 (Issue #112): Gespräch-Skript für betroffene Eltern. Erwartet `usage`, `opener {title, text, note}`, `childQuestions {title, intro, items[].question, items[].anchor}`, `understandingCheck {title, intro, prompt, note}`, `process {title, items[]}`, `disclaimer`, `crossRefs` (`MaterialConversationScript`).
+- `'threshold-checklist'` — Tier-1 (Issue #113): Schwellen-Karte für Angehörige. Erwartet `usage`, `priorityRule {title, intro, items[].step, items[].label, items[].detail}`, `thresholds {title, intro, items[].observation, items[].escalate}`, `contacts {title, intro, items[].number?, items[].name?, items[].detail}`, `selfNote {title, text}`, `disclaimer`, `crossRefs` (`MaterialThresholdChecklist`).
+
+Die Tier-1-Komponenten teilen sich die kleinen Helper `MaterialHandoutHead` / `MaterialHandoutUsage` / `MaterialHandoutDisclaimer`. `MaterialCrisisPlan` ist bewusst NICHT auf die Helper umgestellt — die existierende DOM-Struktur ist von den Print-Tests + Print-Typografie abhängig. Refactoring auf gemeinsame Bausteine kommt als separate Welle, sobald das Pattern bei 3+ Handouts stabil ist.
+
 ### Material-Cluster: Zielgruppen-Blöcke
 
 Die FAQ-Cluster im Material-Tab adressieren zwei Gruppen: Cluster 1–3 Angehörige, Cluster 4–6 betroffene Eltern. Die Gliederung wird im Template über zwei Eingaben gesteuert:

--- a/e2e/navigation.spec.js
+++ b/e2e/navigation.spec.js
@@ -258,6 +258,60 @@ test.describe('Material Handouts', () => {
     const styleContent = await styleTag.textContent();
     expect(styleContent).toContain('data-handout-id="material-handout-mein-notfallplan"');
   });
+
+  // Tier-1-Handout (Issue #112): Conversation-Script fuer betroffene Eltern.
+  test('conversation-script handout (erstes-gespraech) renders with opener + 5 child questions', async ({ page }) => {
+    await page.addInitScript(() => localStorage.clear());
+    await page.goto('/#material');
+
+    const handout = page.locator('#material-handout-erstes-gespraech');
+    await expect(handout).toBeVisible({ timeout: 10_000 });
+    await expect(handout).toContainText('Erstes Gespräch mit dem Kind');
+    await expect(handout).toContainText('Handout für Eltern');
+
+    // Opener-Blockquote ist da
+    await expect(handout.locator('.ui-material-handout__opener')).toBeVisible();
+
+    // Genau fuenf Q&A-Items (typische Kinder-Fragen)
+    const qaItems = handout.locator('.ui-material-handout__qa-item');
+    await expect(qaItems).toHaveCount(5);
+
+    // Verstehens-Check-Prompt + Print-Button vorhanden
+    await expect(handout.locator('.ui-material-handout__prompt')).toBeVisible();
+    await expect(handout.locator('button[data-action="print"]')).toBeVisible();
+  });
+
+  // Tier-1-Handout (Issue #113): Threshold-Checklist fuer Angehoerige.
+  test('threshold-checklist handout (wann-fachstelle) renders with priority steps + thresholds + contacts', async ({
+    page,
+  }) => {
+    await page.addInitScript(() => localStorage.clear());
+    await page.goto('/#material');
+
+    const handout = page.locator('#material-handout-wann-fachstelle');
+    await expect(handout).toBeVisible({ timeout: 10_000 });
+    await expect(handout).toContainText('Wann ist es Zeit, eine Fachstelle zu kontaktieren?');
+    await expect(handout).toContainText('Handout für Angehörige');
+
+    // Drei Prioritaets-Schritte (1 Sicherheit, 2 Versorgung, 3 Grundsatz)
+    const steps = handout.locator('.ui-material-handout__step');
+    await expect(steps).toHaveCount(3);
+
+    // Beobachtungs-Schwellen (mindestens 6 Items)
+    const thresholds = handout.locator('.ui-material-handout__threshold');
+    expect(await thresholds.count()).toBeGreaterThanOrEqual(6);
+
+    // CH-Notfallnummern muessen als Anlaufstellen-Anker enthalten sein
+    await expect(handout).toContainText('144');
+    await expect(handout).toContainText('143');
+    await expect(handout).toContainText('147');
+
+    // Selbst-Schwelle als Callout
+    await expect(handout.locator('.ui-material-handout__callout')).toBeVisible();
+
+    // Print-Button funktioniert (gemeinsamer Mechanik-Pfad ueber MaterialHandoutSwitch)
+    await expect(handout.locator('button[data-action="print"]')).toBeVisible();
+  });
 });
 
 test.describe('Emergency Access', () => {

--- a/src/data/materialContent.js
+++ b/src/data/materialContent.js
@@ -203,6 +203,244 @@ export const MATERIAL_HANDOUTS = [
       ],
     },
   },
+  // Tier-1-Handout (Issue #112): Gespraech-Skript fuer betroffene Eltern.
+  // Setzt direkt an Cluster 4 an (Mit Kindern sprechen) und gibt einen
+  // vorbereiteten Einstiegssatz, fuenf typische Kinder-Fragen mit moeglichen
+  // Antworten + einen Verstehens-Check als druckbares Skript zur Vorbereitung.
+  // Quelle: Stauber et al. (2018) Kap. 5.3.1; Lenz (2010) Tab. 2.
+  {
+    id: 'material-handout-erstes-gespraech',
+    kind: 'conversation-script',
+    eyebrow: 'Handout für Eltern',
+    title: 'Erstes Gespräch mit dem Kind',
+    description:
+      'Eine vorbereitete Skript-Vorlage fuer das erste Gespraech mit dem eigenen Kind ueber die psychische Erkrankung. Gedacht zur Vorbereitung — nicht als Vorlese-Text. Die Saetze sind Anker, keine Vorgaben.',
+    usage: {
+      when: 'In einer ruhigen Phase, nicht im akuten Zustand. Vorzugsweise allein vorab durchlesen, dann das Gespräch in eigener Sprache führen.',
+      people:
+        'Sie selbst (betroffene:r Elternteil) — optional gemeinsam mit der zweiten Bezugsperson, einer Fachperson oder Vertrauensperson zur Vorbereitung.',
+      validity:
+        'Das Skript altert nicht. Es bleibt nützlich für Folgegespräche, wenn das Kind mit neuen Fragen kommt — denn das wird es.',
+      where:
+        'Vorbereitung in Ruhe. Beim Gespräch nicht ablesen, sondern in eigener Sprache reden. Optional als Teil des Eltern-Materials beim Behandlungsteam ablegen.',
+    },
+    opener: {
+      title: 'Möglicher Einstiegssatz',
+      text: '«Damit du Bescheid weisst und dir nicht unnötig Sorgen machst, möchte ich dir erklären, was mit mir los ist.»',
+      note: 'Dieser Satz signalisiert drei Dinge: Offenheit, Fürsorge und die Erlaubnis, Fragen zu stellen. Er funktioniert für Schulkinder und Jugendliche; bei jüngeren Kindern lieber kürzer, beim Alltag ansetzen.',
+    },
+    childQuestions: {
+      title: 'Die fünf typischen Fragen — und mögliche Antwort-Anker',
+      intro:
+        'Forschungsbefunde zeigen fünf wiederkehrende Themenbereiche. Die Reihenfolge variiert mit Alter und Krankheitsverlauf. Es ist hilfreich, sich auf jede vorbereitet zu haben — die Antworten unten sind Beispiel-Anker, nicht Skripte.',
+      items: [
+        {
+          question: 'Wie soll ich mich gegenüber dir verhalten?',
+          anchor:
+            'So normal wie möglich. Wenn du dir unsicher bist, frag mich oder unsere Vertrauensperson. Du musst nicht aufpassen — das ist meine Aufgabe.',
+        },
+        {
+          question: 'Wird sich mein Leben verändern?',
+          anchor:
+            'Manche Dinge bleiben gleich (z. B. dein Schulweg, deine Freundinnen und Freunde). Manche können sich verändern (z. B. wer dich abholt, wenn ich nicht kann). Veränderungen besprechen wir miteinander, du erfährst es nicht plötzlich.',
+        },
+        {
+          question: 'Was ist die Ursache — und werde ich auch krank?',
+          anchor:
+            'Diese Krankheit hat verschiedene Ursachen, nicht eine einzige. Du hast nichts damit zu tun. Dass auch du krank wirst, ist nicht garantiert — viel hängt davon ab, dass es dir gut geht und du Hilfe bekommst, wenn du sie brauchst.',
+        },
+        {
+          question: 'Was ist der Unterschied zu einer körperlichen Krankheit?',
+          anchor:
+            'Eine körperliche Krankheit kann man oft sehen oder spüren. Eine psychische Krankheit verändert Gefühle, Gedanken und Verhalten — das macht sie schwerer sichtbar, aber sie ist genauso ernst. Und sie kann behandelt werden.',
+        },
+        {
+          question: 'Kannst du wieder gesund werden?',
+          anchor:
+            'Vielen Menschen geht es mit der Zeit und mit Hilfe wieder besser. Manche Krankheiten kommen wieder, manche bleiben. Was uns hilft: gute Behandlung, Hilfe von aussen und dass wir miteinander reden.',
+        },
+      ],
+    },
+    understandingCheck: {
+      title: 'Verstehens-Check',
+      intro:
+        'Nach dem Gespräch ist es hilfreich zu prüfen, was angekommen ist — nicht als Test, sondern als Einladung.',
+      prompt: '«Magst du mir erzählen, was du jetzt verstanden hast?»',
+      note: 'Achten Sie nicht nur auf den Inhalt, sondern auch auf Mimik, Tonfall und Körpersprache. Echohaftes Nachsprechen oder Ausweichen können bedeuten: das Kind braucht eine Pause, eine andere Erklärung oder einfach Zeit.',
+    },
+    process: {
+      title: 'Wichtig zu wissen',
+      items: [
+        'Das ist kein einmaliges Gespräch, sondern ein Prozess. Kinder kommen mit neuen Fragen zurück, wenn sie bereit sind.',
+        'Schweigen oder Ausweichen ist keine Ablehnung — manchmal braucht das Kind erst Zeit, das Gehörte zu sortieren.',
+        'Es ist okay, etwas nicht zu wissen. Sie können sagen: «Das weiss ich gerade auch nicht — wir können zusammen nachfragen.»',
+        'Klären Sie das Kind nicht alleine auf, wenn Sie sich überfordert fühlen — Fachpersonen (kjz, PUK Angehörigenberatung, Pro Mente Sana) begleiten solche Gespräche bei Bedarf.',
+      ],
+    },
+    disclaimer:
+      'Dieses Skript ist eine Orientierungshilfe, kein Therapieersatz. Bei akuter Belastung des Kindes oder bei Unsicherheit, was wann gesagt werden soll, sind das kjz, die PUK Angehörigenberatung oder das Institut Kinderseele Schweiz fachliche Anlaufstellen.',
+    crossRefs: {
+      title: 'Verwandte Inhalte',
+      items: [
+        {
+          kind: 'faq',
+          label: 'Aus dem FAQ: Cluster 4 «Mit Kindern über die Erkrankung sprechen»',
+          anchor: '#material-kinder',
+        },
+        {
+          kind: 'faq',
+          label: 'Aus dem FAQ: Cluster 5 «Altersgerecht erklären»',
+          anchor: '#material-altersgerecht',
+        },
+        {
+          kind: 'handout',
+          label: 'Komplementär: «Mein Notfallplan» für die akute Krankheitsphase',
+          anchor: '#material-handout-mein-notfallplan',
+        },
+      ],
+    },
+  },
+  // Tier-1-Handout (Issue #113): Schwellen-Karte fuer Angehoerige. Loest die
+  // Paralyse-Frage "Ist das schon ernst genug, um Hilfe zu holen?" durch
+  // konkrete Beobachtungs-Items + klare Wenn-Dann-Logik + CH-Anlaufstellen
+  // mit Notfallnummern. Datenquelle Anlaufstellen: fachstellenContent.js.
+  {
+    id: 'material-handout-wann-fachstelle',
+    kind: 'threshold-checklist',
+    eyebrow: 'Handout für Angehörige',
+    title: 'Wann ist es Zeit, eine Fachstelle zu kontaktieren?',
+    description:
+      'Eine Schwellen-Karte fuer Angehoerige psychisch erkrankter Menschen. Sie hilft einzuschaetzen, wann Beobachten reicht und wann eine Fachstelle anzurufen ist — und welche Stelle wofuer zustaendig ist.',
+    usage: {
+      when: 'Vorab in einer ruhigen Phase ansehen — damit Sie im Belastungsmoment nicht erst suchen müssen.',
+      people:
+        'Sie selbst (angehörige Person). Optional zur Absprache mit anderen Familienmitgliedern oder dem Behandlungsteam.',
+      validity:
+        'Die Schwellen sind robust, die Anlaufstellen ändern sich kaum. Notfallnummern (144, 143, 147) gelten national rund um die Uhr.',
+      where:
+        'In der Nähe des Telefons. Eine Kopie an die Pinnwand, eine ins Portemonnaie. Bei mehreren Bezugspersonen: gleicher Stand für alle.',
+    },
+    priorityRule: {
+      title: 'Reihenfolge in der Krise',
+      intro: 'Wenn vieles gleichzeitig wichtig wirkt: nicht alles auf einmal lösen, sondern in dieser Reihenfolge.',
+      items: [
+        {
+          step: '1',
+          label: 'Akute Sicherheit zuerst',
+          detail:
+            'Lebensgefahr → 144. Suizidgedanken, schwere Eskalation, Kindeswohl in Gefahr → sofortige Krisenhilfe (siehe Anlaufstellen unten).',
+        },
+        {
+          step: '2',
+          label: 'Versorgung und Alltag',
+          detail:
+            'Sind Kinder verlässlich versorgt? Mahlzeiten, Schulweg, Aufsicht, Medikamenteneinnahme — was kippt zuerst, wer übernimmt?',
+        },
+        {
+          step: '3',
+          label: 'Grundsatzfragen später',
+          detail:
+            'Diagnostik, Behandlungsentscheidungen, langfristige Versorgung — wenn Sicherheit und Alltag stehen. Nicht in der akuten Phase verhandeln.',
+        },
+      ],
+    },
+    thresholds: {
+      title: 'Beobachtungen + Schwellen',
+      intro:
+        'Diese Beobachtungen helfen einzuschätzen, ob eine Fachstelle sinnvoll wird. Mehrere Items gleichzeitig im «jetzt anrufen»-Bereich: nicht weiter abwarten.',
+      items: [
+        {
+          observation: 'Mein:e Angehörige:r spricht von Suizid oder davon, niemandem mehr eine Last sein zu wollen.',
+          escalate: 'Sofort: 144 in akuter Lebensgefahr, sonst AERZTEFON oder Behandlungsteam.',
+        },
+        {
+          observation: 'Routinen lösen sich auf (Schlaf-Wach-Rhythmus, Essen, Hygiene) seit mehr als einer Woche.',
+          escalate: 'Bei Verschlechterung: AERZTEFON, Behandlungsteam, ggf. Pro Mente Sana zur Orientierung.',
+        },
+        {
+          observation: 'Kinder sind nicht mehr verlässlich versorgt (Schulweg, Mahlzeiten, Aufsicht).',
+          escalate: 'Sofort: kjz oder regionale Kindeswohl-Stelle. Nicht warten, bis es eskaliert.',
+        },
+        {
+          observation: 'Ich selbst kann nicht mehr schlafen, bin dauerhaft alarmiert oder ziehe mich zurück.',
+          escalate:
+            'Anhaltend: PUK Angehörigenberatung, Pro Mente Sana oder VASK. Eigene Erschöpfung ist ein legitimer Anlass.',
+        },
+        {
+          observation: 'Es gibt Eskalationen, Drohungen, Gewalt im Haushalt.',
+          escalate: 'Sofort: 144 (Polizei), Beratungsstelle, ggf. Kinderschutz. Eigene Sicherheit zuerst.',
+        },
+        {
+          observation: 'Wir sind unsicher, ob wir die richtige Stelle ansprechen — und schieben es deshalb auf.',
+          escalate: 'Lieber zu früh als zu spät: 143 (Dargebotene Hand) oder Pro Mente Sana zur Orientierung.',
+        },
+      ],
+    },
+    contacts: {
+      title: 'Anlaufstellen Schweiz',
+      intro: 'Notfallnummern gelten rund um die Uhr, kostenlos und auf Wunsch anonym.',
+      items: [
+        {
+          number: '144',
+          name: 'Sanität / Lebensgefahr',
+          detail: 'Sofort, rund um die Uhr, in akuter Lebensgefahr. Auch bei Suizidversuch.',
+        },
+        {
+          number: '143',
+          name: 'Die Dargebotene Hand',
+          detail: 'Anonym, kostenlos, 24/7 — auch zur ersten Orientierung, wenn unklar ist, wohin.',
+        },
+        {
+          number: '147',
+          name: 'Pro Juventute',
+          detail: 'Beratung für Kinder und Jugendliche, anonym, 24/7.',
+        },
+        {
+          number: '0800 33 66 55',
+          name: 'AERZTEFON Kanton Zürich',
+          detail: 'Medizinische Triage in nicht-lebensbedrohlichen Situationen.',
+        },
+        {
+          name: 'kjz',
+          detail: 'Kinder- und Jugendhilfezentren ZH — Beratung, Kindeswohlabklärung, regional.',
+        },
+        {
+          name: 'PUK Angehörigenberatung',
+          detail: 'Kostenlos, vertraulich, auch ohne PUK-Hospitalisation.',
+        },
+        {
+          name: 'Pro Mente Sana',
+          detail: 'Telefon- und Online-Beratung Schweiz für Angehörige und Betroffene.',
+        },
+      ],
+    },
+    selfNote: {
+      title: 'Eigene Erschöpfung ist ein legitimer Anlass',
+      text: 'Anhaltende Überforderung der angehörigen Person ist selbst ein Grund, Hilfe zu holen — nicht erst, wenn auch andere kippen. Angehörigenberatung ist genau dafür da, und sie kostet im Erstgespräch in der Regel nichts.',
+    },
+    disclaimer:
+      'Diese Karte ist eine Orientierungshilfe, kein klinisches Triage-Werkzeug. In jeder akuten Lebensgefahr gilt zuerst 144. Bei Unsicherheit über Kindeswohl: lieber einmal zu früh beim kjz anrufen als einmal zu spät.',
+    crossRefs: {
+      title: 'Verwandte Inhalte',
+      items: [
+        {
+          kind: 'faq',
+          label: 'Aus dem FAQ: Cluster 3 «Zusammenarbeit und nächste Schritte»',
+          anchor: '#material-zusammenarbeit',
+        },
+        {
+          kind: 'faq',
+          label: 'Aus dem FAQ: Cluster 2 «Grenzen und Selbstschutz»',
+          anchor: '#material-grenzen',
+        },
+        {
+          kind: 'navigation',
+          label: 'Vollständiges Fachstellen-Verzeichnis im Netzwerk-Tab',
+          target: 'netzwerk',
+        },
+      ],
+    },
+  },
 ];
 
 // Zielgruppen-Blöcke fuer die Material-Cluster (Issues #102 + #103). Die sechs

--- a/src/styles/app-global.css
+++ b/src/styles/app-global.css
@@ -390,6 +390,141 @@
     font-size: 9pt;
   }
 
+  /* Tier-1-Handouts (Issues #112 + #113): geteilte Section-Bausteine. */
+  .ui-material-handout__section-intro,
+  .ui-material-handout__section-note {
+    color: #000;
+    font-size: 10pt;
+  }
+
+  /* Conversation-Script (H-2): Opener + Q&A + Prompt-Box auf Papier. */
+  .ui-material-handout__opener {
+    background: #fff !important;
+    border: none;
+    border-left: 1.5pt solid #000;
+    border-radius: 0;
+    padding: 2mm 4mm;
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+  .ui-material-handout__opener-text {
+    color: #000;
+    font-size: 11pt;
+  }
+  .ui-material-handout__opener-note {
+    color: #000;
+    font-size: 9pt;
+  }
+  .ui-material-handout__qa-list,
+  .ui-material-handout__notes {
+    page-break-inside: auto;
+    break-inside: auto;
+  }
+  .ui-material-handout__qa-item {
+    background: #fff !important;
+    border: 0.5pt solid #999;
+    padding: 3mm 4mm;
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+  .ui-material-handout__qa-question {
+    color: #000;
+    font-size: 11pt;
+  }
+  .ui-material-handout__qa-number {
+    color: #000;
+  }
+  .ui-material-handout__qa-anchor {
+    color: #000;
+    font-size: 10pt;
+  }
+  .ui-material-handout__prompt {
+    background: #fff !important;
+    border: none;
+    border-left: 1.5pt solid #000;
+    border-radius: 0;
+    padding: 2mm 4mm;
+    color: #000;
+    font-size: 11pt;
+  }
+  .ui-material-handout__notes li {
+    color: #000;
+    font-size: 10pt;
+  }
+
+  /* Threshold-Checklist (H-6): Steps + Beobachtungen + Anlaufstellen + Callout. */
+  .ui-material-handout__steps {
+    page-break-inside: auto;
+    break-inside: auto;
+  }
+  .ui-material-handout__step {
+    background: #fff !important;
+    border: 0.5pt solid #999;
+    padding: 2mm 4mm;
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+  .ui-material-handout__step-number {
+    background: #000 !important;
+    color: #fff !important;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+    width: 6mm;
+    height: 6mm;
+    font-size: 10pt;
+  }
+  .ui-material-handout__step-label {
+    color: #000;
+    font-size: 11pt;
+  }
+  .ui-material-handout__step-detail {
+    color: #000;
+    font-size: 10pt;
+  }
+  .ui-material-handout__thresholds,
+  .ui-material-handout__contacts {
+    page-break-inside: auto;
+    break-inside: auto;
+  }
+  .ui-material-handout__threshold,
+  .ui-material-handout__contact {
+    background: #fff !important;
+    border: 0.5pt solid #999;
+    padding: 2mm 4mm;
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+  .ui-material-handout__threshold-observation {
+    color: #000;
+    font-size: 11pt;
+  }
+  .ui-material-handout__threshold-escalate {
+    color: #000;
+    font-size: 10pt;
+  }
+  .ui-material-handout__contact-number {
+    color: #000;
+    font-size: 11pt;
+  }
+  .ui-material-handout__contact-name {
+    color: #000;
+    font-size: 11pt;
+  }
+  .ui-material-handout__contact-detail {
+    color: #000;
+    font-size: 10pt;
+  }
+  .ui-material-handout__callout {
+    background: #fff !important;
+    border: 1.2pt solid #000;
+    color: #000;
+    padding: 3mm 4mm;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
   /* 10. Vignetten-Print-Hinweis (V1 aus Audit 11) ------------------------ *
    * Die Vignetten-Seite ist bewusst nicht druckbar. Der Hinweis erscheint
    * zentral und ruhig auf der ansonsten leeren Druckseite.

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -2506,6 +2506,272 @@
   text-decoration: underline;
 }
 
+/* Tier-1-Handouts (Issues #112 + #113) — geteilte Section-Bausteine. */
+.ui-material-handout__section-intro {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+}
+
+.ui-material-handout__section-note {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+  font-style: italic;
+}
+
+/* Conversation-Script (H-2): Opener-Blockquote + Q&A-Liste + Verstehens-Check. */
+.ui-material-handout__opener {
+  margin: 0;
+  padding: var(--space-4);
+  border-left: 3px solid var(--accent-primary-strong);
+  border-radius: var(--radius-md);
+  background: var(--surface-app);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.ui-material-handout__opener-text {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  line-height: var(--line-height-copy);
+  color: var(--text-primary);
+}
+
+.ui-material-handout__opener-note {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+  color: var(--text-secondary);
+}
+
+.ui-material-handout__qa-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.ui-material-handout__qa-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-app);
+}
+
+.ui-material-handout__qa-question {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  line-height: var(--line-height-copy);
+  color: var(--text-primary);
+}
+
+.ui-material-handout__qa-number {
+  display: inline-block;
+  margin-right: 0.25rem;
+  color: var(--accent-primary-strong);
+  font-weight: 700;
+}
+
+.ui-material-handout__qa-anchor {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+  color: var(--text-secondary);
+}
+
+.ui-material-handout__prompt {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  border-left: 3px solid var(--accent-secondary, #a1be95);
+  background: var(--surface-app);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  line-height: var(--line-height-copy);
+  color: var(--text-primary);
+}
+
+.ui-material-handout__notes {
+  list-style: disc;
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.ui-material-handout__notes li {
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+  color: var(--text-secondary);
+}
+
+/* Threshold-Checklist (H-6): Reihenfolge-Steps + Beobachtungs-Liste +
+   Anlaufstellen + Selbst-Schwelle als Callout. */
+.ui-material-handout__steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.ui-material-handout__step {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-4);
+  align-items: start;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-app);
+}
+
+.ui-material-handout__step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: var(--accent-primary-strong);
+  color: var(--surface-panel);
+  font-weight: 700;
+  font-size: var(--font-size-sm);
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.ui-material-handout__step-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.ui-material-handout__step-label {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  line-height: var(--line-height-heading);
+  color: var(--text-primary);
+}
+
+.ui-material-handout__step-detail {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+  color: var(--text-secondary);
+}
+
+.ui-material-handout__thresholds {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.ui-material-handout__threshold {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-app);
+}
+
+.ui-material-handout__threshold-observation {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  line-height: var(--line-height-copy);
+  color: var(--text-primary);
+}
+
+.ui-material-handout__threshold-escalate {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+  color: var(--text-secondary);
+}
+
+.ui-material-handout__contacts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.ui-material-handout__contact {
+  display: grid;
+  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+  gap: var(--space-4);
+  align-items: start;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-app);
+}
+
+.ui-material-handout__contact-number {
+  font-size: var(--font-size-md);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--accent-primary-strong);
+  white-space: nowrap;
+}
+
+.ui-material-handout__contact-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.ui-material-handout__contact-name {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  line-height: var(--line-height-heading);
+  color: var(--text-primary);
+}
+
+.ui-material-handout__contact-detail {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+  color: var(--text-secondary);
+}
+
+.ui-material-handout__callout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  background: var(--surface-note);
+  color: var(--text-primary);
+}
+
+.ui-material-handout__callout p:last-child {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+}
+
 .ui-toolbox-quick-access {
   border-radius: calc(var(--radius-xl) + 0.25rem);
   background: var(--surface-app);
@@ -2708,6 +2974,17 @@
   .ui-material-handout__print-btn {
     align-self: flex-start;
     flex-shrink: 0;
+  }
+
+  /* Tier-1-Handouts: zweispaltige Beobachtungs-Items + Anlaufstellen-Liste
+     auf Tablet/Desktop. Steps und Q&A bleiben einspaltig — die linearen
+     Lese-Reihenfolgen sind Teil der Mechanik. */
+  .ui-material-handout__thresholds {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ui-material-handout__contacts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/src/templates/MaterialPageTemplate.jsx
+++ b/src/templates/MaterialPageTemplate.jsx
@@ -258,10 +258,234 @@ function MaterialCrisisPlan({ handout, onNavigate, onPrintHandout }) {
   );
 }
 
+/**
+ * Wiederverwendbare Bausteine fuer die Tier-1-Handouts (Issues #112 + #113).
+ * MaterialCrisisPlan ist bewusst NICHT auf diese Helper umgestellt -- die
+ * existierende DOM-Struktur ist von den Print-Tests + Print-Typografie in
+ * app-global.css abhaengig. Refactoring auf gemeinsame Bausteine kommt als
+ * separate Welle, sobald das Pattern bei 3+ Handouts stabil ist.
+ */
+function MaterialHandoutHead({ handout, onPrintHandout }) {
+  return (
+    <header className="ui-material-handout__head">
+      <div className="ui-material-handout__head-text">
+        <p className="ui-fact-card__label">{handout.eyebrow}</p>
+        <h3 className="ui-material-handout__title">{handout.title}</h3>
+        <p className="ui-material-handout__lead">{handout.description}</p>
+      </div>
+      {onPrintHandout ? (
+        <button
+          type="button"
+          className="ui-material-handout__print-btn no-print"
+          data-action="print"
+          onClick={() => onPrintHandout(handout.id)}
+          aria-label={`${handout.title} drucken oder als PDF speichern`}
+        >
+          <Printer size={14} aria-hidden="true" />
+          <span>Drucken / PDF</span>
+        </button>
+      ) : null}
+    </header>
+  );
+}
+
+function MaterialHandoutUsage({ usage }) {
+  return (
+    <div className="ui-material-handout__usage" aria-label="Hinweise zur Nutzung">
+      <div className="ui-material-handout__usage-item">
+        <p className="ui-fact-card__label">Wann</p>
+        <p>{usage.when}</p>
+      </div>
+      <div className="ui-material-handout__usage-item">
+        <p className="ui-fact-card__label">Mit wem</p>
+        <p>{usage.people}</p>
+      </div>
+      <div className="ui-material-handout__usage-item">
+        <p className="ui-fact-card__label">Wie lange gilt es</p>
+        <p>{usage.validity}</p>
+      </div>
+      <div className="ui-material-handout__usage-item">
+        <p className="ui-fact-card__label">Wohin damit</p>
+        <p>{usage.where}</p>
+      </div>
+    </div>
+  );
+}
+
+function MaterialHandoutDisclaimer({ disclaimer }) {
+  if (!disclaimer) return null;
+  return (
+    <div className="ui-material-handout__disclaimer" role="note">
+      <p>{disclaimer}</p>
+    </div>
+  );
+}
+
+/**
+ * Tier-1-Handout (Issue #112): Gespraech-Skript fuer betroffene Eltern.
+ * Format B (Conversation Script) -- vorbereiteter Einstieg, fuenf typische
+ * Kinder-Fragen mit Antwort-Ankern, Verstehens-Check + Prozess-Notizen.
+ */
+function MaterialConversationScript({ handout, onNavigate, onPrintHandout }) {
+  return (
+    <article id={handout.id} data-handout-id={handout.id} className="ui-material-handout ui-section-anchor-offset">
+      <MaterialHandoutHead handout={handout} onPrintHandout={onPrintHandout} />
+      <MaterialHandoutUsage usage={handout.usage} />
+
+      {handout.opener ? (
+        <section className="ui-material-handout__section">
+          <h4 className="ui-material-handout__section-title">{handout.opener.title}</h4>
+          <blockquote className="ui-material-handout__opener">
+            <p className="ui-material-handout__opener-text">{handout.opener.text}</p>
+            {handout.opener.note ? <p className="ui-material-handout__opener-note">{handout.opener.note}</p> : null}
+          </blockquote>
+        </section>
+      ) : null}
+
+      {handout.childQuestions?.items?.length ? (
+        <section className="ui-material-handout__section">
+          <h4 className="ui-material-handout__section-title">{handout.childQuestions.title}</h4>
+          {handout.childQuestions.intro ? (
+            <p className="ui-material-handout__section-intro">{handout.childQuestions.intro}</p>
+          ) : null}
+          <ol className="ui-material-handout__qa-list">
+            {handout.childQuestions.items.map((item, index) => (
+              <li key={item.question} className="ui-material-handout__qa-item">
+                <p className="ui-material-handout__qa-question">
+                  <span className="ui-material-handout__qa-number">{index + 1}.</span> {item.question}
+                </p>
+                <p className="ui-material-handout__qa-anchor">{item.anchor}</p>
+              </li>
+            ))}
+          </ol>
+        </section>
+      ) : null}
+
+      {handout.understandingCheck ? (
+        <section className="ui-material-handout__section">
+          <h4 className="ui-material-handout__section-title">{handout.understandingCheck.title}</h4>
+          {handout.understandingCheck.intro ? (
+            <p className="ui-material-handout__section-intro">{handout.understandingCheck.intro}</p>
+          ) : null}
+          <p className="ui-material-handout__prompt">{handout.understandingCheck.prompt}</p>
+          {handout.understandingCheck.note ? (
+            <p className="ui-material-handout__section-note">{handout.understandingCheck.note}</p>
+          ) : null}
+        </section>
+      ) : null}
+
+      {handout.process?.items?.length ? (
+        <section className="ui-material-handout__section">
+          <h4 className="ui-material-handout__section-title">{handout.process.title}</h4>
+          <ul className="ui-material-handout__notes">
+            {handout.process.items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <MaterialHandoutDisclaimer disclaimer={handout.disclaimer} />
+      <MaterialHandoutCrossRefs crossRefs={handout.crossRefs} onNavigate={onNavigate} />
+    </article>
+  );
+}
+
+/**
+ * Tier-1-Handout (Issue #113): Schwellen-Karte fuer Angehoerige. Format C
+ * (Threshold Checklist) -- Reihenfolge in der Krise, Beobachtungs-Items mit
+ * klarer Wenn-Dann-Logik, kompakte CH-Anlaufstellen, Selbst-Schwelle als
+ * legitimer Anlass.
+ */
+function MaterialThresholdChecklist({ handout, onNavigate, onPrintHandout }) {
+  return (
+    <article id={handout.id} data-handout-id={handout.id} className="ui-material-handout ui-section-anchor-offset">
+      <MaterialHandoutHead handout={handout} onPrintHandout={onPrintHandout} />
+      <MaterialHandoutUsage usage={handout.usage} />
+
+      {handout.priorityRule?.items?.length ? (
+        <section className="ui-material-handout__section">
+          <h4 className="ui-material-handout__section-title">{handout.priorityRule.title}</h4>
+          {handout.priorityRule.intro ? (
+            <p className="ui-material-handout__section-intro">{handout.priorityRule.intro}</p>
+          ) : null}
+          <ol className="ui-material-handout__steps">
+            {handout.priorityRule.items.map((step) => (
+              <li key={step.step} className="ui-material-handout__step">
+                <span className="ui-material-handout__step-number" aria-hidden="true">
+                  {step.step}
+                </span>
+                <div className="ui-material-handout__step-body">
+                  <p className="ui-material-handout__step-label">{step.label}</p>
+                  <p className="ui-material-handout__step-detail">{step.detail}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
+      ) : null}
+
+      {handout.thresholds?.items?.length ? (
+        <section className="ui-material-handout__section">
+          <h4 className="ui-material-handout__section-title">{handout.thresholds.title}</h4>
+          {handout.thresholds.intro ? (
+            <p className="ui-material-handout__section-intro">{handout.thresholds.intro}</p>
+          ) : null}
+          <ul className="ui-material-handout__thresholds">
+            {handout.thresholds.items.map((item) => (
+              <li key={item.observation} className="ui-material-handout__threshold">
+                <p className="ui-material-handout__threshold-observation">{item.observation}</p>
+                <p className="ui-material-handout__threshold-escalate">
+                  <span className="ui-fact-card__label">Wenn ja</span>
+                  {item.escalate}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {handout.contacts?.items?.length ? (
+        <section className="ui-material-handout__section">
+          <h4 className="ui-material-handout__section-title">{handout.contacts.title}</h4>
+          {handout.contacts.intro ? (
+            <p className="ui-material-handout__section-intro">{handout.contacts.intro}</p>
+          ) : null}
+          <ul className="ui-material-handout__contacts">
+            {handout.contacts.items.map((c) => (
+              <li key={`${c.number || ''}-${c.name || ''}`} className="ui-material-handout__contact">
+                {c.number ? <span className="ui-material-handout__contact-number">{c.number}</span> : null}
+                <div className="ui-material-handout__contact-body">
+                  {c.name ? <p className="ui-material-handout__contact-name">{c.name}</p> : null}
+                  {c.detail ? <p className="ui-material-handout__contact-detail">{c.detail}</p> : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {handout.selfNote ? (
+        <aside className="ui-material-handout__callout" aria-label={handout.selfNote.title}>
+          <p className="ui-fact-card__label">{handout.selfNote.title}</p>
+          <p>{handout.selfNote.text}</p>
+        </aside>
+      ) : null}
+
+      <MaterialHandoutDisclaimer disclaimer={handout.disclaimer} />
+      <MaterialHandoutCrossRefs crossRefs={handout.crossRefs} onNavigate={onNavigate} />
+    </article>
+  );
+}
+
 function MaterialHandoutSwitch({ handout, onNavigate, onPrintHandout }) {
   switch (handout.kind) {
     case 'crisis-plan':
       return <MaterialCrisisPlan handout={handout} onNavigate={onNavigate} onPrintHandout={onPrintHandout} />;
+    case 'conversation-script':
+      return <MaterialConversationScript handout={handout} onNavigate={onNavigate} onPrintHandout={onPrintHandout} />;
+    case 'threshold-checklist':
+      return <MaterialThresholdChecklist handout={handout} onNavigate={onNavigate} onPrintHandout={onPrintHandout} />;
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

- **H-2 Conversation-Script** (Issue #112) für betroffene Eltern: Skript-Vorlage fürs erste Gespräch mit dem Kind — vorbereiteter Einstiegssatz, fünf typische Kinder-Fragen mit Antwort-Ankern (Stauber 2018; Lenz 2010), Verstehens-Check + Prozess-Hinweise.
- **H-6 Threshold-Checklist** (Issue #113) für Angehörige: Schwellen-Karte mit Reihenfolge in der Krise (Sicherheit → Versorgung → Grundsatz), sechs Beobachtungs-Items mit Wenn-Dann-Logik, CH-Anlaufstellen inkl. Notfallnummern (144/143/147), Selbst-Schwelle als Callout.
- Beide nutzen den existierenden Print-Mechanismus (`useMaterialHandoutPrint` + `data-handout-id`-Scope). Gemeinsame Helper `MaterialHandoutHead` / `MaterialHandoutUsage` / `MaterialHandoutDisclaimer` für die neuen Komponenten — `MaterialCrisisPlan` bleibt bewusst unverändert (DOM-Stabilität für bestehende Print-Tests).

## Mechanik

- `MATERIAL_HANDOUTS` in `src/data/materialContent.js` um zwei Objekte erweitert (`kind: 'conversation-script'` und `kind: 'threshold-checklist'`).
- `MaterialHandoutSwitch` in `MaterialPageTemplate.jsx` um zwei Cases erweitert.
- Screen-CSS in `primitives.css` (~20 neue BEM-Klassen) + Print-CSS in `app-global.css` §9 für papierfreundliche Darstellung.
- `CLAUDE.md`: Material-Handouts-Sektion um Auflistung aller bekannten `kind`-Werte + Daten-Schemata erweitert.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx prettier --check` — clean (auto-format auf data + spec angewandt)
- [x] `npm run build` — clean (Bundle: MaterialSection 57 KB → 17 KB gz)
- [x] `npx playwright test` — 37/37 grün, davon 2 neue Tests für die neuen Handouts
- [ ] Manuell auf Material-Tab geprüft: beide Handouts sichtbar, Print-Buttons funktionieren, Browser-Druckdialog zeigt isoliertes Handout
- [ ] Manuell mit `prefers-reduced-motion` geprüft (keine Animationen in den neuen Komponenten, daher unkritisch)

Closes #112
Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)