### PR TITLE
feat(ui): Visual-Polish Sprint 6 — Tab-Change-Transition via View Transition API (O11)

### DIFF
--- a/src/context/AppStateContext.jsx
+++ b/src/context/AppStateContext.jsx
@@ -101,10 +101,31 @@ export function AppStateProvider({ children }) {
   };
 
   // Navigate to a tab with an optional focus target (sets navigationFocusTargetRef for App)
+  // Audit 25 / Sprint 6 (O11): Bei Browsern mit View Transition API wird der
+  // Tab-Wechsel als Cross-Fade gerendert (Chromium 111+, Safari 18+). Das
+  // macht den SPA-Wechsel als sanfte Uebergabe erfahrbar statt als
+  // instantaner DOM-Austausch. Fallback fuer Firefox / aeltere Browser:
+  // direkter State-Update (Verhalten wie vor Sprint 6). prefers-reduced-motion
+  // bypasst die Transition bewusst -- Nutzer mit Motion-Aversion sollen
+  // keine crossfade-Bewegung bekommen, auch keine sanfte.
   const navigate = useCallback((nextTab, options = {}) => {
     const { focusTarget = 'heading' } = options;
     navigationFocusTargetRef.current = focusTarget;
-    setActiveTab((prev) => (prev === nextTab ? prev : nextTab));
+
+    const applyUpdate = () => setActiveTab((prev) => (prev === nextTab ? prev : nextTab));
+
+    const supportsViewTransition =
+      typeof document !== 'undefined' && typeof document.startViewTransition === 'function';
+    const prefersReducedMotion =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (supportsViewTransition && !prefersReducedMotion) {
+      document.startViewTransition(applyUpdate);
+    } else {
+      applyUpdate();
+    }
   }, []);
 
   // Reset all persisted state to defaults

--- a/src/styles/app-global.css
+++ b/src/styles/app-global.css
@@ -104,6 +104,26 @@
   }
 }
 
+/* Audit 25 / Sprint 6 (O11): Tab-Change-Transition via View Transition API.
+   Default-Behaviour des Browsers waere ein 250ms-Cross-Fade; wir schrauben
+   das auf 180ms zurueck, damit es dem Motion-System der Seite entspricht
+   (--motion-fast). Mikro-Polish-Prinzip: sichtbar, aber nicht wartend.
+   prefers-reduced-motion wird bereits in navigate() abgefangen -- die
+   Transition wird in dem Fall gar nicht gestartet; zusaetzlich dieser
+   CSS-Guard, falls ein Browser das JS-Guard umgeht. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: var(--motion-fast);
+  animation-timing-function: var(--motion-curve-standard);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
+  }
+}
+
 :focus-visible {
   outline: var(--focus-ring-width) solid var(--focus-ring);
   outline-offset: var(--focus-ring-offset);


### PR DESCRIPTION
## Summary

Letzte „Nice-to-have"-Option aus dem Audit-25-Katalog: **O11 Tab-Change-Transition**. `navigate()` in `AppStateContext` wird über die View Transition API gewrappt — Chromium 111+ und Safari 18+ rendern den Tab-Wechsel als 180 ms-Cross-Fade, ältere Browser und Firefox laufen weiterhin im direkten State-Update.

## Entscheidungen

- **`document.startViewTransition(applyUpdate)`** statt eines eigenen Fade-Mechanismus über React-State — die API ist designed für exakt diesen Use-Case (DOM-Austausch einfaden), hat native Paint-Synchronisation und braucht keine zusätzliche State-Variable.
- **Duration 180 ms** statt Browser-Default (~250 ms), damit es dem Motion-System der Seite entspricht (`--motion-fast`). Mikro-Polish, kein Marketing.
- **Doppelter `prefers-reduced-motion`-Guard**: einmal in JS (Transition wird erst gar nicht gestartet), einmal in CSS (`animation: none` auf `::view-transition-*`). Redundant, aber billig — falls ein Browser den einen Guard umgeht.
- **Kein Fallback-Fade für Firefox**: ein manueller Fade via React-State hätte Trade-offs (Double-Render, Fokus-Glitch, Lazy-Section-Flicker). Firefox-User bekommen instantaner Wechsel — exakt das bisherige Verhalten, also kein Regress.

## Korrektur der Sprint-5-Nomenklatur

In [PR #151](../pull/151) waren die Option-Nummern vertauscht:

- Dort „O11" → war ein neu konzipierter **Glossar-Letter-Index** (nicht im Katalog, eigenständige Bonus-Idee).
- Dort „O16" → war ein **Teilschritt von O10** (Reveal-Feintuning ohne Stagger). Der echte O16 im Katalog war „Logo/Monogramm aufwerten" — post-launch.

Der echte **O11 Tab-Change-Transition** aus dem Audit-25-Katalog landet hiermit in diesem PR. Stand Katalog nach Merge: 11 von 16 Optionen verifizierbar abgearbeitet. Rest (O3, O6, O7, O8, O10-Stagger-Teil, O13, O16) entweder post-launch, Design-Kapazität erforderlich, oder explizit nicht empfohlen (O13 widerspricht Emergency-First).

## Verifikation (Chromium 1194, 1440 × 900)

- `document.startViewTransition` verfügbar, `prefers-reduced-motion` = false → Transition läuft
- Klick auf Tab-Button „Evidenz" erhöht den Transition-Counter — der Wrapper wird tatsächlich aufgerufen (nicht der Fallback-Zweig)
- CSS-Regeln im Stylesheet: `::view-transition-old(root)` + `::view-transition-new(root)` mit `animation-duration: var(--motion-fast)` (180 ms) und `animation-timing-function: var(--motion-curve-standard)`
- `prefers-reduced-motion`-Override: `animation: none` (computed als `auto ease 0s 1 normal none running none`)
- `npm run lint` clean, `npm run build` clean

## Test plan

- [ ] In Chromium/Safari: Zwischen Tabs wechseln (Hauptmenü, Footer-Links, Closing-Section-Links) — sanfter 180 ms-Cross-Fade
- [ ] In Firefox: Wechsel ohne Transition (instantan, wie vor Sprint 6)
- [ ] `prefers-reduced-motion: reduce` aktivieren (DevTools oder OS) → keine Animation, instantaner Wechsel
- [ ] Lazy-geladene Tabs (Material, Toolbox) → keine Flash-of-Unstyled-Content
- [ ] Focus-Management: Heading-Focus wird korrekt gesetzt (Accessibility-Kontinuität)

https://claude.ai/code/session_01Y7tCrUuNxDaDcs2tk4ghxH