### PR TITLE
fix(network): Leitfragen von Du- auf Fachperson-Perspektive umstellen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,9 +103,13 @@ Mischadressaten innerhalb eines Tabs erzeugen Mikro-Brüche, die Lesende verunsi
 1. **Umformulieren** in den Frame des Tabs (z. B. „Wer gehört zur Kernfamilie der/des Betroffenen?" statt „Wer gehört zu deiner Kernfamilie?").
 2. **Explizit als Sub-Adressat markieren** mit dem `audience`-Pattern aus dem Material-Tab (Block-Header + Audience-Badge pro Cluster — siehe „Material-Cluster: Zielgruppen-Blöcke" oben). Dieses Pattern ist aktuell nur im Material-Tab im Einsatz und kann bei Bedarf auf andere Tabs übertragen werden.
 
-### Bekannte offene Mismatches (Stand: dieser PR)
+### Bekannte Mismatches
 
-- **Netzwerk-Tab**: `NETWORK_MAP_QUESTIONS` (`networkContent.js`) verwendet Du-Anrede an Patient:innen („Wer gehört zu **deiner** Kernfamilie", „Mit wem kannst **du** reden") — bricht den Fachperson-Frame des Tabs. Lösung: Umformulieren in Sie-Form / Fachperson-Perspektive. Wird nicht in diesem Doku-PR gefixt — Folge-Issue empfohlen.
+Aktueller Stand: **keine offenen Mismatches bekannt**.
+
+Historisch behoben:
+
+- **Netzwerk-Tab** (Issue #118, behoben kurz nach PR #117): `NETWORK_MAP_QUESTIONS` in `networkContent.js` sprach Patient:innen mit Du an („deiner Kernfamilie", „kannst du reden"). Die Fragen sind jetzt in Beobachtungsform formuliert („der/des Betroffenen", „die/der Betroffene") und damit konsistent mit dem `'fachperson'`-Frame des Tabs. Das Beispiel oben in „Mischung innerhalb eines Tabs vermeiden" stammt aus diesem Fall.
 
 ## Konventionen
 

--- a/src/data/networkContent.js
+++ b/src/data/networkContent.js
@@ -43,13 +43,19 @@ export const NETWORK_MAP_STEPS = [
   'anschliessend Lücken besprechen: Wo fehlt Unterstützung, wer weiss schon Bescheid, wem könnte man sich anvertrauen?',
 ];
 
+// Leitfragen fuer die Exploration durch die Fachperson -- bewusst in
+// Beobachtungsform formuliert ("der/des Betroffenen", "die/der Betroffene"),
+// nicht als direkte Du-Anrede an Patient:innen. Konsistent mit
+// `primaryAudience: 'fachperson'` des Netzwerk-Tabs (siehe CLAUDE.md
+// "Zielgruppen"). Issue #118 hat die frueher hier verbliebene Du-Form
+// auf Sie- bzw. Fachperson-Perspektive umgestellt.
 export const NETWORK_MAP_QUESTIONS = [
-  'Wer gehört zu deiner Kernfamilie und wer zur erweiterten Familie?',
-  'Wer hat dir oder deiner Familie bei Schwierigkeiten schon geholfen?',
-  'Mit wem kannst du reden oder etwas unternehmen?',
+  'Wer gehört zur Kernfamilie der/des Betroffenen, wer zur erweiterten Familie?',
+  'Wer hat der/dem Betroffenen oder der Familie bei Schwierigkeiten schon geholfen?',
+  'Mit wem kann die/der Betroffene reden oder etwas unternehmen?',
   'Wer weiss über die aktuelle Belastung oder Erkrankung Bescheid?',
   'Gibt es Schule, Verein, Nachbarschaft oder Fachstellen, die eine tragende Rolle spielen?',
-  'Wem möchtest du was erzählen und wo braucht es eher Schutz der Privatsphäre?',
+  'Wem möchte die/der Betroffene was erzählen, wo braucht es eher Schutz der Privatsphäre?',
 ];
 
 export const NETWORK_MAP_LENSES = [


### PR DESCRIPTION
## Summary

Schliesst #118. Fixt den einzigen in CLAUDE.md "Bekannte offene Mismatches" dokumentierten Zielgruppen-Bruch.

`NETWORK_MAP_QUESTIONS` in `src/data/networkContent.js` sprach Patient:innen direkt mit Du an, obwohl der Netzwerk-Tab `primaryAudience: 'fachperson'` traegt und die Fragen im Template als "Leitfragen fuer die Exploration" gerahmt sind — also Fragen fuer die Fachperson, nicht fuer die Patient:in.

- 4 von 6 Fragen umformuliert auf Beobachtungsform ("der/des Betroffenen", "die/der Betroffene"), nach dem Pattern aus CLAUDE.md "Zielgruppen".
- 2 Fragen waren bereits neutral und bleiben unveraendert.
- Kommentar-Block am Array erklaert die Wahl der Formulierung und verweist auf das Framework.

## CLAUDE.md

"Bekannte offene Mismatches" ist jetzt "Bekannte Mismatches" mit **"keine offenen bekannt"** als Stand. Der Netzwerk-Fall bleibt als historisch behoben dokumentiert — er bleibt auch das Beispiel in "Mischung innerhalb eines Tabs vermeiden".

## Test plan

- [x] `npm run lint` clean
- [x] `npx prettier --check CLAUDE.md src/data/networkContent.js` clean
- [x] `npm run build` clean
- [x] `npm run test:e2e` — 37/37 grün (keine Tests koppeln auf die alten Strings, keine DOM-Struktur-Aenderung)
- [x] Reformulierung passt zum vorhandenen Template-Kontext ("Leitfragen fuer die Exploration", Ziel "Kind / Familie", Aside-Text über Fachperson-Exploration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)