### PR TITLE
sec(csp): Policy im Report-Only-Modus ergänzen (Audit 19 P3, Phase 1)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,9 +4,15 @@
 
 # Security-Header für alle Routen.
 # Hinweise:
-# - kein CSP-Header gesetzt: die App lädt zur Laufzeit keine externen Ressourcen,
-#   aber inline-Styles/SVG kommen aus React/Vite — daher würde eine strikte CSP
-#   ohne sorgfältige Prüfung Build-Output brechen. Lieber bewusst ergänzen.
+# - CSP im Report-Only-Modus: beobachtet Verstösse ohne zu blockieren.
+#   Monitoring via Browser-DevTools-Console (kein report-uri konfiguriert,
+#   da kein Collector-Endpoint bereitsteht). Nach 1-2 Wochen ohne Noise
+#   wird der Header zu "Content-Security-Policy" promotet (Folge-PR).
+#   Bekannte zu klärende Stelle: <script type="application/ld+json"> in
+#   index.html — wird unter script-src 'self' potenziell gemeldet; Enforce-
+#   Phase extrahiert in externe .json-Datei oder nutzt SHA-256-Hash.
+#   style-src 'unsafe-inline' bleibt: React emittiert inline style="..."
+#   Attribute, die nicht sinnvoll hashbar sind (bekannter SPA-Kompromiss).
 # - HSTS preload nicht aktiviert: erst sinnvoll wenn produktive Custom-Domain steht.
 # - COOP same-origin: isoliert Top-Level-Browsing-Context gegen cross-origin
 #   window.opener-Angriffe. Die App öffnet selbst keine Popups; alle externen
@@ -23,6 +29,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=(), interest-cohort=()"
     Cross-Origin-Opener-Policy = "same-origin"
+    Content-Security-Policy-Report-Only = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'"
 
 [[headers]]
   for = "/"


### PR DESCRIPTION
## Summary

Folge-Ticket 1 aus Audit 19 (PR #133), **Phase 1 von 2**: Setzt `Content-Security-Policy-Report-Only` für alle Routen in `netlify.toml`. Beobachtet Verstösse ohne zu blockieren.

## Policy

```
default-src 'self';
script-src 'self';
style-src 'self' 'unsafe-inline';
img-src 'self' data:;
font-src 'self';
connect-src 'self';
object-src 'none';
base-uri 'self';
frame-ancestors 'none';
form-action 'self'
```

## Design-Entscheidungen

| Direktive | Wahl | Begründung |
|---|---|---|
| `script-src` | `'self'` (strict) | Kein `'unsafe-inline'` in Report-Only → Verstösse werden sichtbar, statt weggepolstert. Bekannte Kandidatin: `<script type="application/ld+json">` in `index.html`. Phase 2 entscheidet über Auslagerung vs. Hash. |
| `style-src` | `'self' 'unsafe-inline'` | React emittiert `style="..."`-Attribute bei jedem Render; nicht sinnvoll hashbar. Bekannter SPA-Kompromiss, bleibt auch in Enforce-Phase. |
| `img-src` | `'self' data:` | Kleine Inline-SVGs/PNGs via `data:` in Komponenten. |
| `connect-src` | `'self'` | Kein Backend, keine externen APIs. |
| `frame-ancestors` | `'none'` | Dupliziert `X-Frame-Options: DENY` auf dem moderneren Pfad. |
| `form-action` | `'self'` | Audit 19 §1.9: 0 Forms. Restriktiv lassen. |
| `report-uri` | **nicht gesetzt** | Kein Collector-Endpoint vorhanden. Monitoring läuft via Browser-DevTools-Console. |

## Monitoring-Plan (1–2 Wochen nach Merge)

In DevTools-Console pro Browser (Chrome + Firefox) prüfen auf `Content Security Policy`-Warnings:

- [ ] Start-Tab (`#start`) — First Paint + After Hydration.
- [ ] Lernmodule (`#lernmodule`) — alle Module einmal öffnen.
- [ ] Vignetten (`#vignetten`) — eine Vignette durchklicken (State-Updates).
- [ ] Glossar (`#glossar`) — Filter + Scroll.
- [ ] Evidenz (`#evidenz`) — Links prüfen.
- [ ] Toolbox (`#toolbox`) — Download-Buttons.
- [ ] Netzwerk (`#netzwerk`) — Map + Fragen.
- [ ] Material (`#material`) — mindestens ein Handout öffnen **und** drucken (Print-Dialog löst zusätzliche Style-Injektion aus).

Bei Violations: im Folge-PR (Phase 2) entweder Policy anpassen oder Code-Stelle auflösen (z. B. JSON-LD extrahieren).

## Risiko

- **Report-Only bricht nichts** — der Header loggt nur, erzwingt nichts. Downgrade = Header-Zeile entfernen (trivial).
- Erwartete Violations: JSON-LD-Script (bekannt, Kandidat für Phase 2). Alles andere = neue Erkenntnis.

## Test plan

- [x] `git diff` enthält nur `netlify.toml` (+10/−3: Kommentar-Update + neue Header-Zeile).
- [x] Kein Code / keine Runtime-Dependencies geändert.
- [x] CI (Lint/Format/Build) unberührt.
- [ ] Nach Netlify-Deploy: `curl -I https://<domain>/ | grep -i content-security-policy-report-only` → Policy vorhanden.
- [ ] Haupt-Routen einmal in DevTools-Console prüfen (Monitoring-Checkliste oben).

## Nächster Schritt

Phase 2 (separate PR, ~2 Wochen nach Merge): `Content-Security-Policy-Report-Only` → `Content-Security-Policy` + Auflösung der Inline-Script-Stelle.

https://claude.ai/code/session_01Y7tCrUuNxDaDcs2tk4ghxH