### PR TITLE
sec(ci): wöchentlicher npm audit als separater Workflow (Audit 19 P3)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,52 @@
+# Wochentlicher npm-audit-Gate fuer Relational Recovery.
+#
+# Laeuft Montag 06:00 UTC und manuell via workflow_dispatch. Bewusst
+# getrennt von ci.yml gehalten:
+# - CI soll PR-Latenz nicht vom npm-Advisory-Stand abhaengen.
+# - Ein neues Upstream-Advisory darf existierende PRs nicht rot faerben.
+#
+# --audit-level=high: schlaegt nur bei high/critical fehl. Low/moderate
+# in Dev-Deps ist Advisory-Rauschen, das nicht automatisch handelbar ist.
+#
+# Audit-Scope:
+# - Erst prod-only (--omit=dev) -- diese Advisories landen im Build-Output
+#   und sind die eigentliche Risiko-Quelle.
+# - Dann full inkl. Dev-Deps -- Entwickler-Maschinen / CI-Runner schuetzen.
+#
+# Manuell triggern: Actions-Tab -> "Weekly npm audit" -> "Run workflow".
+
+name: Weekly npm audit
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch: {}
+
+concurrency:
+  group: audit-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: npm audit (high/critical)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
+      - name: Audit all dependencies
+        run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary

Folge-Ticket 3 aus Audit 19 (PR #133): Legt `.github/workflows/audit.yml` an — läuft **Montag 06:00 UTC** und manuell via `workflow_dispatch`.

## Design-Entscheidungen

| Entscheidung | Begründung |
|---|---|
| Separater Workflow, nicht in `ci.yml` | PR-Latenz soll nicht vom npm-Advisory-Stand abhängen; neue Upstream-Advisories dürfen bestehende PRs nicht rot färben. |
| `--audit-level=high` | Schlägt nur bei `high`/`critical` fehl. Low/moderate in Dev-Deps ist Advisory-Rauschen, das nicht automatisch handelbar ist. |
| Zwei Steps (prod-only + full) | Step 1 (`--omit=dev`) ist die eigentliche Risiko-Quelle (Build-Output). Step 2 schützt Dev-Umgebung / CI-Runner. |
| `cron: '0 6 * * 1'` | Montag früh UTC → Findings liegen zum Wochenstart auf dem Tisch, ohne Wochenend-Noise. |
| `workflow_dispatch` | Manueller Trigger für Ad-hoc-Checks nach grösseren Dependency-Bumps. |

## Test plan

- [x] Neuer File nur unter `.github/workflows/audit.yml` (52 Zeilen).
- [x] Kein Code / keine Runtime-Dependencies geändert.
- [x] YAML-Syntax valide (Standard GitHub-Workflow-Schema).
- [ ] Nach Merge: einmal manuell triggern via Actions-Tab → „Weekly npm audit" → „Run workflow" → erwartet: grün, `found 0 vulnerabilities` (Audit 19 Stand).

## Bezug zu Audit 19

Aktueller npm-audit-Stand laut Audit 19 §1.5: **0 Vulnerabilities** (prod + dev). Dieser Workflow hält das Signal laufend auf Grün oder macht eine Regression binnen 7 Tagen sichtbar.

https://claude.ai/code/session_01Y7tCrUuNxDaDcs2tk4ghxH