### PR TITLE
feat(ui): Visual-Polish Sprint 4 — Footer-Identität, Section-Rhythmus, Surface-Accent-Soft (O5+O14+O15)

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -94,6 +94,18 @@ const Footer = memo(function Footer() {
           </div>
         </div>
 
+        {/* Audit 25 / Sprint 4 (O15): Serif-Italic-Identitaetssatz als
+            editoriale Stimme zwischen Navigations-Grid und Uppercase-Claim.
+            Die bewusste Ruhe in Manrope/Source-Serif + Italic setzt einen
+            kleinen Ton-Kontrast gegen die Uppercase-Kacheln darunter und
+            macht den Footer zur Identitaetsflaeche statt zur blossen
+            Service-Zeile. Text ist redaktionell; Paarung mit dem Claim
+            darunter ist Absicht (Editorial-Satz zuerst, dann Markenton). */}
+        <p className="footer-identity">
+          Ein ruhiger Ort zwischen{' '}
+          <em className="footer-identity__emphasis">Erwachsenenpsychiatrie und Beratungsalltag.</em>
+        </p>
+
         <div className="footer-bottom">
           <p className="footer-bottom__claim">Fachlich ruhig. Systemisch. Praxisnah.</p>
         </div>

--- a/src/components/closing/ClosingSection.jsx
+++ b/src/components/closing/ClosingSection.jsx
@@ -421,7 +421,15 @@ export default function ClosingSection({ section, sectionId, surface = 'plain', 
 
   return (
     <>
-      <Section id={section.id || sectionId} spacing="tight" surface={surface} className={className}>
+      {/* Audit 25 / Sprint 4 (O14): Section-Rhythmus variieren.
+          Die ClosingSection war bislang auf jeder Seite mit `spacing="tight"`
+          direkt an die letzte Kapitel-Section angeschlossen -- der Uebergang
+          von Inhaltsfluss zu Abschluss blieb dadurch kaum spuerbar. Mit
+          `spacing="standard"` entsteht ein klarer Atempunkt (+5.5rem vs
+          3.75rem) zwischen letzter Arbeitssektion und Abschlussblock.
+          Die nested ClosingReferences bleibt bewusst `tight`, weil sie
+          innerhalb des Closing-Stacks sitzt (kein zweiter Atempunkt noetig). */}
+      <Section id={section.id || sectionId} spacing="standard" surface={surface} className={className}>
         <div className={hasPrintView ? 'ui-stack ui-stack--loose no-print' : 'ui-stack ui-stack--loose'}>
           <ClosingHeader section={section} />
           <ClosingPrimaryActions items={section.primaryActions} />

--- a/src/components/ui/PageHero.jsx
+++ b/src/components/ui/PageHero.jsx
@@ -32,6 +32,7 @@ export default function PageHero({
   actions = [],
   asideTitle,
   asideCopy,
+  asideTone,
   image,
   imageAlt,
   stats = [],
@@ -157,7 +158,7 @@ export default function PageHero({
           ) : null}
 
           {(asideTitle || asideCopy) && (
-            <div className="ui-hero__aside">
+            <div className={`ui-hero__aside${asideTone ? ` ui-hero__aside--${asideTone}` : ''}`}>
               {asideTitle ? <p className="ui-hero__aside-title">{asideTitle}</p> : null}
               {asideCopy ? <p className="ui-hero__aside-copy">{asideCopy}</p> : null}
             </div>

--- a/src/sections/GlossarSection.jsx
+++ b/src/sections/GlossarSection.jsx
@@ -6,7 +6,12 @@ import { getPageHeadingId } from '../utils/appHelpers';
 export default function GlossarSection() {
   return (
     <GlossarPageTemplate
-      hero={{ ...GLOSSARY_HERO, icon: BookOpenText, accentColor: 'var(--accent-info-strong)' }}
+      hero={{
+        ...GLOSSARY_HERO,
+        icon: BookOpenText,
+        accentColor: 'var(--accent-info-strong)',
+        asideTone: 'highlight',
+      }}
       pageHeadingId={getPageHeadingId('glossar')}
       intro={GLOSSARY_INTRO}
       groups={GLOSSARY_GROUPS}

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -1063,6 +1063,20 @@
   padding: 1.25rem;
 }
 
+/* Audit 25 / Sprint 4 (O5): Highlight-Variante aktiviert --surface-accent-soft
+   (das blieb bisher ungenutzt, ausser als 24%-Beimischung im --surface-note).
+   Einsatz aktuell nur auf dem Glossar-Hero-Aside -- der weich-gelbe
+   Hintergrund signalisiert dort die Funktion "Referenz / Nachschlagewerk"
+   und hebt den Aside bewusst gegen die anderen Hero-Asides ab. Kontrast:
+   --text-primary (#2f2f28) auf --surface-accent-soft (#f1f3ce) = 11.05 : 1
+   (AA fuer Normaltext 4.5 deutlich uebererfuellt). Border uebernimmt eine
+   gedaempfte Mischung aus --accent-secondary, damit der Rand nicht in der
+   warmen Seitenfarbe verschwindet. */
+.ui-hero__aside--highlight {
+  background: var(--surface-accent-soft);
+  border-color: color-mix(in srgb, var(--accent-secondary) 40%, var(--border-default) 60%);
+}
+
 .ui-hero__aside-title {
   margin: 0;
   color: var(--text-primary);
@@ -4062,6 +4076,30 @@
   font-size: var(--font-size-xs);
   font-weight: 500;
   line-height: 1.9;
+}
+
+/* Audit 25 / Sprint 4 (O15): Identitaetssatz in Source Serif 4 Italic
+   schiebt sich zwischen Nav-Grid und Uppercase-Claim. Groesserer margin-top
+   setzt den Satz optisch als eigenen Block ab, die margin-bottom laesst den
+   nachfolgenden Claim anschliessen. --footer-text-warm (#5a4a3f) erreicht
+   auf der Sandkachel 6.24 Kontrast (AA). Font-Family erbt nicht automatisch
+   die Serif; explizit setzen, da Manrope der Footer-Default ist. */
+.footer-identity {
+  margin: var(--space-7) 0 var(--space-4);
+  padding-top: var(--space-6);
+  border-top: 1px solid color-mix(in srgb, var(--footer-text-warm) 18%, transparent 82%);
+  color: var(--footer-text-warm);
+  font-family: var(--font-heading);
+  font-size: clamp(1rem, 1.2vw, 1.1875rem);
+  font-style: italic;
+  font-weight: 400;
+  line-height: 1.55;
+  max-width: 44rem;
+}
+
+.footer-identity__emphasis {
+  font-style: italic;
+  color: var(--footer-text-warm);
 }
 
 .footer-bottom {


### PR DESCRIPTION
## Summary

Drei editoriale Feinjustierungen aus Audit 25 (quartäre Welle nach den Sprints 1–3):

- **O15 — Footer als Identitätsfläche**: Neuer Satz in Source Serif 4 Italic zwischen Nav-Grid und Uppercase-Claim: _„Ein ruhiger Ort zwischen **Erwachsenenpsychiatrie und Beratungsalltag**."_ Border-top als leiser Divider, Farbe `--footer-text-warm` (6.24 : 1 Kontrast, AA). Setzt Ton-Kontrast (Serif-Italic vs Uppercase-Claim) und macht die Fusszeile zur Identitätsfläche statt zur blossen Service-Zeile.
- **O14 — Section-Rhythmus variieren**: ClosingSection-Wrapper von `spacing="tight"` (3.75 rem) auf `spacing="standard"` (5.5 rem). Der Übergang von letzter Arbeitssektion zu Abschlussblock ist dadurch spürbar, ohne den Closing-Stack selbst zu strecken. Die nested `ClosingReferences` bleibt bewusst `tight`.
- **O5 — `--surface-accent-soft` aktivieren**: Token blieb bisher nur als 24 %-Beimischung im `--surface-note` lebendig. Neuer `asideTone`-Prop auf `PageHero` + CSS-Variante `.ui-hero__aside--highlight` mit purem `#f1f3ce`. Einsatz: Glossar-Hero-Aside (semantisch _„Referenz / Nachschlagewerk"_). Kontrast `--text-primary` auf Surface: 11.05 : 1 (AA deutlich übererfüllt). Border via `color-mix` mit `--accent-secondary`.

## Entscheidungen

- `asideTone` als opt-in-Prop (nicht als automatisches Mapping): bestehende Heroes bleiben unverändert; nur Glossar bekommt aktuell die Highlight-Variante.
- ClosingSection-Spacing: `standard`, nicht `wide` — `wide` (7.5 rem) wirkt auf kurzen Seiten (Glossar) zu luftig; `standard` gibt auf allen Seiten einen hörbaren, aber nicht übertriebenen Atempunkt.
- Identitätssatz redaktionell gewählt, nicht aus Daten-Feed — Footer ist Brand-Territorium, keine dynamische Inhaltsfläche.

## Verifikation (Chromium 1440 × 900)

- `.footer-identity` rendert in Source Serif 4 Italic 17.28 px, `color rgb(90, 74, 63)` = `--footer-text-warm`, Border-top 1 px ✓
- `.ui-hero__aside--highlight` auf Glossar: `backgroundColor rgb(241, 243, 206)` = `#f1f3ce` ✓
- Evidenz-ClosingSection rendert ohne `ui-section--tight` (nur `ui-section`, = default standard spacing) ✓
- `npm run lint` clean, `npm run build` clean (1724 Module, 3.29 s)

## Test plan

- [ ] Smoke-Check `/` (Start) + `/#glossar` + `/#evidenz` in Dev-Server
- [ ] Footer-Identitätssatz rendert in Serif-Italic, Border-Top sichtbar
- [ ] Glossar-Hero-Aside hat soft-olivgelbe Fläche, Text klar lesbar
- [ ] Abstand zwischen letzter Kapitel-Sektion und ClosingSection ist auf allen Detail-Seiten (Evidenz, Toolbox, Netzwerk, Material) sichtbar grösser als zuvor
- [ ] Keine Regression in Print-Stylesheet (Footer ist `no-print`)

https://claude.ai/code/session_01Y7tCrUuNxDaDcs2tk4ghxH