### PR TITLE
sec(headers): COOP same-origin ergänzen (Audit 19 P3)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,12 @@
 #   aber inline-Styles/SVG kommen aus React/Vite — daher würde eine strikte CSP
 #   ohne sorgfältige Prüfung Build-Output brechen. Lieber bewusst ergänzen.
 # - HSTS preload nicht aktiviert: erst sinnvoll wenn produktive Custom-Domain steht.
+# - COOP same-origin: isoliert Top-Level-Browsing-Context gegen cross-origin
+#   window.opener-Angriffe. Die App öffnet selbst keine Popups; alle externen
+#   Links haben rel="noopener noreferrer".
+# - COEP require-corp bewusst NICHT: würde zukünftig eingebettete Bilder/iframes
+#   ohne CORP-Header brechen. Erst sinnvoll, wenn Cross-Origin-Isolation aktiv
+#   gebraucht wird (z. B. SharedArrayBuffer).
 [[headers]]
   for = "/*"
   [headers.values]
@@ -16,6 +22,7 @@
     X-Frame-Options = "DENY"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+    Cross-Origin-Opener-Policy = "same-origin"
 
 [[headers]]
   for = "/"


### PR DESCRIPTION
## Summary

Folge-Ticket 2 aus Audit 19 (PR #133): Setzt `Cross-Origin-Opener-Policy: same-origin` für alle Routen in `netlify.toml`.

## Kontext

- Isoliert den Top-Level-Browsing-Context gegen Cross-Origin-`window.opener`-Angriffe.
- Risikolos: Die App öffnet selbst keine Popups; alle externen Links tragen bereits `rel="noopener noreferrer"` (Audit 19 §1.7).
- **COEP bewusst NICHT gesetzt:** `Cross-Origin-Embedder-Policy: require-corp` würde zukünftig eingebettete Bilder/iframes ohne CORP-Header brechen. Erst sinnvoll, wenn Cross-Origin-Isolation (z. B. `SharedArrayBuffer`) aktiv gebraucht wird.

## Test plan

- [x] `git diff` enthält nur `netlify.toml` (+7 Zeilen: 6 Kommentar + 1 Header).
- [x] Kein Code geändert, CI bleibt grün (Lint/Format/Build unberührt).
- [ ] Nach Netlify-Deploy: `curl -I https://<domain>/ | grep -i cross-origin` → `Cross-Origin-Opener-Policy: same-origin`. (Menschlicher Reviewer, Sandbox-Egress blockt externe Requests.)
- [ ] DevTools-Console auf allen Haupt-Routen unverändert (kein Noise durch COOP).

https://claude.ai/code/session_01Y7tCrUuNxDaDcs2tk4ghxH