### PR TITLE
docs(qa): 5 wiederverwendbare Audit-Prompts in qa/prompts/

### DIFF
--- a/qa/prompts/README.md
+++ b/qa/prompts/README.md
@@ -1,0 +1,58 @@
+# Audit-Prompts
+
+Wiederverwendbare Claude-Code-Prompts für systematische Audits dieses Repos.
+Jeder Prompt ist **projektspezifisch** optimiert — Routen, Scripts, Tokens und
+Audience-Framework sind bereits eingetragen. Kein Nachfüllen von Platzhaltern
+nötig.
+
+## Arbeitsweise
+
+Jeder Prompt folgt demselben 4-Phasen-Muster:
+
+1. **Phase 1 — Inventur (read-only):** Claude sammelt Befunde, schreibt Bericht.
+2. **Phase 2 — Triage / Massnahmenkatalog:** Claude gruppiert + priorisiert.
+3. **Phase 3 — Umsetzung:** nur nach expliziter Freigabe, ein Commit pro Fix.
+4. **Phase 4 — Verifikation:** Vorher/Nachher-Vergleich, Scripts re-run.
+
+**Zwischen-Stopps sind das Qualitätsmerkmal** — nicht alles auf einmal laufen
+lassen.
+
+## Verfügbare Prompts
+
+| Datei | Audit | Einsatzzeitpunkt |
+|---|---|---|
+| [`audit-a11y-interaktion.md`](audit-a11y-interaktion.md) | 1 · Accessibility + Interaktions-Integrität | Vor Release, nach Layout-Änderungen |
+| [`audit-performance.md`](audit-performance.md) | 2 · Performance + Bundle-Hygiene | Bei langsamen Seiten, vor Release, Bundle-Wachstum |
+| [`audit-content-sprache.md`](audit-content-sprache.md) | 3 · Content-Qualität + Sprache (inkl. Audience-Framework) | Vor grösseren Content-Freigaben |
+| [`audit-css-hygiene.md`](audit-css-hygiene.md) | 4 · Design-Token + CSS-Hygiene | Nach vielen Feature-Ergänzungen, uneinheitliche Tokens |
+| [`audit-sicherheit.md`](audit-sicherheit.md) | 5 · Sicherheit + Deployment-Hygiene | Vor Deployment, nach Security-relevanten Änderungen |
+
+## Nutzung
+
+1. Öffne den gewünschten Prompt.
+2. Kopiere den Inhalt des `# Audit: …`-Blocks (markierter Bereich).
+3. Starte in einem neuen Claude-Code-Session-Branch (siehe Prompt).
+4. Füge den Prompt ein. Claude arbeitet Phase 1 ab und stoppt.
+5. Nach Review: Freigabe für Phase 2. Wieder Stopp.
+6. Nach Review: Freigabe für Phase 3 + 4.
+
+## Bericht-Konvention
+
+Audit-Berichte werden fortlaufend nummeriert (`qa/audit-15-*.md`, `-16-*.md`,
+usw.). Die aktuelle höchste Nummer ist **14**. Die Prompts schlagen Dateinamen
+vor, der konkrete Präfix wird zu Beginn jedes Audits bestätigt.
+
+## Reihenfolge-Empfehlung für einen Release-Zyklus
+
+1. **Sicherheit** — zuerst, damit Secrets sofort behandelt werden können.
+2. **Accessibility** — weil A11y-Defekte am schwersten wiegen.
+3. **Content** — inhaltliche Probleme vor visuellen.
+4. **CSS-Hygiene** — Styling-Konsistenz auf sauberem Inhalt.
+5. **Performance** — zuletzt, weil sie auf stabilem Code am meisten bringt.
+
+## Hinweise
+
+- Schweizer Orthografie (`ss` statt `ß`) ist verbindlich.
+- Alle Prompts respektieren das `primaryAudience`-Framework (siehe `CLAUDE.md`).
+- Die Audits werden NICHT von Claude auto-gemergt — jede Änderung läuft durch
+  einen PR mit menschlicher Freigabe.

--- a/qa/prompts/audit-a11y-interaktion.md
+++ b/qa/prompts/audit-a11y-interaktion.md
@@ -1,0 +1,152 @@
+# Audit-Prompt — Accessibility + Interaktions-Integrität
+
+**Einsatz:** Vor Release oder nach grösseren Layout-/Navigations-Änderungen.
+
+**Was es findet:** WCAG-Verstösse, fehlende Labels, Kontrast-Probleme, kaputte
+Tastatur-Navigation, überlagerte Klick-Ziele (Audit-14-Klasse).
+
+**Bauzeit-Hinweis:** Die geometrischen Interaktions-Scripts sind **bereits
+permanent im Repo** (`qa/scripts/`) — NICHT neu erstellen, nur laufen lassen.
+
+---
+
+```
+# Audit: Accessibility und Interaktions-Integritaet
+
+## Kontext
+
+Du pruefst das Relational-Recovery-Fachportal (Schweizer Fachportal, de-CH)
+systematisch auf Barrierefreiheit und interaktive Integritaet. Das schliesst
+klassische WCAG-Pruefungen ein und eine Klasse von Defekten, die statische
+Pruefer nicht finden: Elemente, die sich gegenseitig ueberlagern und Klicks
+auf das falsche Ziel leiten.
+
+Die vierte Schicht der Notfall-Architektur (Audit 14) ist bereits installiert:
+`qa/scripts/interaction-overlap.mjs`, `qa/scripts/click-reachability.mjs`,
+`qa/scripts/z-stack.mjs`, `qa/scripts/click-diagnose.mjs`. Diese Scripts
+werden wiederverwendet — nicht neu angelegt.
+
+## Constraints
+
+- Arbeitsbranch: der aktuelle Session-Branch (nicht zwingend `audit/*`).
+- Bericht: `qa/audit-<nnn>-a11y-interaktion.md` (naechste freie Nummer ab 15).
+- Keine Code-Aenderungen in Phase 1 und 2.
+- Schweizer Orthografie (`ss` statt `ß`) ist verbindlich.
+- Barrierefreiheits-Substanz wird nie reduziert, nur ergaenzt.
+- Notfallnummern (144, AERZTEFON, 147) muessen immer erreichbar sein — dieser
+  Check ist nicht verhandelbar (siehe `CLAUDE.md`).
+
+## Routen
+
+Die App hat 8 Hash-Routen. Pruefe alle, nicht nur Stichproben:
+`#start`, `#lernmodule`, `#vignetten`, `#glossar`, `#material`, `#evidenz`,
+`#toolbox`, `#netzwerk`.
+
+## Phase 1 — Inventur (read-only)
+
+### 1.1 Automatisierte Pruefung
+
+Starte Preview-Server im Hintergrund (`npm run build && npm run preview`,
+Port 4173). Dann:
+
+- Falls `pa11y` oder `@axe-core/cli` via `npx` verfuegbar: alle 8 Routen
+  durchlaufen, Befunde nach Schwere gruppieren.
+- Falls nicht verfuegbar: statische Pruefung ueber Grep/Read gegen JSX-Dateien
+  (Labels, alt-Text, aria-*) und manuelle Heuristiken. Dokumentiere das als
+  Werkzeug-Grenze — KEIN `npm install` ohne Freigabe.
+- Lighthouse ist in dieser Umgebung nicht zwingend verfuegbar. Falls nicht,
+  markiere den Block als "manuell nachzureichen" und ueberspringe.
+
+### 1.2 Statische Semantik-Checks (read-only, per Grep/Read)
+
+Pro Route die zugehoerige Section-/Template-Komponente pruefen:
+
+- **Heading-Hierarchie**: Gibt es Spruenge (h1 → h3)? Mehrfache h1?
+  Beachten: im Material-Tab gilt die dokumentierte Regel
+  H1 Page → H2 Block → H3 Cluster (siehe CLAUDE.md "Material-Cluster").
+- **Landmark-Struktur**: `<main>`, `<nav>`, `<header>`, `<footer>` vorhanden?
+- **Bilder**: Jeder `<img>` mit `alt`-Attribut? Dekorative Bilder `alt=""`?
+- **Links und Buttons**: kein leerer Text, kein `<button>` ohne Label,
+  kein `<a>` ohne `href` oder mit `href="#"` als Pseudo-Button.
+- **Formulare**: Inputs mit zugehoerigem `<label>` (htmlFor / id-Paar) oder
+  `aria-label`.
+- **Tastatur**: alle interaktiven Elemente Tab-erreichbar? Esc schliesst
+  Modals (Mobile-Menue, Dialog-Varianten)?
+- **Reduced-Motion**: gepruefte Komponenten respektieren
+  `prefers-reduced-motion` (siehe CLAUDE.md).
+
+### 1.3 Kontrast-Spotcheck
+
+Anstatt blind durch alle Stellen zu gehen:
+
+- Ziehe `src/styles/tokens.css`. Dort sind Kontrast-Zusagen kommentiert
+  (z.B. "AA+ on --surface-page", "target AA"). Pruefe 5 Paarungen, die
+  besonders risikoreich sind: `--text-muted` auf `--surface-subtle`,
+  `--text-link` auf `--surface-info-soft`, Disabled-States, Badges,
+  `--text-inverse-muted` auf `--surface-inverse-*`.
+- Jede Paarung: berechneter Kontrast-Wert, WCAG-Level (AA/AAA/fail).
+
+### 1.4 Interaktions-Overlap + Klick-Erreichbarkeit
+
+Lass die bestehenden Scripts laufen (Preview muss aktiv sein):
+
+```
+node qa/scripts/interaction-overlap.mjs http://127.0.0.1:4173
+node qa/scripts/click-reachability.mjs http://127.0.0.1:4173
+node qa/scripts/z-stack.mjs http://127.0.0.1:4173
+```
+
+Dokumentiere:
+- Exit-Codes (0 = sauber, 1 = kritisch/hoch).
+- Overlap-Funde nach Viewport.
+- Klick-Failures nach Route.
+- Z-Index-Anomalien (bekannte Baseline: Skip 200, Header 150, Dialog 120,
+  Backdrop 110, Persistenz 100 — siehe `qa/scripts/README.md`).
+
+Falls ein neuer Failure-Typ auftaucht: `click-diagnose.mjs` mit angepassten
+`SCENARIOS` einsetzen (Phase-2-Tool) — nicht in Phase 1 aendern, nur dokumentieren.
+
+### 1.5 tel:-Link-Invariante (R31)
+
+Pro Route muessen drei `tel:`-Links sichtbar und klickbar bleiben:
+144, AERZTEFON (0800 33 66 55), 147. Das Script `click-reachability.mjs`
+deckt das bereits ab — im Bericht die konkrete Zahl pro Route aufnehmen.
+
+### 1.6 Gesamtbild
+
+Tabelle in den Bericht:
+- Pa11y/axe-Funde pro Route (oder "n.v.")
+- Heading-Spruenge, fehlende Labels, Kontrast-Risiken
+- Overlap-Funde nach Viewport
+- Klick-Failures
+- Z-Index-Anomalien
+- tel:-Invariante pro Route (Soll: je 3)
+
+**STOPP.** Fasse Phase 1 in 5-10 Zeilen zusammen und warte auf Freigabe.
+
+## Phase 2 — Triage
+
+Pro Befund einordnen als:
+- **Sofort-Fix**: klein, klar, A11y-relevant → Kandidat fuer Phase 3.
+- **Follow-up-Ticket**: substantiell, nicht release-blockierend.
+- **Akzeptiert**: bewusste Design-Entscheidung, im Bericht begruendet.
+
+Release-Readiness-Aussage mit Stufe A (release-ready), B (mit Caveats),
+C (blockiert).
+
+**STOPP.** Warte auf Freigabe fuer Phase 3.
+
+## Phase 3 — Fixes (nur nach Freigabe)
+
+Pro Fix ein eigener Commit. Commit-Pattern: `audit(a11y): fix <was>`.
+Nach jedem Fix die drei Scripts erneut laufen lassen. Bei Regression:
+Fix revertieren, Befund dokumentieren, keine "Notnagel"-Hotfixes.
+
+## Phase 4 — Verifikation
+
+- `npm run lint` + `npm run build` sauber.
+- Lighthouse/Pa11y-Re-Run falls in Phase 1 verfuegbar.
+- Alle drei qa/scripts gruen (Exit-Code 0).
+- Finale Release-Readiness-Aussage im Bericht.
+- PR-Body enthaelt Vorher/Nachher-Tabelle.
+```

--- a/qa/prompts/audit-content-sprache.md
+++ b/qa/prompts/audit-content-sprache.md
@@ -1,0 +1,170 @@
+# Audit-Prompt — Content-Qualität + Sprache
+
+**Einsatz:** Vor grösseren Content-Freigaben; wenn neue Tabs/Cluster dazukommen;
+nach inhaltlichen Nachträgen.
+
+**Was es findet:** Anrede-Brüche zwischen Audiences, unerklärter Fachjargon,
+tote Links, Stigma-Risiken, fehlende Quellentransparenz, Schweiz-Orthografie-
+Abweichungen.
+
+**Bauzeit-Hinweis:** Dieser Audit ist das natürliche Werkzeug zur Pflege des
+`primaryAudience`-Frameworks (`fachperson` vs. `weitergabe`) aus `CLAUDE.md`.
+Mischadressaten innerhalb eines Tabs sind die häufigste Defektklasse.
+
+---
+
+```
+# Audit: Content-Qualitaet und Sprache
+
+## Kontext
+
+Du pruefst die Textinhalte des Relational-Recovery-Fachportals auf
+sprachliche Qualitaet, Konsistenz und inhaltliche Substanz. Das Projekt
+richtet sich an zwei Zielgruppen:
+
+- **Fachpersonen** in Erwachsenenpsychiatrie + Beratung (Tabs: Start,
+  Lernmodule, Vignetten, Glossar, Evidenz, Toolbox, Netzwerk).
+- **Weitergabe an Patient:innen + Angehoerige** (Tab: Material) — die
+  Fachperson haelt das Material in der Hand und gibt es an Betroffene
+  weiter.
+
+Die Sprache ist Deutsch mit **Schweizer Orthografie (`ss` statt `ß`,
+verbindlich)**. Fachsprachlich warm-professionell, nicht behoerdlich, nicht
+klinisch-kalt.
+
+**Entscheidungslogik fuer Audience-Brueche**: siehe `CLAUDE.md`, Abschnitt
+"Zielgruppen". Mischadressaten innerhalb eines Tabs sind die haeufigste
+Defektklasse (historisches Beispiel: Netzwerk-Tab, Issue #118).
+
+## Constraints
+
+- Arbeitsbranch: der aktuelle Session-Branch.
+- Bericht: `qa/audit-<nnn>-content-sprache.md` (naechste freie Nummer ab 15).
+- Keine Code-Aenderungen, nur Content-Dateien unter `src/data/`.
+- Fachliche Aussagen werden nur auf *Formulierung* geprueft. Inhaltliche
+  Korrektheit wird als "zu validieren" markiert, nicht als Fakt behandelt —
+  KESB-, Kindesschutz- und medizinische Aussagen brauchen menschliche Freigabe.
+- Notfallnummern (144, AERZTEFON, 147) sind unveraenderlich.
+
+## Phase 1 — Inventur (read-only)
+
+### 1.1 Content-Inventar
+
+Alle Content-Module in `src/data/` auflisten:
+`appShellContent.js`, `evidenceContent.js`, `fachstellenContent.js`,
+`glossaryContent.js`, `learningContent.js`, `materialContent.js`,
+`networkContent.js`, `routeMeta.js`, `sourcesContent.js`, `toolboxContent.js`.
+
+Pro Datei: Zeilenzahl, adressierter Tab, adressierte Zielgruppe
+(`primaryAudience`-Pflichtfeld aus `TAB_ITEMS`).
+
+### 1.2 Audience-Konsistenz (Pflicht-Check)
+
+Pro Tab die jeweilige Content-Datei nach Anrede-Bruechen durchsuchen:
+- Fachperson-Tabs: kein direktes "Du", kein "Dein". Erwartet: Sie,
+  unpersoenlich, Passiv, Beobachtungsform ("der/des Betroffenen").
+- Weitergabe-Tab (`materialContent.js`): direkte Ansprache an Patient:innen
+  oder Angehoerige zulaessig, aber pro Handout eindeutig (nicht mischen
+  innerhalb EINES Handouts).
+- Cluster im Material-Tab: Jeder Cluster hat `audience: 'angehoerige'` oder
+  `'eltern'`. Pruefen, ob Anrede mit dem Cluster-Marker uebereinstimmt.
+
+Jeder Bruch: Quelldatei, Zeile, woertliches Zitat, vorgeschlagene
+Umformulierung.
+
+### 1.3 Fachjargon-Audit
+
+Pro Tab Begriffsliste extrahieren (Begriffe, die ohne Erklaerung
+verwendet werden). Kreuztabelle:
+
+| Begriff | Tab | Im Glossar? | Adressat versteht ohne Kontext? |
+|---|---|---|---|
+
+Spezialfall: Fachbegriffe im Material-Tab sollten immer in Klammern
+erklaert werden (z.B. "Parentifizierung (wenn Kinder Erwachsenen-Rollen
+uebernehmen)").
+
+### 1.4 Sprachliche Qualitaet
+
+Stichprobe von 5 laengeren Textbloecken pro Tab:
+- Durchschnittliche Satzlaenge (Ziel: 10-18 Woerter).
+- Passiv-Anteil in Prozent.
+- Nominalstil-Dichte (schwere "-ung"-Nominalisierungen).
+- Floskel-Dichte ("ganzheitlich", "nachhaltig", "im Sinne von",
+  "im Rahmen von").
+- Tonalitaet: warm-fachlich vs. klinisch vs. behoerdlich.
+
+### 1.5 Schweizer Orthografie
+
+`grep -r "ß" src/data/` — jeder Treffer ist ein Defekt (ausser Zitaten aus
+historischen Quellen, dann explizit markieren).
+Weitere CH-Marker: "Velo" statt "Fahrrad", "parkieren" statt "parken" (nur
+relevant, wenn solche Begriffe vorkommen).
+
+### 1.6 Quellen-Check
+
+- `src/data/sourcesContent.js` + `src/data/evidenceContent.js`: werden
+  Claims mit Quellen belegt?
+- Empirische Daten: Quelle nicht aelter als 10 Jahre (Ausnahme: klassische
+  Basiswerke, dann markieren).
+- Verifizierbare Claims ohne Quelle: flaggen.
+
+### 1.7 Link-Rot
+
+Alle externen Links extrahieren (`http://`/`https://`) aus den
+Content-Modulen. Status pruefen (HEAD-Request in einem kleinen Node-Script
+oder mit `curl -s -I -o /dev/null -w "%{http_code}" <url>`). Fuer das
+Relational-Recovery-Projekt existiert bereits `qa/link-check-results.txt`
+und `qa/link_check_urls.txt` als Pattern — daran anlehnen.
+
+Pro 4xx/5xx: Quelldatei, Link-Text, Ziel-URL, HTTP-Status, Vorschlag.
+
+### 1.8 Stigma- und Sensibilitaets-Check
+
+Suchlisten:
+- Stigmatisierende Formulierungen ("leidet an", "ist psychisch krank",
+  "die Kranke"). Bevorzugt: "ist betroffen von", "lebt mit".
+- KESB/Kindesschutz/Zwangsmassnahmen: emotional neutrale, faktenorientierte
+  Sprache. Siehe `qa/juristische-faktenbasis-kindesschutz.md` und
+  `qa/audit-03-kesb-sensibilitaet.md` als Referenz.
+- Opferperspektive vs. Ressourcenorientierung: wird das Kind nur als
+  "Gefaehrdetes" dargestellt oder auch als Akteur mit Bewaeltigungsstrategien?
+
+### 1.9 Gesamtbild
+
+Tabelle:
+- Audience-Brueche pro Tab.
+- Unerklaerte Fachbegriffe.
+- Passiv-Anteil pro Tab (Stichprobe).
+- Floskeldichte.
+- `ß`-Treffer.
+- Fehlende Quellen, veraltete Quellen.
+- 4xx/5xx-Links.
+- Stigma-Flags.
+
+**STOPP.** Fasse Phase 1 in 5-10 Zeilen zusammen und warte auf Freigabe.
+
+## Phase 2 — Diagnose
+
+Pro Befund: konkreter Aenderungsvorschlag, Schwere, Aufwand. Gruppierung:
+- **Sofort-Fix (Formulierung)**: z.B. `ß` → `ss`, Anrede-Bruch umformulieren,
+  tote Links ersetzen.
+- **Redaktionelles Ticket**: laengere Umformulierungen, fachliche Claims.
+- **Fachliche Freigabe noetig**: medizinische/juristische Aussagen.
+- **Akzeptiert**: bewusste Stil-Entscheidung.
+
+**STOPP.** Warte auf Freigabe fuer Phase 3.
+
+## Phase 3 — Umsetzung
+
+Pro Aenderung ein Commit. Commit-Pattern: `audit(content): <was>`.
+Inhaltliche Substanz bleibt unveraendert — nur Formulierung. Bei Zweifel
+in Phase 2-Triage verschieben, nicht hier entscheiden.
+
+## Phase 4 — Verifikation
+
+- `grep -r "ß" src/data/` ist leer.
+- Anrede-Stichprobe pro Tab konsistent.
+- Link-Check erneut, 0 neue Failures.
+- Sprachliche Metriken vorher/nachher im Bericht.
+```

--- a/qa/prompts/audit-css-hygiene.md
+++ b/qa/prompts/audit-css-hygiene.md
@@ -1,0 +1,156 @@
+# Audit-Prompt — Design-Token + CSS-Hygiene
+
+**Einsatz:** Nach vielen Feature-Ergänzungen, bei uneinheitlich wirkenden
+Farben/Abständen, vor Design-System-Dokumentation.
+
+**Was es findet:** Hardcodierte Farben und Abstände, tote Tokens, inkonsistente
+Nutzung, unerklärte Sonderfälle.
+
+**Bauzeit-Hinweis:** Das Token-System dieses Repos ist ungewöhnlich sauber
+strukturiert (`src/styles/tokens.css`, 169 Zeilen mit Kontrast-Kommentaren).
+Der Audit soll es nicht umkrempeln, sondern hartcodierte Abweichungen finden.
+
+---
+
+```
+# Audit: Design-Token und CSS-Hygiene
+
+## Kontext
+
+Du pruefst das Styling-System von Relational Recovery auf Konsistenz,
+Token-Nutzung und Wartbarkeit. Die Dreiteilung ist:
+
+- `src/styles/tokens.css` — Single Source of Truth fuer Farben, Abstaende,
+  Radii, Typografie, Motion. Kontrast-Zusagen sind als Kommentare
+  dokumentiert.
+- `src/styles/primitives.css` — `ui-`-praefixierte Komponenten-Klassen
+  (BEM-aehnlich).
+- `src/styles/app-global.css` — globale Regeln inkl. `@media print`
+  (Abschnitt 9).
+
+Tailwind 4 ist via `@tailwindcss/vite` eingebunden; Utility-Klassen werden
+inline in JSX verwendet.
+
+Kernregel: **Farb-Identitaet hat Vorrang vor Token-Coverage.** "Close
+enough" ist bei Farben kein Argument — wenn ein Hex-Wert nicht exakt zu
+einem Token passt, wird er nicht migriert, sondern als "neuer Token noetig"
+markiert.
+
+## Constraints
+
+- Arbeitsbranch: der aktuelle Session-Branch.
+- Bericht: `qa/audit-<nnn>-css-hygiene.md` (naechste freie Nummer ab 15).
+- Keine visuellen Aenderungen in Phase 1/2. Nur Dokumentation.
+- In Phase 3 nur Farb-Migrationen, die 1:1 auf einen bestehenden Token
+  treffen. Sonst Token-Einfuehrung mit Freigabe.
+
+## Phase 1 — Inventur (read-only)
+
+### 1.1 Token-System erfassen
+
+- `tokens.css` lesen, Token-Kategorien + Anzahl zaehlen (Farben, Abstaende,
+  Fontsizes, Radii, Schatten, Motion).
+- Token-Aliase identifizieren (Token A referenziert Token B).
+- Dokumentations-Status: `docs/design-system/` durchgehen — was ist
+  dokumentiert, was fehlt?
+
+### 1.2 Hardcodierte Werte (systematisch)
+
+Grep im gesamten Repo (ausser `tokens.css` und `node_modules`):
+- **Hex-Farben** (`#[0-9a-fA-F]{3,8}`): alle Treffer in
+  `src/styles/primitives.css`, `src/styles/app-global.css`, JSX-Dateien
+  mit inline `style=`, sowie CSS-in-JS, falls vorhanden.
+- **rgb/rgba/hsl/oklch** ausserhalb `tokens.css`.
+- **px-Werte** in `margin`, `padding`, `gap`, `font-size`, `border-radius`,
+  `box-shadow`.
+- **Inline-Tailwind-Arbitrary-Werte** (`[12px]`, `[#abc]`) in JSX.
+
+Pro Fund: Quelldatei, Zeile, Wert, naechster passender Token + Diff
+(exakt / ~1-2px / farblich drift / kein Token vorhanden).
+
+Ausnahmen, die NICHT geflaggt werden:
+- Werte in `@media print` (Print-Typografie hat eigene Regeln — siehe
+  CLAUDE.md "Material-Handouts").
+- Werte innerhalb von SVG-`<svg>`-Tags (dekorative Illustrationen).
+- Pfad-Definitionen (`d="M..."`).
+
+### 1.3 Token-Nutzungs-Analyse
+
+Pro Token in `tokens.css`:
+- Wird er referenziert (Grep `var\(--<name>\)`)? Anzahl Treffer.
+- Tote Tokens: definiert, nie referenziert.
+- Heissgenutzte Tokens: > 20 Referenzen (Info fuer Change-Impact).
+
+### 1.4 CSS-Strukturcheck
+
+- `primitives.css`: 4146 Zeilen. Gibt es BEM-Blocks, die sich
+  konzeptuell ueberschneiden? Duplizierte Regel-Koerper?
+- `app-global.css`: 614 Zeilen. Klar abgegrenzte Sections? Kommentare
+  als Nummerierung?
+- Tailwind-Utility vs. `.ui-*`-Klassen: gibt es JSX, die dasselbe Styling
+  doppelt bekommt (Utility + Klasse)?
+
+### 1.5 Tote CSS-Regeln
+
+Grep-gestuetzte Heuristik:
+- Selektoren in `primitives.css` (`.ui-*`): kommt die Klasse in JSX vor?
+  Wenn nicht: Kandidat fuer tote Regel.
+- `@media`-Queries auf exotische Breakpoints, die nicht im Rest der App
+  vorkommen.
+- Leere CSS-Dateien oder fast-leere.
+
+### 1.6 Print-Konsistenz
+
+Da der Material-Tab druckbare Handouts enthaelt:
+- `@media print`-Regeln in `app-global.css` (Abschnitt 9) — werden sie
+  alle `.ui-material-handout*`-Klassen abgedeckt, die in `MaterialHandouts.jsx`
+  existieren?
+- Konflikte zwischen Bildschirm- und Print-Tokens sauber per `!important`
+  getrennt, wo noetig (siehe CLAUDE.md zu `MaterialAgeGrid`).
+
+### 1.7 Gesamtbild
+
+Tabelle:
+- Token-Zahlen (aktiv / tot / alias).
+- Hardcodierte Werte nach Typ (Farbe/Spacing/Fontsize/Radius/Shadow) und
+  nach Ort.
+- Tote Regeln (geschaetzt).
+- Strukturbewertung je Datei (A/B/C).
+
+Top-5 Hot-Spots.
+
+**STOPP.** Fasse Phase 1 in 5-10 Zeilen zusammen und warte auf Freigabe.
+
+## Phase 2 — Massnahmenkatalog
+
+Pro Hex-/px-Wert eine Entscheidung vorschlagen:
+- **T1 — Token angleichen**: wenn der Token selbst den falschen Wert hat.
+- **T2 — Neuen Token einfuehren**: wenn der Wert eine eigene semantische
+  Rolle hat. Namensvorschlag + Kommentar-Zweck.
+- **T3 — Migrieren zu bestehendem Token**: nur wenn Diff = 0 (Farbe) oder
+  semantisch gerechtfertigt (Spacing).
+- **T4 — Als Sonderfall belassen**: echte Ausnahme, im Bericht begruenden.
+
+Spacing-Hardcodes (z.B. `margin: 12px`): lassen sie sich zu einem Spacing-
+Token (`--space-3` etc.) migrieren? Wenn ja: in einem Commit buendeln.
+
+Tote Tokens und Regeln: koennen sie ersatzlos gestrichen werden? Falls
+unsicher: im Bericht als "Kandidat, menschliche Pruefung noetig" flaggen.
+
+**STOPP.** Warte auf Freigabe fuer Phase 3.
+
+## Phase 3 — Umsetzung
+
+Pro Massnahme ein Commit. Commit-Pattern: `audit(css): <was>`.
+Bei Farb-Migrationen: nach jedem Commit `npm run build` + Sichtkontrolle
+der Preview. Falls Screenshots-Tool verfuegbar (z.B. das bestehende
+`scripts/visual-qa.mjs`): Vorher/Nachher-Screenshots in den Commit-Body.
+
+## Phase 4 — Verifikation
+
+- `npm run lint` + `npm run build` sauber.
+- Visueller Vorher/Nachher auf mind. 3 Routen (Start, Toolbox, Material).
+- Keine Farb-Verschiebungen.
+- Token-Coverage-Statistik: Anteil tokenisierter vs. hardcodierter Werte
+  (Zahl vorher/nachher).
+```

--- a/qa/prompts/audit-performance.md
+++ b/qa/prompts/audit-performance.md
@@ -1,0 +1,141 @@
+# Audit-Prompt — Performance + Bundle-Hygiene
+
+**Einsatz:** Bei Perf-Verdacht, vor Release, bei unerklaerlichem Bundle-Wachstum.
+
+**Was es findet:** Unnoetige Dependencies, zu grosse Chunks, fehlende
+Lazy-Loading-Gelegenheiten, unoptimierte Bilder, CLS-Quellen.
+
+**Bauzeit-Hinweis:** Die App ist Vite 7 + React 19 + Tailwind 4. Lazy-Loading
+ist konzeptuell schon gesetzt (Sections sind `React.lazy`, HomeLanding bewusst
+nicht — siehe `CLAUDE.md`). Dieser Audit validiert die Umsetzung, nicht die
+Idee.
+
+---
+
+```
+# Audit: Performance und Bundle-Hygiene
+
+## Kontext
+
+Du pruefst Relational Recovery (Vite 7, React 19, Tailwind 4, rein
+clientseitig, kein Backend) auf Performance-Probleme und Bundle-Hygiene.
+Ziel: Core Web Vitals gruen, Bundle nachvollziehbar, keine toten
+Dependencies.
+
+Die App laedt keine externen Runtime-Ressourcen (siehe `netlify.toml`-
+Kommentar) — das ist bereits ein Perf-Vorteil. Der Fokus liegt auf
+Build-Output, Bildern und Split-Strategie.
+
+## Constraints
+
+- Arbeitsbranch: der aktuelle Session-Branch.
+- Bericht: `qa/audit-<nnn>-performance.md` (naechste freie Nummer ab 15).
+- Keine funktionalen Aenderungen in Phase 1/2.
+- Keine neuen Dependencies ohne Freigabe — insbesondere kein
+  Bundle-Analyzer via `npm install`, sondern Build-Output parsen.
+
+## Routen
+
+Desktop- und Mobile-Messung auf den 3 schwersten Routen:
+`#toolbox` (interaktions-schwer), `#netzwerk` (link-schwer),
+`#material` (Content + Print-Styling). Plus `#start` als Baseline.
+
+## Phase 1 — Inventur (read-only)
+
+### 1.1 Build-Output
+
+`npm run build` ausfuehren. Dokumentiere:
+- Gesamtgroesse `dist/` (JS, CSS, Assets getrennt).
+- Pro Chunk: Dateiname, Groesse raw + gzip (Vite gibt beides aus).
+- Top-5 groesste JS-Chunks — welches Feature sitzt drin?
+- Gibt es einen Entry-Chunk > 200 KB (gzip)? Wenn ja: warum?
+
+Kein Bundle-Analyzer installieren. Falls der User einen Analyzer will,
+als Follow-up vorschlagen (rollup-plugin-visualizer waere der Standard).
+
+### 1.2 Core-Web-Vitals (falls moeglich)
+
+- Preview starten (`npm run preview`, Port 4173).
+- Falls Lighthouse/PageSpeed-CLI verfuegbar: LCP, CLS, INP, FCP, Speed Index
+  fuer die 4 Routen in Desktop und Mobile. Sonst: Block als
+  "manuell nachzureichen" markieren.
+- Alternative: Heuristik ueber Build-Output + statische Pruefung.
+
+### 1.3 Dependency-Audit
+
+`package.json` lesen. Pro Dependency:
+- Wird sie per `import` referenziert? (Grep `from '<name>'` in `src/`.)
+- Verwaiste Deps flaggen.
+- Doppelte Funktionalitaet erkennen (z.B. zwei Icon-Libs). Aktueller Stand:
+  nur `lucide-react` — das ist bewusst schlank.
+- `npm audit --omit=dev` fuer Laufzeit-CVEs.
+
+### 1.4 Bild-Audit
+
+Alle Bilder in `public/` und `src/assets/`:
+- Format (WebP/AVIF/PNG/JPG/SVG), Dateigroesse, Pixel-Dimensionen.
+- Werden sie irgendwo in doppelter Groesse geladen?
+- `loading="lazy"` auf allen below-the-fold-Bildern?
+- Hero-Datei: `src/assets/relational-recovery-hero-v3-web.webp` — pruefen,
+  ob sie als LCP-Kandidat mit `fetchpriority="high"` o.ae. markiert ist.
+
+### 1.5 Lazy-Loading und Code-Splitting
+
+- Welche Sections sind `React.lazy`? (Siehe `src/App.jsx`.) Ist
+  `HomeLandingTemplate` weiterhin bewusst eager? (Siehe `CLAUDE.md`.)
+- Gibt es Sections, die heute eager geladen werden, aber lazy sein sollten?
+- Wird der Suspense-Fallback sinnvoll angezeigt (kein Layout-Shift)?
+
+### 1.6 Layout-Shift-Quellen
+
+- Bilder ohne `width`/`height` oder `aspect-ratio`?
+- `@font-face` mit `font-display: swap` korrekt gesetzt?
+- Dynamisch eingefuegte Elemente (Persistenz-Banner, Notfall-Banner) —
+  verschieben sie Layout oder overlay-only?
+
+### 1.7 Runtime-Hotspots (statisch)
+
+Grep nach bekannten Smells:
+- `useEffect`-Ketten mit teuren Dependencies.
+- `Array.prototype.filter`/`.map` in Render ohne `useMemo`, wenn gross.
+- React 19-spezifisch: `use` korrekt eingesetzt? Unnoetige Context-Subscriber?
+
+### 1.8 Gesamtbild
+
+Tabelle:
+- Build-Groessen vs. Budget-Hypothese (JS < 200 KB gzip pro Route-Chunk?).
+- CWV-Werte pro Route (falls gemessen).
+- Deps: Gesamtzahl, verwaiste, CVE-Schwere.
+- Bilder: ungeoptimierte Anzahl.
+- Lazy-Loading-Coverage.
+- CLS-Risikostellen.
+
+Top-5 Hot-Spots fuer Gewinn pro Aufwand.
+
+**STOPP.** Fasse Phase 1 in 5-10 Zeilen zusammen und warte auf Freigabe.
+
+## Phase 2 — Massnahmenkatalog
+
+Pro Hot-Spot: konkreter Vorschlag, erwarteter Gewinn (geschaetzt in KB oder
+ms), Aufwand (S/M/L), Risiko. Priorisierung P1/P2/P3.
+
+Spezielles Augenmerk:
+- Bild-Optimierung vor Code-Splitting (hoechster Gewinn pro Aufwand).
+- Keine "Hip"-Optimierungen (Preact-Migration, Astro-Umzug) vorschlagen —
+  die App ist bewusst React-19.
+
+**STOPP.** Warte auf Freigabe fuer Phase 3.
+
+## Phase 3 — Umsetzung
+
+Pro Massnahme ein Commit. Commit-Pattern: `audit(perf): <was>`.
+Nach jeder Bild-/Asset-Aenderung: `npm run build` + Bundle-Diff im
+Commit-Body.
+
+## Phase 4 — Verifikation
+
+- Build laeuft sauber, keine neuen Warnings.
+- Bundle-Groessen vorher/nachher (Tabelle im Bericht).
+- CWV-Re-Run falls in Phase 1 gemessen.
+- `npm audit` unveraendert oder besser.
+```

--- a/qa/prompts/audit-sicherheit.md
+++ b/qa/prompts/audit-sicherheit.md
@@ -1,0 +1,190 @@
+# Audit-Prompt — Sicherheit + Deployment-Hygiene
+
+**Einsatz:** Vor dem ersten öffentlichen Deployment, nach Security-relevanten
+Änderungen, regelmässig (quartalsweise) für Dependency-Hygiene.
+
+**Was es findet:** Exponierte Secrets, fehlende HTTP-Headers, Dependency-CVEs,
+offene Debug-Endpoints, unsichere Formulare, localStorage-Risiken.
+
+**Bauzeit-Hinweis:** Relational Recovery ist eine rein clientseitige SPA ohne
+Backend, ohne API-Calls, ohne eigene Auth. Das reduziert die Angriffsfläche
+stark, aber verlagert sie auf Build-Artefakte, Deployment und Third-Party-
+Links. `netlify.toml` setzt bereits die wichtigsten Header (bewusst ohne CSP
+— Begründung im File).
+
+---
+
+```
+# Audit: Sicherheit und Deployment-Hygiene
+
+## Kontext
+
+Du pruefst Relational Recovery (rein clientseitige React 19 SPA, Deployment
+auf Netlify) auf Sicherheitsrisiken und Deployment-Hygiene.
+
+Bestandsaufnahme zur Orientierung:
+- Kein Backend, keine API-Calls, keine eigenen Credentials.
+- `netlify.toml` setzt HSTS, X-Content-Type-Options, X-Frame-Options,
+  Referrer-Policy, Permissions-Policy. **CSP ist bewusst NICHT gesetzt** —
+  die Begruendung steht als Kommentar im File. Das ist kein Defekt, sondern
+  eine dokumentierte Design-Entscheidung zur Reconsideration.
+- localStorage-Key: `rr_app_state_v5` (enthaelt keine personenbezogenen
+  Daten — siehe CLAUDE.md).
+- `.env.example` ist tracked, `.env*` ist in `.gitignore`.
+
+## Constraints
+
+- Arbeitsbranch: der aktuelle Session-Branch.
+- Bericht: `qa/audit-<nnn>-sicherheit.md` (naechste freie Nummer ab 15).
+- **Gefundene Secrets werden SOFORT gemeldet**, nicht erst im Phase-2-Bericht —
+  menschliche Revocation hat Vorrang.
+- Keine funktionalen Aenderungen in Phase 1/2.
+- Kein `npm install` ohne Freigabe; `npm audit` geht auch ohne Install.
+
+## Phase 1 — Inventur (read-only)
+
+### 1.1 Secret-Scan (oberste Prioritaet)
+
+Systematisch grep nach:
+- Muster: `sk-`, `ghp_`, `gho_`, `ghs_`, `nfp_`, `xoxb-`, `xoxp-`,
+  `AIza[0-9A-Za-z_\-]{35}`, `AKIA[0-9A-Z]{16}`.
+- Variablennamen: `password\s*=`, `apiKey`, `api_key`, `secret\s*=`,
+  `token\s*=`, `private_key`, `-----BEGIN .* PRIVATE KEY-----`.
+- URLs mit Credentials: `https?://[^/\s]+:[^@\s]+@`.
+- Base64-Muster (>= 40 Zeichen) in Code-Dateien — nur als Heuristik, nicht
+  jeder Treffer ist ein Secret.
+
+Scope: das gesamte Repo ausser `node_modules/`, `dist/`, `output/`,
+`qa/mobile-artifacts/`.
+
+**Wenn ein echtes Secret gefunden wird: SOFORT STOPPEN, melden, auf
+Revocation warten, bevor der Audit fortgesetzt wird.**
+
+### 1.2 Git-History-Check
+
+- `git log --all -p -S "sk-" -S "password=" -S "apiKey"` — wurde jemals
+  ein Secret-Muster im Diff eingefuehrt?
+- `git log --all --full-history -- .env .env.local` — wurde eine echte
+  `.env` jemals committed?
+
+Falls Funde: im Bericht dokumentieren, **Secret gilt als kompromittiert,
+auch wenn "geloescht"**. Revocation + BFG/filter-repo als Massnahme.
+
+### 1.3 .gitignore-Pruefung
+
+- `.gitignore` lesen. Deckt sie ab: `.env`, `.env.*`, `node_modules`,
+  `dist/`, `output/`, `.DS_Store`, `*.log`, `test-results/`,
+  `playwright-report/`, `.netlify`?
+- Gibt es Dateien im Arbeitsbaum, die via `.gitignore` geblockt sein sollten
+  (`git ls-files | grep ...`)?
+
+### 1.4 HTTP-Security-Headers
+
+- `netlify.toml` lesen und gegen Baseline pruefen:
+  HSTS ✅, X-Content-Type-Options ✅, X-Frame-Options ✅,
+  Referrer-Policy ✅, Permissions-Policy ✅, **CSP: absichtlich fehlend**.
+- Im Bericht dokumentieren, welche weiteren Headers sinnvoll waeren
+  (Cross-Origin-Opener-Policy, Cross-Origin-Embedder-Policy) — aber ohne
+  direkt zu fixen. Das ist Phase 2-Gespraech.
+- CSP: Pruefe, ob der Grund "inline-Styles/SVG aus React/Vite" heute noch
+  gilt (bei React 19 + Vite 7). Wenn eine realistische CSP-Policy ohne
+  `unsafe-inline` moeglich waere, als P2-Ticket empfehlen.
+
+### 1.5 Dependency-Vulnerabilities
+
+```
+npm audit --omit=dev --json > /tmp/npm-audit-prod.json
+npm audit --json > /tmp/npm-audit-all.json
+```
+
+Dokumentiere:
+- Anzahl pro Schwere (critical / high / moderate / low).
+- Fuer critical/high: Paket, Version, Fix verfuegbar?
+- Dev-Only-Vulns separat — meist weniger dringend (beeinflussen nicht die
+  Laufzeit der deployed App).
+
+### 1.6 Inline-Scripts und Event-Handler
+
+- Inline `<script>...</script>` in `index.html`, `public/*.html`,
+  `src/prerendered/*`? (Das Prerender-Tooling injiziert moeglicherweise
+  Scripts — als "beabsichtigt" dokumentieren, wenn so.)
+- `on*`-Handler als Strings in HTML-Dateien (`onclick="..."`)?
+- `dangerouslySetInnerHTML` in JSX? (CLAUDE.md sagt: darf nicht vorkommen —
+  verifizieren.)
+- `eval(`, `new Function(`, `setTimeout(stringArg,` — alle drei Grep.
+
+### 1.7 Externe Links und Third-Party
+
+- Alle externen Links mit `target="_blank"` haben `rel="noopener noreferrer"`
+  (CLAUDE.md-Vorgabe). Grep `target="_blank"` ohne `rel=.*noopener`.
+- Drittanbieter-Ressourcen im Build-Output? (`grep -r "fonts.googleapis" dist/`,
+  `"cdn\." dist/`, etc.) — erwartet: keine.
+
+### 1.8 localStorage/sessionStorage
+
+- Was wird unter `rr_app_state_v5` abgelegt? Hole `src/context/AppStateContext*`
+  und `src/utils/appHelpers*` und pruefe die geschriebenen Felder.
+- Enthalten sie PII/Health-Daten nach DSGVO/DSG-Massstab?
+- Gibt es weitere Storage-Keys (grep `localStorage\.setItem\(`,
+  `sessionStorage\.setItem\(`)?
+
+### 1.9 Formulare und User-Input
+
+- Gibt es `<form>`-Elemente mit echtem Submit? (Erwartet: wenig bis keine,
+  da kein Backend.)
+- Falls ja: Sanitization beim Anzeigen (kein `dangerouslySetInnerHTML`)?
+- Inputs, deren Werte in URL/Hash/localStorage landen: XSS-Risiko beim
+  spaeteren Anzeigen?
+
+### 1.10 Deployment-Konfiguration
+
+- `netlify.toml`: Build-Command, Publish-Verzeichnis korrekt.
+- `vite.config.js`: keine unerwarteten Plugins oder Secrets in `define:`.
+- `scripts/replace-env.mjs`, `scripts/inject-prerender.mjs`: werden sie mit
+  sicheren Inputs aufgerufen? (Command-Injection-Flaeche pruefen.)
+- Gibt es Deployment-Automationen ausserhalb Netlify (`.github/workflows/`)?
+
+### 1.11 Gesamtbild
+
+Tabelle:
+- Exponierte Secrets (Ziel: 0).
+- Git-History-Secrets (Ziel: 0).
+- Fehlende Headers (CSP ist separat gelistet mit dokumentierter Begruendung).
+- Vulns nach Schwere.
+- Inline-Scripts, `dangerouslySetInnerHTML`, eval-Muster.
+- Externe Links ohne `rel="noopener"`.
+- localStorage-Inhalt: sensitiv ja/nein.
+
+Risiko-Einschaetzung: kritisch / hoch / mittel / niedrig.
+
+**STOPP.** Fasse Phase 1 in 5-10 Zeilen zusammen und warte auf Freigabe.
+Falls Secrets gefunden wurden: schon vorher gemeldet.
+
+## Phase 2 — Massnahmenkatalog
+
+Pro Befund: konkreter Fix, Schwere, Aufwand.
+- Kritische Befunde (exponierte Secrets, bekannte Exploits, fehlendes
+  `rel="noopener"` bei externen Links) sind **nicht verhandelbar**.
+- CSP ist ein separates Kapitel: Vorschlag fuer eine realistische Policy
+  mit minimalen Kompromissen, nicht "blind setzen".
+
+**STOPP.** Warte auf Freigabe fuer Phase 3.
+
+## Phase 3 — Umsetzung
+
+Pro Fix ein Commit. Commit-Pattern: `audit(sec): <was>`.
+- Secret-Revocations passieren AUSSERHALB des Repos (in den jeweiligen
+  Service-Dashboards). Der Commit entfernt den Wert, die Revocation ist
+  Menschenpflicht — im PR-Body explizit bestaetigen.
+- Dependency-Updates: ein Commit pro Paket (oder gebuendelt nach Major),
+  Changelog-Link im Commit-Body.
+
+## Phase 4 — Verifikation
+
+- `npm audit --omit=dev` zeigt 0 critical/high.
+- Kein Secret-Muster im Diff (`git diff` vs. `main` nochmal grep).
+- Security-Headers per `curl -I https://<deployed-url>` verifiziert (falls
+  deployed).
+- `.gitignore` deckt alle sensitiven Dateitypen ab.
+- PR-Body enthaelt: Revocation bestaetigt ja/nein, welche Services.
+```


### PR DESCRIPTION
## Summary

Legt fünf projektspezifisch optimierte Audit-Prompts unter `qa/prompts/` ab. Routen, Scripts, Tokens, Audience-Framework und Netlify-Header-Status sind bereits eingetragen — kein Platzhalter-Nachfüllen nötig.

- **audit-a11y-interaktion.md** — nutzt bestehende `qa/scripts/*.mjs` aus Audit 14 (nicht neu erstellen), deckt alle 8 Hash-Routen ab, tel:-Invariante als nicht-verhandelbar.
- **audit-performance.md** — Vite 7 / React 19 / Tailwind 4 benannt, kein `npm install` ohne Freigabe, Lazy-Loading-Konvention aus CLAUDE.md verifiziert.
- **audit-content-sprache.md** — auf das `primaryAudience`-Framework (`fachperson`/`weitergabe`) aufgesetzt, Schweizer Orthografie (`ss`) eigener Check, KESB-Sensibilität referenziert.
- **audit-css-hygiene.md** — Dreiteilung `tokens.css` / `primitives.css` / `app-global.css` strukturgebend, Print-Styling für Material-Handouts eigener Check.
- **audit-sicherheit.md** — CSP-Abwesenheit in `netlify.toml` als dokumentierte Design-Entscheidung markiert (kein Finding), Secret-Funde unterbrechen den Flow sofort.

README dokumentiert Nutzung, 4-Phasen-Muster und Reihenfolge-Empfehlung. Neue Berichte starten bei `audit-15-*` (höchste bestehende Nr. 14).

## Test plan

- [x] Alle fünf Prompts sind in `qa/prompts/` abgelegt.
- [x] README verlinkt alle fünf Prompts.
- [x] Keine Code-Änderungen ausserhalb `qa/prompts/` — rein dokumentarisch.
- [ ] Ein Audit-Durchlauf (Vorschlag: Sicherheit) verifiziert die Prompts inhaltlich.

https://claude.ai/code/session_01Y7tCrUuNxDaDcs2tk4ghxH