### PR TITLE
feat(ui): Visual-Polish Sprint 2 — tabspezifische Hero-Akzentfarben (O4)

### DIFF
--- a/src/components/ui/PageHero.jsx
+++ b/src/components/ui/PageHero.jsx
@@ -25,6 +25,7 @@ export default function PageHero({
   eyebrow,
   title,
   accent,
+  accentColor,
   lead,
   headingId,
   icon,
@@ -40,8 +41,9 @@ export default function PageHero({
   audienceNote,
 }) {
   const HeroIcon = icon || null;
+  const heroStyle = accentColor ? { '--hero-accent-color': accentColor } : undefined;
   return (
-    <div className="ui-hero">
+    <div className="ui-hero" style={heroStyle}>
       <div className="ui-hero__inner">
         <div className="ui-hero__content">
           {HeroIcon ? (

--- a/src/sections/ElearningSection.jsx
+++ b/src/sections/ElearningSection.jsx
@@ -31,6 +31,7 @@ export default function ElearningSection() {
 
   const hero = {
     icon: GraduationCap,
+    accentColor: 'var(--accent-info-strong)',
     eyebrow: 'Fachliche Kurzformate',
     title: 'Lernen in',
     accent: 'ruhigen Fachsequenzen.',

--- a/src/sections/EvidenceSection.jsx
+++ b/src/sections/EvidenceSection.jsx
@@ -115,6 +115,7 @@ function digitalMediaItems(items = []) {
 export default function EvidenceSection({ downloadResources = [] }) {
   const hero = {
     icon: Activity,
+    accentColor: 'var(--accent-info-strong)',
     eyebrow: 'Evidenz und klinische Orientierung',
     title: 'Einordnen, benennen und',
     accent: 'familienorientiert handeln.',

--- a/src/sections/GlossarSection.jsx
+++ b/src/sections/GlossarSection.jsx
@@ -6,7 +6,7 @@ import { getPageHeadingId } from '../utils/appHelpers';
 export default function GlossarSection() {
   return (
     <GlossarPageTemplate
-      hero={{ ...GLOSSARY_HERO, icon: BookOpenText }}
+      hero={{ ...GLOSSARY_HERO, icon: BookOpenText, accentColor: 'var(--accent-info-strong)' }}
       pageHeadingId={getPageHeadingId('glossar')}
       intro={GLOSSARY_INTRO}
       groups={GLOSSARY_GROUPS}

--- a/src/sections/MaterialSection.jsx
+++ b/src/sections/MaterialSection.jsx
@@ -105,7 +105,7 @@ export default function MaterialSection({ sharedDownloadResources = [] }) {
 
   return (
     <MaterialPageTemplate
-      hero={{ ...MATERIAL_HERO, icon: CircleHelp }}
+      hero={{ ...MATERIAL_HERO, icon: CircleHelp, accentColor: 'var(--accent-primary-strong)' }}
       pageHeadingId={getPageHeadingId('material')}
       intro={MATERIAL_INTRO}
       clusters={MATERIAL_CLUSTERS}

--- a/src/sections/NetworkSection.jsx
+++ b/src/sections/NetworkSection.jsx
@@ -71,6 +71,7 @@ export default function NetworkSection() {
 
   const hero = {
     icon: MapPin,
+    accentColor: 'var(--accent-info-strong)',
     eyebrow: 'Weitervermittlung und Triage',
     title: 'Fachstellen für',
     accent: 'Zürich und schweizweite Ergänzungen.',

--- a/src/sections/VignettenSection.jsx
+++ b/src/sections/VignettenSection.jsx
@@ -21,6 +21,7 @@ export default function VignettenSection() {
 
   const hero = {
     icon: HeartHandshake,
+    accentColor: 'var(--accent-primary-strong)',
     eyebrow: 'Fallreflexion',
     title: 'Training',
     accent: 'mit Fallvignetten',

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -910,7 +910,7 @@
 }
 
 .ui-hero__accent {
-  color: var(--accent-primary);
+  color: var(--hero-accent-color, var(--accent-primary));
   font-style: italic;
 }
 


### PR DESCRIPTION
## Summary

Audit-25 **O4** umgesetzt: Der Italic-Accent im PageHero ist nicht mehr ueber alle 8 Tabs identisch rot, sondern folgt einer **3-Farben-Semantik** aus dem bestehenden Token-System.

**Farbfamilien (AA-verifiziert gegen `--surface-page` #f9f4ee)**

| Farbe | Token | CR | WCAG | Tabs |
|---|---|---|---|---|
| Rot | `--accent-primary` #d24136 | 4.22 | AA-Large | Start, Toolbox |
| Deep-Brick | `--accent-primary-strong` #8d3f32 | 6.65 | AA-Body | Vignetten, Material |
| Teal | `--accent-info-strong` #1e656d | 6.12 | AA-Body | Lernmodule, Glossar, Evidenz, Netzwerk |

Semantische Gruppierung:
- **Rot** = Dashboard + Triage (Orientierungs-/Alert-Funktion)
- **Deep-Brick** = Weitergabe + Fallarbeit (warme, menschliche Naehe)
- **Teal** = strukturiertes Referenzmaterial (Lernen, Nachschlagen, Evidenz, Verweise)

**Im O4-Katalog vorgeschlagene, aber verworfene Kandidaten** (Kontrast-Fail):
- `--accent-secondary` #a1be95 (CR 1.86)
- `--accent-info` #92aac7 (CR 2.18)
- `--accent-warning` #eb8a3e (CR 2.33 — knapp unter 3:1 AA-Large-Schwelle)

Statt diese Farben nur fuer Toolbox zu erzwingen, bleibt Toolbox auf `--accent-primary` (Default) — passt semantisch zum Alarm/Triage-Charakter der Toolbox.

## Implementierung

- `PageHero` akzeptiert optionales `accentColor`-Prop (CSS-Value-String)
- Setzt CSS Custom Property `--hero-accent-color` auf der `.ui-hero`-Root
- `.ui-hero__accent` liest `var(--hero-accent-color, var(--accent-primary))` — Fallback sorgt dafuer, dass Tabs ohne Prop unveraendert bleiben
- 6 Sections reichen ihren Tab-Accent durch

## Verifikation

Playwright-Check gegen `vite preview` bestaetigt die erwartete Farbausgabe pro Tab:
```
start      rgb(210, 65, 54)   = #d24136 (primary)
lernmodule rgb(30, 101, 109)  = #1e656d (info-strong)
vignetten  rgb(141, 63, 50)   = #8d3f32 (primary-strong)
glossar    rgb(30, 101, 109)
material   rgb(141, 63, 50)
evidenz    rgb(30, 101, 109)
toolbox    rgb(210, 65, 54)
netzwerk   rgb(30, 101, 109)
```

Lint + Build gruen.

## Test plan
- [x] Kontrast je Farbe gegen `--surface-page` gerechnet (WCAG-Formel)
- [x] `npm run lint` passt
- [x] `npm run build` passt
- [x] Alle 8 Tabs liefern die erwartete Accent-Farbe
- [ ] Review: ist die 3-Farben-Semantik (Rot/Deep-Brick/Teal) tragfaehig oder zu teal-lastig?

https://claude.ai/code/session_01Y7tCrUuNxDaDcs2tk4ghxH