### PR TITLE
feat(ui): Visual-Polish Sprint 5 — Glossar-Letter-Index + Reveal-Feintuning (O11+O16)

### DIFF
--- a/src/components/ui/GlossarLetterIndex.jsx
+++ b/src/components/ui/GlossarLetterIndex.jsx
@@ -1,0 +1,44 @@
+/**
+ * Alphabet-Navigation fuer den Glossar-Tab (Audit 25 / Sprint 5, O11).
+ *
+ * Zeigt alle 26 Buchstaben des Alphabets als kompaktes Pill-Band.
+ * Buchstaben mit mindestens einem zugeordneten Term sind klickbare
+ * Sprunglinks (Ankerziel: `#glossar-term-{id}` des ersten Terms); ohne
+ * Term bleibt der Buchstabe als gedimmter Span sichtbar -- das Band
+ * dient damit auch als At-a-Glance-Coverage-Indikator.
+ *
+ * Keine eigene Section -- Template bettet den Nav in einen schmalen
+ * Container ein, damit Cluster-Nav und Letter-Nav direkt nebeneinander
+ * liegen und sich nicht beide eine volle Section-Hoehe teilen.
+ */
+export default function GlossarLetterIndex({ entries = [] }) {
+  if (!entries.length) return null;
+
+  return (
+    <nav className="ui-letter-index" aria-label="Alphabetische Navigation durch die Begriffe">
+      <ul className="ui-letter-index__list">
+        {entries.map((entry) => {
+          const label = entry.firstTermId
+            ? `${entry.letter} — ${entry.count} ${entry.count === 1 ? 'Begriff' : 'Begriffe'}`
+            : `${entry.letter} — kein Begriff vorhanden`;
+          const baseClass = 'ui-letter-index__item';
+          const className = entry.firstTermId ? baseClass : `${baseClass} ${baseClass}--empty`;
+
+          return (
+            <li key={entry.letter} className="ui-letter-index__cell">
+              {entry.firstTermId ? (
+                <a className={className} href={`#glossar-term-${entry.firstTermId}`} aria-label={label}>
+                  {entry.letter}
+                </a>
+              ) : (
+                <span className={className} aria-label={label} aria-disabled="true">
+                  {entry.letter}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/ui/Section.jsx
+++ b/src/components/ui/Section.jsx
@@ -29,7 +29,12 @@ function useRevealRef() {
           }
         }
       },
-      { threshold: 0.08, rootMargin: '0px 0px 40px 0px' }
+      // Audit 25 / Sprint 5 (O16): Threshold von 0.08 auf 0.15 angehoben.
+      // Bei 0.08 loeste der Reveal schon aus, wenn 8% einer Sektion am
+      // unteren Viewport-Rand angeschnitten waren -- die Animation lief
+      // oft ausserhalb der Aufmerksamkeit ab. 0.15 wartet bis 15% sichtbar
+      // sind, sodass der Uebergang im Blickfeld passiert.
+      { threshold: 0.15, rootMargin: '0px 0px 40px 0px' }
     );
 
     observer.observe(node);

--- a/src/styles/app-global.css
+++ b/src/styles/app-global.css
@@ -74,10 +74,18 @@
    Bei prefers-reduced-motion: sofort sichtbar, keine Animation. */
 /* Transition schnell genug, damit Inhalte auf einem Fachportal sofort
    lesbar sind — kein visuelles Warten beim Scrollen. Mikro-Polish
-   statt Marketing-Animation (Nutzer-Audit N1). */
+   statt Marketing-Animation (Nutzer-Audit N1).
+   Audit 25 / Sprint 5 (O16): translateY von 6px auf 10px angehoben,
+   damit die Bewegung auch beim schnellen Scrollen wahrnehmbar bleibt
+   (6px war in der Praxis unter der Wahrnehmungsschwelle). Duration
+   bleibt bei --motion-fast (180ms) -- Text soll nicht auf die Animation
+   warten. Zusaetzlich: Threshold-Bump in Section.jsx von 0.08 auf 0.15
+   verlagert den Ausloeser etwas spaeter in den sichtbaren Bereich, sodass
+   die Animation tatsaechlich beobachtet wird statt unbemerkt am Rand zu
+   verklingen. */
 .reveal-on-scroll {
   opacity: 0;
-  transform: translateY(6px);
+  transform: translateY(10px);
   transition:
     opacity var(--motion-fast) var(--motion-curve-standard),
     transform var(--motion-fast) var(--motion-curve-standard);

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -4219,3 +4219,77 @@
   flex: 1;
   min-width: 0;
 }
+
+/* Audit 25 / Sprint 5 (O11): Alphabet-Navigation auf dem Glossar-Tab.
+   Kompaktes Pill-Band: jedes Zeichen sitzt auf einem 2rem-Minifeld,
+   klickbare Letter tragen den warmen Primary-Accent, leere Letter
+   bleiben als gedimmter Hinweis sichtbar (At-a-Glance-Coverage).
+   Auf Mobile: das Band bricht in mehrere Reihen um, bleibt aber
+   beruehrbar dank min-height 2rem (44px-Touch-Target wird ueber
+   die Hit-Area des <a> mit padding erreicht). */
+.ui-letter-index {
+  width: 100%;
+}
+
+.ui-letter-index__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ui-letter-index__cell {
+  display: flex;
+}
+
+.ui-letter-index__item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  min-height: 2.25rem;
+  padding: 0 0.5rem;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--surface-app);
+  color: var(--text-primary);
+  font-family: var(--font-heading);
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  line-height: 1;
+  text-decoration: none;
+  transition:
+    background var(--motion-fast) var(--motion-curve-standard),
+    color var(--motion-fast) var(--motion-curve-standard),
+    border-color var(--motion-fast) var(--motion-curve-standard),
+    transform var(--motion-fast) var(--motion-curve-standard);
+}
+
+.ui-letter-index__item:hover,
+.ui-letter-index__item:focus-visible {
+  background: var(--accent-primary-strong);
+  border-color: var(--accent-primary-strong);
+  color: var(--text-inverse);
+  transform: translateY(-1px);
+}
+
+/* Gedimmte Darstellung fuer Buchstaben ohne Term. Kontrast bleibt
+   >= 4.5:1 (--text-muted auf --surface-subtle: 4.89), damit der
+   Buchstabe fuer Screen Reader + sehende Nutzer noch wahrnehmbar
+   ist -- inaktiv heisst nicht unsichtbar. */
+.ui-letter-index__item--empty {
+  background: var(--surface-subtle);
+  border-color: var(--border-subtle);
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.ui-letter-index__item--empty:hover,
+.ui-letter-index__item--empty:focus-visible {
+  background: var(--surface-subtle);
+  border-color: var(--border-subtle);
+  color: var(--text-muted);
+  transform: none;
+}

--- a/src/templates/GlossarPageTemplate.jsx
+++ b/src/templates/GlossarPageTemplate.jsx
@@ -1,9 +1,11 @@
 import EditorialIndex from '../components/ui/EditorialIndex';
 import EditorialIntro from '../components/ui/EditorialIntro';
 import Container from '../components/ui/Container';
+import GlossarLetterIndex from '../components/ui/GlossarLetterIndex';
 import PageHero from '../components/ui/PageHero';
 import Section from '../components/ui/Section';
 import SectionHeader from '../components/ui/SectionHeader';
+import { buildGlossarLetterIndex } from '../utils/glossarLetterIndex';
 
 function GlossarGroup({ group }) {
   return (
@@ -18,7 +20,11 @@ function GlossarGroup({ group }) {
 
         <div className="ui-glossary-term-grid">
           {group.terms.map((entry) => (
-            <details key={entry.term} className="ui-disclosure-card">
+            // Audit 25 / Sprint 5 (O11): Term-id als Scroll-Anker fuer die
+            // Letter-Index-Jumps. Klick auf "P" in der Alphabet-Navigation
+            // springt via `#glossar-term-{id}` auf den ersten Term, dessen
+            // Anfangsbuchstabe (nach Umlaut-Faltung) passt.
+            <details id={`glossar-term-${entry.id}`} key={entry.term} className="ui-disclosure-card">
               <summary className="ui-disclosure-card__summary">
                 <div>
                   <p className="ui-fact-card__label">Begriff</p>
@@ -46,6 +52,8 @@ function GlossarGroup({ group }) {
 }
 
 export default function GlossarPageTemplate({ hero, pageHeadingId, intro, groups = [] }) {
+  const letterIndex = buildGlossarLetterIndex(groups);
+
   return (
     <div className="ui-stack">
       <Container width="wide">
@@ -53,6 +61,15 @@ export default function GlossarPageTemplate({ hero, pageHeadingId, intro, groups
       </Container>
       <EditorialIntro intro={intro} />
       <EditorialIndex items={groups} spacing="compact" surface="muted" />
+      {/* Audit 25 / Sprint 5 (O11): Alphabet-Navigation unter der Cluster-Nav.
+          Cluster-Nav beantwortet "welches Thema?", Letter-Nav beantwortet
+          "welcher Begriff?". Beide im schmalen Stack, um die Seite nicht
+          mit doppelten Orientierungsbaendern aufzubauschen. Die schmale
+          Section (spacing="compact") haelt das Band visuell nahe an der
+          Cluster-Nav. */}
+      <Section spacing="compact" surface="plain">
+        <GlossarLetterIndex entries={letterIndex} />
+      </Section>
       {groups.map((group) => (
         <GlossarGroup key={group.id} group={group} />
       ))}

--- a/src/utils/glossarLetterIndex.js
+++ b/src/utils/glossarLetterIndex.js
@@ -1,0 +1,41 @@
+/**
+ * Letter-Index fuer den Glossar-Tab (Audit 25 / Sprint 5, O11).
+ *
+ * Baut aus einer Liste von GlossaryGroups ein Alphabet-Array, das fuer
+ * jeden Buchstaben (A-Z, deutsche Umlaute werden auf ihren Basisbuchstaben
+ * gefaltet: Ä->A, Ö->O, Ü->U) anzeigt, ob und zu welchem ersten Term
+ * gesprungen werden kann. Buchstaben ohne Term bleiben sichtbar, aber
+ * inaktiv -- das Index-Band zeigt damit auch die Abdeckung.
+ *
+ * Reihenfolge im Rueckgabewert entspricht der ueblichen de-CH-Sortierung
+ * A-Z (26 Buchstaben). Der erste Term pro Buchstabe ist derjenige, der
+ * in `groups` zuerst auftaucht -- das spiegelt die Cluster-Reihenfolge,
+ * nicht die Alphabet-Reihenfolge innerhalb des Buchstabens.
+ */
+const BASE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+const UMLAUT_MAP = { Ä: 'A', Ö: 'O', Ü: 'U' };
+
+function normalizeFirstLetter(term) {
+  const first = term.trim().charAt(0).toUpperCase();
+  return UMLAUT_MAP[first] || first;
+}
+
+/**
+ * @param {Array<{terms: Array<{id: string, term: string}>}>} groups
+ * @returns {Array<{letter: string, firstTermId: string|null, count: number}>}
+ */
+export function buildGlossarLetterIndex(groups = []) {
+  const byLetter = new Map();
+  for (const group of groups) {
+    for (const entry of group.terms || []) {
+      const letter = normalizeFirstLetter(entry.term);
+      if (!byLetter.has(letter)) {
+        byLetter.set(letter, { letter, firstTermId: entry.id, count: 0 });
+      }
+      byLetter.get(letter).count += 1;
+    }
+  }
+  return BASE_ALPHABET.map(
+    (letter) => byLetter.get(letter) || { letter, firstTermId: null, count: 0 }
+  );
+}


### PR DESCRIPTION
## Summary

Zwei orthogonale Quick-Wins aus dem Audit-25-Katalog, in einem Zug:

- **O11 — Glossar-Letter-Index**: Kompaktes A–Z-Pill-Band unter der Cluster-Nav auf dem Glossar-Tab. Aktive Buchstaben linken als Sprunganker auf den ersten passenden Term; inaktive bleiben als gedimmte Spans sichtbar — das Band ist so zugleich Navigation und At-a-Glance-Coverage-Indikator. Umlaut-Faltung (Ä→A, Ö→O, Ü→U) nach Phonebook-Konvention. Kontrast der gedimmten Zellen 4.89 : 1 (AA für Normaltext).
- **O16 — Reveal-on-Scroll Feintuning**: `translateY` von 6 px → 10 px (6 px war unter der Wahrnehmungsschwelle), Threshold von 0.08 → 0.15 (verlagert den Auslöser in den sichtbaren Bereich, statt die Animation unbemerkt am Viewport-Rand verpuffen zu lassen). Duration + Curve bleiben — „Mikro-Polish statt Marketing-Animation" ist weiterhin das Leitprinzip.

## Entscheidungen

- Letter-Index sitzt **unter** der Cluster-Nav in einer eigenen `spacing="compact"`-Section — nicht nebeneinander, weil beide Bänder gleich hohe Priorität haben und ein horizontales Nebeneinander die Hierarchie unsauber macht.
- Inaktive Buchstaben werden gerendert (statt versteckt), damit das Band auch die Abdeckung signalisiert — „gibt es ein Q?" beantwortet das Band mit einem einzigen Blick.
- `P` springt auf _Psychisch belastete Elternschaft_, weil das der erste P-Term in der Cluster-Reihenfolge ist — nicht in der Alphabet-Reihenfolge. Bewusste Entscheidung: wir brechen die Cluster-Gliederung nicht auf, um einen sekundären Index zu bedienen.
- Neue Term-`id`s der Form `glossar-term-{id}` nutzen die bestehenden stabilen IDs aus `glossaryContent.js` — keine neuen IDs, keine Migrationsschuld.
- O16 bleibt absichtlich schnell (180 ms). Der Punkt war nicht „langsamer animieren", sondern „so animieren, dass man es tatsächlich sieht".

## Verifikation (Chromium 1440 × 900)

- 26 Letter-Cells gerendert, 13 aktiv (A, B, G, H, K, L, M, N, P, R, S, T, W), 13 leer (C, D, E, F, I, J, O, Q, U, V, X, Y, Z).
- Alle aktiven Anker resolven gegen ein vorhandenes `<details id>` — smooth-scroll funktioniert.
- `.reveal-on-scroll` computed: `transform: matrix(1,0,0,1,0,10)`, `transition-duration: 0.18s` (translateY 10 px bestätigt, Duration unverändert).
- `npm run lint` clean, `npm run build` clean (1724 Module).

## Test plan

- [ ] `#glossar` laden, Alphabet-Band sichtbar unter der Cluster-Nav
- [ ] Klick auf aktive Buchstaben (z. B. L, K, S) scrollt zum ersten Term
- [ ] Leere Buchstaben sind nicht klickbar, aber sichtbar
- [ ] Hover auf aktive Pill → Primary-Strong-Fill + kleiner Lift
- [ ] Andere Seiten scrollen: Sections faden mit 10 px Y-Offset ein, Animation ist spürbar aber kurz (180 ms)
- [ ] `prefers-reduced-motion`: keine Animation, Inhalte sofort sichtbar

https://claude.ai/code/session_01Y7tCrUuNxDaDcs2tk4ghxH