### PR TITLE
feat(ui): Visual-Polish Sprint 1 — Card-Hover, Stats-Serif, Tab-Icons

### DIFF
--- a/src/components/ui/PageHero.jsx
+++ b/src/components/ui/PageHero.jsx
@@ -27,6 +27,7 @@ export default function PageHero({
   accent,
   lead,
   headingId,
+  icon,
   actions = [],
   asideTitle,
   asideCopy,
@@ -38,10 +39,16 @@ export default function PageHero({
   audienceLabel,
   audienceNote,
 }) {
+  const HeroIcon = icon || null;
   return (
     <div className="ui-hero">
       <div className="ui-hero__inner">
         <div className="ui-hero__content">
+          {HeroIcon ? (
+            <span className="ui-hero__icon" aria-hidden="true">
+              <HeroIcon size={28} strokeWidth={1.6} />
+            </span>
+          ) : null}
           {eyebrow ? <Eyebrow>{eyebrow}</Eyebrow> : null}
           <h1
             id={headingId}

--- a/src/sections/ElearningSection.jsx
+++ b/src/sections/ElearningSection.jsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { GraduationCap } from 'lucide-react';
 import heroIllustration from '../assets/relational-recovery-hero-v3-web.webp';
 import { E_MODULES } from '../data/learningContent';
 import LearningPageTemplate from '../templates/LearningPageTemplate';
@@ -29,6 +30,7 @@ export default function ElearningSection() {
       };
 
   const hero = {
+    icon: GraduationCap,
     eyebrow: 'Fachliche Kurzformate',
     title: 'Lernen in',
     accent: 'ruhigen Fachsequenzen.',

--- a/src/sections/EvidenceSection.jsx
+++ b/src/sections/EvidenceSection.jsx
@@ -1,3 +1,4 @@
+import { Activity } from 'lucide-react';
 import EvidencePageTemplate from '../templates/EvidencePageTemplate';
 import {
   ABOUT_THIS_WEBSITE_POINTS,
@@ -113,6 +114,7 @@ function digitalMediaItems(items = []) {
 
 export default function EvidenceSection({ downloadResources = [] }) {
   const hero = {
+    icon: Activity,
     eyebrow: 'Evidenz und klinische Orientierung',
     title: 'Einordnen, benennen und',
     accent: 'familienorientiert handeln.',

--- a/src/sections/GlossarSection.jsx
+++ b/src/sections/GlossarSection.jsx
@@ -1,3 +1,4 @@
+import { BookOpenText } from 'lucide-react';
 import { GLOSSARY_GROUPS, GLOSSARY_HERO, GLOSSARY_INTRO } from '../data/glossaryContent';
 import GlossarPageTemplate from '../templates/GlossarPageTemplate';
 import { getPageHeadingId } from '../utils/appHelpers';
@@ -5,7 +6,7 @@ import { getPageHeadingId } from '../utils/appHelpers';
 export default function GlossarSection() {
   return (
     <GlossarPageTemplate
-      hero={GLOSSARY_HERO}
+      hero={{ ...GLOSSARY_HERO, icon: BookOpenText }}
       pageHeadingId={getPageHeadingId('glossar')}
       intro={GLOSSARY_INTRO}
       groups={GLOSSARY_GROUPS}

--- a/src/sections/MaterialSection.jsx
+++ b/src/sections/MaterialSection.jsx
@@ -1,3 +1,4 @@
+import { CircleHelp } from 'lucide-react';
 import MaterialPageTemplate from '../templates/MaterialPageTemplate';
 import {
   MATERIAL_CLUSTERS,
@@ -104,7 +105,7 @@ export default function MaterialSection({ sharedDownloadResources = [] }) {
 
   return (
     <MaterialPageTemplate
-      hero={MATERIAL_HERO}
+      hero={{ ...MATERIAL_HERO, icon: CircleHelp }}
       pageHeadingId={getPageHeadingId('material')}
       intro={MATERIAL_INTRO}
       clusters={MATERIAL_CLUSTERS}

--- a/src/sections/NetworkSection.jsx
+++ b/src/sections/NetworkSection.jsx
@@ -70,6 +70,7 @@ export default function NetworkSection() {
   );
 
   const hero = {
+    icon: MapPin,
     eyebrow: 'Weitervermittlung und Triage',
     title: 'Fachstellen für',
     accent: 'Zürich und schweizweite Ergänzungen.',

--- a/src/sections/ToolboxSection.jsx
+++ b/src/sections/ToolboxSection.jsx
@@ -4,6 +4,7 @@ import {
   Check,
   CheckCircle2,
   ChevronRight,
+  ClipboardCheck,
   Download,
   ExternalLink,
   Printer,
@@ -217,6 +218,7 @@ export default function ToolboxSection({
       : `${answeredCount} von ${TRIAGE_PROMPTS.length} Fragen beantwortet. Die aktuell wichtigste Spur ist ${primaryPriority?.title?.toLowerCase() ?? 'noch offen'}.`;
 
   const hero = {
+    icon: ClipboardCheck,
     eyebrow: 'Klinische Orientierung',
     title: 'Toolbox: Orientierung, Schutz und nächste Schritte',
     accent: 'in belasteten Familiensituationen.',

--- a/src/sections/VignettenSection.jsx
+++ b/src/sections/VignettenSection.jsx
@@ -1,3 +1,4 @@
+import { HeartHandshake } from 'lucide-react';
 import VignettenPageTemplate from '../templates/VignettenPageTemplate';
 import { VIGNETTEN } from '../data/learningContent';
 import { getPageHeadingId } from '../utils/appHelpers';
@@ -19,6 +20,7 @@ export default function VignettenSection() {
   const feedbackId = `${vignette.id}-feedback`;
 
   const hero = {
+    icon: HeartHandshake,
     eyebrow: 'Fallreflexion',
     title: 'Training',
     accent: 'mit Fallvignetten',

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -280,11 +280,16 @@
 
 .ui-card--editorial-link {
   text-align: left;
-  transition: transform var(--motion-fast) ease;
+  transition:
+    transform var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease,
+    border-color var(--motion-fast) ease;
 }
 
 .ui-card--editorial-link:hover {
-  transform: translateY(-2px);
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-elevated);
+  border-color: var(--border-strong);
 }
 
 .ui-button {
@@ -883,6 +888,19 @@
   align-content: start;
 }
 
+.ui-hero__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  margin-bottom: calc(var(--space-2) * -1);
+  border-radius: var(--radius-pill);
+  background: var(--surface-subtle);
+  color: var(--text-muted);
+  border: 1px solid var(--border-subtle);
+}
+
 .ui-hero__title {
   margin: 0;
   font-size: clamp(2.25rem, 5vw, 4.75rem);
@@ -1112,8 +1130,11 @@
 .ui-fact-card__value {
   margin: var(--space-3) 0 0;
   color: var(--text-primary);
-  font-size: clamp(1.5rem, 2vw, 2rem);
-  font-weight: 800;
+  font-family: var(--font-heading);
+  font-size: clamp(1.75rem, 2.4vw, 2.375rem);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums lining-nums;
+  letter-spacing: -0.02em;
   line-height: 1;
 }
 


### PR DESCRIPTION
## Summary

Audit-25 Top-3-Quickwins aus dem Optionen-Katalog — zusammen ~1 h Aufwand, null Trade-off, sofort sichtbare Aufwertung.

**O9 Card-Hover intensivieren** (`primitives.css`)
- `.ui-card--editorial-link:hover`: translateY(-2px) → translateY(-4px)
- Zusatz: box-shadow → `--shadow-elevated`, border → `--border-strong`
- Transition-Liste um `box-shadow` + `border-color` erweitert

**O2 Stats-Numerals in Serif** (`primitives.css`)
- `.ui-fact-card__value`: font-family → `var(--font-heading)`, weight 800 → 600
- `font-variant-numeric: tabular-nums lining-nums`
- Size-Clamp leicht hochgezogen, letter-spacing -0.02em (Display-Metric)

**O12 Tab-Icon im Page-Hero** (`PageHero.jsx` + 7 Sections)
- Neuer `icon`-Prop an PageHero, rendert 28px-Lucide-Icon in 40×40-Pill (`--surface-subtle`) ueber dem Eyebrow
- 7 Sections reichen ihr Tab-Icon aus `lucide-react` durch (keine neue Abhaengigkeit)
- Start-Tab bewusst ohne Icon (hat eigene Custom-Illustration)

## Verifikation

Playwright-Check gegen `vite preview` bestaetigt auf allen 7 Nicht-Start-Tabs:
- `iconPresent: true, svgPresent: true, iconSize: 38x38`
- Stats: `fontFamily: "Source Serif 4", Georgia, serif` · `fontWeight: 600`
- Hover: `transform: translateY(-4px)` · `box-shadow: --shadow-elevated` · `border: #bda894 (--border-strong)`

Lint + Build gruen.

## Test plan
- [x] `npm run lint` passt
- [x] `npm run build` passt
- [x] Alle 7 Tabs zeigen ein tabspezifisches Icon im Hero
- [x] Stats-Zahlen rendern in Serif mit tabular+lining figures
- [x] Card-Hover zeigt intensiveren Lift + Shadow + Border
- [ ] User-Review: sind die Icons im Hero nicht zu dominant? (reversibel via `icon`-Prop-Entfernung)

https://claude.ai/code/session_01Y7tCrUuNxDaDcs2tk4ghxH