### PR TITLE
docs(audience): primaryAudience-Framework dokumentieren + Runtime-Guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,11 +62,50 @@ Die FAQ-Cluster im Material-Tab adressieren zwei Gruppen: Cluster 1–3 Angehör
 
 Neue Cluster hinzufügen: `audience`-Feld nicht vergessen. Wenn eine neue Zielgruppe dazukommt, einen weiteren Eintrag in `MATERIAL_CLUSTER_AUDIENCES` anlegen und ggf. eine Badge-Variante in `primitives.css` unter `.ui-badge[data-audience='…']` ergänzen.
 
-## Zielgruppen
+## Zielgruppen (`primaryAudience`-Framework)
 
-- **Primäradressat aller Tabs: Fachpersonen** (Erwachsenenpsychiatrie und Beratungskontext). Default, sobald ein Tab kein `primaryAudience`-Feld in `appShellContent.js` trägt.
-- **Ausnahme: der Material-Tab** (`#material`). Inhalte sind als Handout-Material gerahmt, das Fachpersonen im Gespräch mit Patient:innen und Angehörigen einsetzen oder zur Weitergabe verlinken. Trägt `primaryAudience: 'weitergabe'`.
-- Mischung der Adressaten innerhalb eines Tabs bewusst vermeiden. Wenn unklar ist, welcher Zielgruppe ein neuer Inhalt dient: eher auf Fachperson zuspitzen und entlastendes/erklärendes Weitergabe-Material im Material-Tab bündeln.
+Jeder Tab in `TAB_ITEMS` (`src/data/appShellContent.js`) trägt ein **Pflichtfeld `primaryAudience`** mit genau einem von zwei Werten:
+
+| Wert           | Adressat                                                                                         | Tabs                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| `'fachperson'` | Fachpersonen in Erwachsenenpsychiatrie + Beratungskontext (Default)                              | Start, Lernmodule, Vignetten, Glossar, Evidenz, Toolbox, Netzwerk |
+| `'weitergabe'` | Patient:innen und Angehörige — Material, das Fachpersonen im Gespräch einsetzen oder weitergeben | Material                                                          |
+
+Die JSDoc-Union `PrimaryAudience = FachpersonAudience | WeitergabeAudience` macht den Wertebereich explizit. Ein Dev-Mode-Guard in `appShellContent.js` prüft beim Laden, dass jeder Tab einen gültigen Wert trägt — ohne Test-Framework, ohne Production-Overhead.
+
+### Was `primaryAudience` steuert (redaktionelle Hand)
+
+Der Marker ist kein Layout-Schalter, sondern eine **redaktionelle Selbstverpflichtung**: Er steuert die Sprache, Anrede, Beispiele und Disclaimer-Tonalität für den gesamten Tab.
+
+| Signal               | `'fachperson'`                                                                  | `'weitergabe'`                                           |
+| -------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Anrede               | Sie / unpersönlich / passiv                                                     | Sie / Du, situativ — eher direkt an Betroffene           |
+| Vokabular            | Fachbegriffe ohne Erklärung erlaubt (Parentifizierung, Schweigepflicht, Triage) | Alltagssprache; Fachbegriffe nur mit Klammer-Erklärung   |
+| Beispiele            | klinische Fallrahmungen, Versorgungs-Situationen                                | familiäre Alltags-Situationen, kindbezogene Konkretionen |
+| Disclaimer-Tonalität | „nicht als Diagnose-/Urteilsinstrument"                                         | „kein Therapieersatz, bei Belastung Fachstelle X"        |
+| Aside / Eyebrow      | „Klinische Orientierung", „Fachpraxis", „Versorgungsalltag"                     | „Handout für Eltern", „Handout für Angehörige"           |
+
+### Entscheidungs-Logik für neue Tabs
+
+Wenn ein neuer Tab dazukommt, beantworte zuerst diese Frage:
+
+> **Wer hält das Material in der Hand, während er es liest — die Fachperson oder die betroffene Person?**
+
+- Liest die **Fachperson**, um daraus eine Einschätzung / ein Gespräch / eine Vermittlung zu bauen → `'fachperson'`.
+- Liest die **betroffene Person** (oder ein Angehöriger / ein Kind), möglicherweise allein, möglicherweise nach Übergabe durch eine Fachperson → `'weitergabe'`.
+
+Im Zweifel: `'fachperson'` wählen und das weitergabe-fähige Teilstück als druckbares Handout im Material-Tab bündeln (statt einen Mischtab zu bauen).
+
+### Mischung innerhalb eines Tabs vermeiden
+
+Mischadressaten innerhalb eines Tabs erzeugen Mikro-Brüche, die Lesende verunsichern (plötzliches Du, plötzlicher Fachjargon). Wenn ein Cluster oder ein Block aus dem deklarierten Frame fällt, gibt es zwei legitime Auswege:
+
+1. **Umformulieren** in den Frame des Tabs (z. B. „Wer gehört zur Kernfamilie der/des Betroffenen?" statt „Wer gehört zu deiner Kernfamilie?").
+2. **Explizit als Sub-Adressat markieren** mit dem `audience`-Pattern aus dem Material-Tab (Block-Header + Audience-Badge pro Cluster — siehe „Material-Cluster: Zielgruppen-Blöcke" oben). Dieses Pattern ist aktuell nur im Material-Tab im Einsatz und kann bei Bedarf auf andere Tabs übertragen werden.
+
+### Bekannte offene Mismatches (Stand: dieser PR)
+
+- **Netzwerk-Tab**: `NETWORK_MAP_QUESTIONS` (`networkContent.js`) verwendet Du-Anrede an Patient:innen („Wer gehört zu **deiner** Kernfamilie", „Mit wem kannst **du** reden") — bricht den Fachperson-Frame des Tabs. Lösung: Umformulieren in Sie-Form / Fachperson-Perspektive. Wird nicht in diesem Doku-PR gefixt — Folge-Issue empfohlen.
 
 ## Konventionen
 

--- a/src/data/appShellContent.js
+++ b/src/data/appShellContent.js
@@ -17,14 +17,26 @@ import { FACHSTELLEN, SUPPORT_OFFER_IDS } from './fachstellenContent';
  */
 
 /**
+ * @typedef {('fachperson')} FachpersonAudience
+ * Default-Adressat des Portals: Fachpersonen in Erwachsenenpsychiatrie
+ * und Beratungskontext. Sie-Anrede, Fach-Vokabular, klinische Rahmung,
+ * Neutralitaet ohne therapeutische Direktive. Sieben von acht Tabs
+ * tragen diese Markierung.
+ */
+
+/**
  * @typedef {('weitergabe')} WeitergabeAudience
- * Redaktionelles Metadatum fuer Ausnahme-Tabs. Seit Audience-Cut-Phase 2
- * ist Fachperson der Default — nur der Material-Tab traegt das Feld
- * `primaryAudience: 'weitergabe'`, weil seine Inhalte als Handout-Material
- * an Patient:innen und Angehoerige gedacht sind (Fachperson nutzt sie im
- * Gespraech oder gibt sie weiter). Das Nav-Label "Material" traegt das
- * Zielgruppen-Signal selbst, deshalb ist der frueher zusaetzlich gesetzte
- * audienceBadge hier entfallen.
+ * Ausnahme-Adressat: Patient:innen und Angehoerige. Inhalte sind als
+ * Handout-Material gerahmt, das Fachpersonen im Gespraech einsetzen oder
+ * zur Weitergabe verlinken. Sprache zugaenglich, Anrede situativ (oft Du),
+ * keine Fachsprache ohne Erklaerung. Aktuell traegt nur der Material-Tab
+ * dieses Feld.
+ */
+
+/**
+ * @typedef {FachpersonAudience | WeitergabeAudience} PrimaryAudience
+ * Diskriminierte Union — jeder Tab muss genau einen der beiden Werte
+ * tragen. Fehlende oder andere Werte sind ein Fehler.
  */
 
 /**
@@ -34,10 +46,10 @@ import { FACHSTELLEN, SUPPORT_OFFER_IDS } from './fachstellenContent';
  * @property {React.ComponentType} icon - Lucide-React-Icon-Komponente.
  * @property {string} footerNote - Kurzer Beschreibungstext fuer den Footer.
  * @property {'primary'} priority - Aktuell sind alle Top-Level-Tabs 'primary'.
- * @property {WeitergabeAudience} [primaryAudience] - Optional. Nur gesetzt
- *   fuer Tabs, deren Inhalte als Material zur Weitergabe an Patient:innen
- *   und Angehoerige gedacht sind. Fehlendes Feld bedeutet: Default-Adressat
- *   Fachperson.
+ * @property {PrimaryAudience} primaryAudience - Pflichtfeld. Steuert die
+ *   redaktionelle Hand fuer den gesamten Tab: Sprache, Anrede, Beispiele,
+ *   Disclaimer-Tonalitaet. Siehe CLAUDE.md "Zielgruppen" fuer die
+ *   Entscheidungslogik.
  * @property {string} [audienceBadge] - Optional. Sichtbarer Zielgruppen-
  *   Marker im Nav-Button (Desktop + Mobile). Aktuell ungenutzt — fuer
  *   kuenftige Sub-Adressat-Markierung pro Cluster reserviert (siehe
@@ -46,18 +58,27 @@ import { FACHSTELLEN, SUPPORT_OFFER_IDS } from './fachstellenContent';
 
 /** @type {TabItem[]} */
 export const TAB_ITEMS = [
-  // Default-Adressat aller Tabs ohne explizites primaryAudience-Feld:
-  // Fachperson. Nur der Material-Tab traegt `primaryAudience: 'weitergabe'`,
-  // weil seine Inhalte als Handout-Material an Patient:innen und Angehoerige
-  // gedacht sind. Das Nav-Label "Material" traegt das Zielgruppen-Signal
-  // selbst, deshalb ist dort aktuell kein zusaetzlicher audienceBadge gesetzt.
-  { id: 'start', label: 'Start', icon: LayoutDashboard, footerNote: 'Dashboard und Orientierung', priority: 'primary' },
+  // Jeder Tab traegt explizit `primaryAudience`. Sieben von acht sind
+  // 'fachperson' (Default-Adressat: Erwachsenenpsychiatrie + Beratung).
+  // Nur der Material-Tab ist 'weitergabe' — Handouts fuer Patient:innen
+  // und Angehoerige, die Fachpersonen im Gespraech einsetzen oder
+  // weitergeben. Entscheidungslogik fuer kuenftige Tabs in CLAUDE.md
+  // "Zielgruppen".
+  {
+    id: 'start',
+    label: 'Start',
+    icon: LayoutDashboard,
+    footerNote: 'Dashboard und Orientierung',
+    priority: 'primary',
+    primaryAudience: 'fachperson',
+  },
   {
     id: 'lernmodule',
     label: 'Lernmodule',
     icon: GraduationCap,
     footerNote: 'Kurzformate für Fachpraxis',
     priority: 'primary',
+    primaryAudience: 'fachperson',
   },
   {
     id: 'vignetten',
@@ -65,6 +86,7 @@ export const TAB_ITEMS = [
     icon: HeartHandshake,
     footerNote: 'Fallreflexion und Dialog',
     priority: 'primary',
+    primaryAudience: 'fachperson',
   },
   {
     id: 'glossar',
@@ -72,6 +94,7 @@ export const TAB_ITEMS = [
     icon: BookOpenText,
     footerNote: 'Begriffe, Konzepte und Sprache',
     priority: 'primary',
+    primaryAudience: 'fachperson',
   },
   {
     id: 'material',
@@ -87,6 +110,7 @@ export const TAB_ITEMS = [
     icon: Activity,
     footerNote: 'Kapitel, Vertiefung, Materialien',
     priority: 'primary',
+    primaryAudience: 'fachperson',
   },
   {
     id: 'toolbox',
@@ -94,6 +118,7 @@ export const TAB_ITEMS = [
     icon: ClipboardCheck,
     footerNote: 'Triage, Schutz, nächste Schritte',
     priority: 'primary',
+    primaryAudience: 'fachperson',
   },
   {
     id: 'netzwerk',
@@ -101,8 +126,26 @@ export const TAB_ITEMS = [
     icon: MapPin,
     footerNote: 'Fachstellen und Weitervermittlung',
     priority: 'primary',
+    primaryAudience: 'fachperson',
   },
 ];
+
+// Dev-Guard: jeder TabItem muss ein gueltiges `primaryAudience` tragen.
+// Laeuft nur im Dev-Build (Vite-Konstante DEV) und kostet in Production
+// nichts. Verhindert, dass kuenftige Tab-Eintraege das Pflichtfeld
+// vergessen — ohne ein eigenes Test-Framework dafuer aufzusetzen.
+if (import.meta.env?.DEV) {
+  const VALID_AUDIENCES = new Set(['fachperson', 'weitergabe']);
+  for (const tab of TAB_ITEMS) {
+    if (!VALID_AUDIENCES.has(tab.primaryAudience)) {
+      console.error(
+        `[appShellContent] TAB_ITEMS["${tab.id}"]: primaryAudience fehlt oder ist ungueltig ` +
+          `(erwartet: 'fachperson' | 'weitergabe', erhalten: ${JSON.stringify(tab.primaryAudience)}). ` +
+          `Siehe CLAUDE.md "Zielgruppen" fuer die Entscheidungslogik.`
+      );
+    }
+  }
+}
 
 // Zwei unabhaengige Versionsachsen -- bewusst nicht synchron:
 //


### PR DESCRIPTION
## Summary

Schliesst #106. Vertieft das `primaryAudience`-Framework — die redaktionelle Hand pro Tab (Sprache, Anrede, Vokabular, Beispiele, Disclaimer-Tonalitaet).

- **CLAUDE.md "Zielgruppen"**: Werte-Tabelle (fachperson = 7 Tabs, weitergabe = Material), Signal-Tabelle pro Audience, Entscheidungs-Heuristik *"Wer haelt das Material in der Hand"*, Mischungs-Vermeidung mit zwei legitimen Auswegen.
- **src/data/appShellContent.js**: JSDoc-Union `PrimaryAudience = FachpersonAudience | WeitergabeAudience`, `primaryAudience` als Pflichtfeld auf TabItem, alle 7 Nicht-Material-Tabs explizit auf `'fachperson'` gesetzt, Dev-Mode-Guard (`import.meta.env?.DEV`) prueft beim Modulladen jeden Tab.

Statt eigener ESLint-Regel (zu viel Scope fuer einen Doku-PR) ein leichter Dev-Mode-Runtime-Guard, der `console.error` wirft, wenn ein Tab den Pflichtwert vergisst — kein Production-Overhead.

## Audit-Befund (in CLAUDE.md dokumentiert)

Beim Sprach-Audit der Sections gegen die deklarierte Audience: ein realer Mismatch gefunden.

- **Netzwerk-Tab** (deklariert: `'fachperson'`): `NETWORK_MAP_QUESTIONS` in `networkContent.js` benutzt Du-Anrede an Patient:innen ("Wer gehoert zu **deiner** Kernfamilie", "Mit wem kannst **du** reden") — bricht den Fachperson-Frame des Tabs.
- **Toolbox-Tab**: Issue #106 vermutete eine Anrede-Mischung in der Konversations-Struktur "Pruefen/Planen/Dokumentieren". Im aktuellen Toolbox-Code findet sich diese Struktur nicht — es wird durchgaengig "Assessment/Score-Bands" verwendet, klar Fachperson. Verdacht entkraeftet.

Der Netzwerk-Mismatch wird in diesem Doku-PR bewusst NICHT mitgefixt — separater Folge-Issue empfohlen (Umformulierung in Sie-Form).

## Test plan

- [x] `npm run lint` clean (eine Vorab-Warnung zu unused `eslint-disable` in dieser Iteration entfernt)
- [x] `npx prettier --check CLAUDE.md src/data/appShellContent.js` clean
- [x] `npm run build` clean
- [x] `npm run test:e2e` — 37/37 grün (kein neuer Test angelegt, da Doku + Dev-Guard ohne Production-Code-Pfad)
- [ ] Manuell verifizieren: Dev-Server starten und einen Tab in `appShellContent.js` testweise auf `primaryAudience: 'invalid'` setzen → Guard sollte `console.error` mit Tab-ID + erwartetem Wertebereich werfen

🤖 Generated with [Claude Code](https://claude.com/claude-code)