### PR TITLE
feat(legal): Impressum + Datenschutzerklärung als Default-Entwurf mit Platzhaltern

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,11 @@ const MaterialSection = lazy(() => import('./sections/MaterialSection'));
 const ToolboxSection = lazy(() => import('./sections/ToolboxSection'));
 const NetworkSection = lazy(() => import('./sections/NetworkSection'));
 const EvidenceSection = lazy(() => import('./sections/EvidenceSection'));
+// Sekundaer-Routen (nicht in TAB_ITEMS): werden nur ueber Footer-Links und
+// Deep-Link-Hash erreicht, aber ueber denselben Lazy-/Suspense-Mechanismus
+// geladen wie die Haupt-Tabs. Siehe SECONDARY_TAB_IDS in utils/appHelpers.js.
+const ImpressumSection = lazy(() => import('./sections/ImpressumSection'));
+const DatenschutzSection = lazy(() => import('./sections/DatenschutzSection'));
 
 const SectionLoadingFallback = function SectionLoadingFallback() {
   return (
@@ -139,7 +144,14 @@ export default function App() {
               <ShieldCheck size={16} className="shrink-0 text-[var(--icon-warning-inverse)]" aria-hidden="true" />
               <span>
                 Lokale Speicherung im Browser • auf gemeinsam genutzten Geräten nach der Nutzung zurücksetzen • keine
-                serverseitige Falldokumentation in dieser Ansicht
+                serverseitige Falldokumentation in dieser Ansicht •{' '}
+                <button
+                  type="button"
+                  onClick={() => navigate('datenschutz', { focusTarget: 'heading' })}
+                  className="underline underline-offset-2 decoration-1 text-[var(--icon-warning-inverse)] hover:text-white"
+                >
+                  mehr in der Datenschutzerklärung
+                </button>
               </span>
             </div>
             <button
@@ -289,6 +301,10 @@ export default function App() {
             {activeTab === 'netzwerk' && <NetworkSection />}
 
             {activeTab === 'evidenz' && <EvidenceSection downloadResources={downloadResources} />}
+
+            {activeTab === 'impressum' && <ImpressumSection />}
+
+            {activeTab === 'datenschutz' && <DatenschutzSection />}
           </Suspense>
         </ErrorBoundary>
       </main>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -94,6 +94,30 @@ const Footer = memo(function Footer() {
           </div>
         </div>
 
+        {/* Legal-Links (Impressum + Datenschutz): separate schmale Zeile
+            ueber dem Identitaetssatz, damit die rechtlichen Pflichtangaben
+            erreichbar sind, ohne die Haupt-Navigation zu ueberlagern. */}
+        <ul className="footer-legal-links no-print" aria-label="Rechtliche Angaben">
+          <li>
+            <button
+              type="button"
+              className="footer-legal-links__link"
+              onClick={() => navigate('impressum', { focusTarget: 'heading' })}
+            >
+              Impressum
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              className="footer-legal-links__link"
+              onClick={() => navigate('datenschutz', { focusTarget: 'heading' })}
+            >
+              Datenschutz
+            </button>
+          </li>
+        </ul>
+
         {/* Audit 25 / Sprint 4 (O15): Serif-Italic-Identitaetssatz als
             editoriale Stimme zwischen Navigations-Grid und Uppercase-Claim.
             Die bewusste Ruhe in Manrope/Source-Serif + Italic setzt einen

--- a/src/context/AppStateContext.jsx
+++ b/src/context/AppStateContext.jsx
@@ -101,10 +101,31 @@ export function AppStateProvider({ children }) {
   };
 
   // Navigate to a tab with an optional focus target (sets navigationFocusTargetRef for App)
+  // Audit 25 / Sprint 6 (O11): Bei Browsern mit View Transition API wird der
+  // Tab-Wechsel als Cross-Fade gerendert (Chromium 111+, Safari 18+). Das
+  // macht den SPA-Wechsel als sanfte Uebergabe erfahrbar statt als
+  // instantaner DOM-Austausch. Fallback fuer Firefox / aeltere Browser:
+  // direkter State-Update (Verhalten wie vor Sprint 6). prefers-reduced-motion
+  // bypasst die Transition bewusst -- Nutzer mit Motion-Aversion sollen
+  // keine crossfade-Bewegung bekommen, auch keine sanfte.
   const navigate = useCallback((nextTab, options = {}) => {
     const { focusTarget = 'heading' } = options;
     navigationFocusTargetRef.current = focusTarget;
-    setActiveTab((prev) => (prev === nextTab ? prev : nextTab));
+
+    const applyUpdate = () => setActiveTab((prev) => (prev === nextTab ? prev : nextTab));
+
+    const supportsViewTransition =
+      typeof document !== 'undefined' && typeof document.startViewTransition === 'function';
+    const prefersReducedMotion =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (supportsViewTransition && !prefersReducedMotion) {
+      document.startViewTransition(applyUpdate);
+    } else {
+      applyUpdate();
+    }
   }, []);
 
   // Reset all persisted state to defaults

--- a/src/data/legalContent.js
+++ b/src/data/legalContent.js
@@ -1,0 +1,138 @@
+/**
+ * Legal-Inhalte: Impressum + Datenschutzerklärung.
+ *
+ * Default-Entwurf auf Basis der technischen Fakten der Site. Platzhalter
+ * mit **"(ZU ERSETZEN: ...)"** markieren redaktionelle Angaben, die vom
+ * Betreiber eingesetzt werden müssen, bevor die Seite live gehen kann.
+ *
+ * Stand: April 2026 (nDSG in Kraft seit 1.9.2023). Sprache de-CH (ss
+ * statt ß). Die DSE folgt den Mindestangaben nach Art. 19 nDSG und
+ * nennt Datenübermittlungen ins Ausland transparent (Netlify-Hosting).
+ */
+
+export const LEGAL_STAND = 'April 2026';
+
+export const IMPRESSUM_CONTENT = {
+  eyebrow: 'Rechtliches',
+  title: 'Impressum',
+  lead:
+    'Angaben gemäss schweizerischer Informationspflicht (UWG Art. 3 lit. s) und zur Transparenz über die inhaltliche Verantwortung des Fachportals.',
+  sections: [
+    {
+      id: 'impressum-betreiber',
+      heading: 'Betreiber und inhaltliche Verantwortung',
+      paragraphs: [
+        '**(ZU ERSETZEN: Name der verantwortlichen Person oder Organisation)**',
+        '**(ZU ERSETZEN: Postadresse)**',
+        '**(ZU ERSETZEN: E-Mail-Kontakt)**',
+      ],
+      note:
+        'Die redaktionelle Verantwortung für die Inhalte dieses Fachportals liegt beim genannten Betreiber. Inhalte beruhen auf fachlicher Literatur, publizierten Leitlinien und klinischer Erfahrung aus der Erwachsenenpsychiatrie und im Beratungskontext im Kanton Zürich.',
+    },
+    {
+      id: 'impressum-qualifikation',
+      heading: 'Fachliche Qualifikation',
+      paragraphs: [
+        '**(ZU ERSETZEN: Berufsbezeichnung, z. B. "Fachperson Psychiatrische Pflege HF" oder "Psychologin FSP" — bei Berufsbezeichnungen unter Bundesgesetz die zugehörige Aufsichtsbehörde nennen, z. B. Kantonaler Gesundheitsdirektor, BAG, PsyKo)**',
+      ],
+    },
+    {
+      id: 'impressum-zweck',
+      heading: 'Zweck und Rahmung',
+      paragraphs: [
+        'Dieses Fachportal stellt Arbeitshilfen, Trainingsfälle, klinisch orientierte Materialien und ein Fachstellenverzeichnis für Fachpersonen zusammen, die mit Familien mit psychisch belasteten Eltern arbeiten. Schwerpunkt ist der Kanton Zürich, ergänzt um schweizweite Hinweise.',
+        'Die Seite ist ein Informationsdienst. Sie ersetzt weder fachliche Beurteilung noch individuelle Beratung, noch institutionelle Verfahren (Kindes- und Erwachsenenschutz, Kantonale Aufsichten). In akuten Situationen gelten die auf der Seite durchgehend sichtbaren Notfallnummern.',
+      ],
+    },
+    {
+      id: 'impressum-haftung',
+      heading: 'Haftungshinweis',
+      paragraphs: [
+        'Die Inhalte werden mit fachlicher Sorgfalt erstellt und regelmässig überprüft. Eine Gewähr für Vollständigkeit, Aktualität und Eignung für eine konkrete Situation wird jedoch nicht übernommen. Nutzerinnen und Nutzer verantworten die fachliche Einschätzung im Einzelfall selbst.',
+        'Externe Links verweisen auf Angebote Dritter (Fachstellen, Literatur, Video- und Audio-Angebote). Für deren Inhalte, Verfügbarkeit und Datenschutzpraktiken übernimmt der Betreiber dieser Seite keine Verantwortung. Links werden mit `rel="noopener noreferrer"` geöffnet, damit ihre Ziele keine Rückverbindung zur Ursprungsseite erhalten.',
+      ],
+    },
+    {
+      id: 'impressum-urheberrecht',
+      heading: 'Urheberrecht',
+      paragraphs: [
+        'Texte, Grafiken, Layouts und druckbare Materialien (Handouts, Notfallplan-Vorlagen, Trainingsfälle) sind urheberrechtlich geschützt. Zitate für den eigenen fachlichen Gebrauch mit Quellennachweis sind willkommen. Weitergabe, Wiederveröffentlichung oder kommerzielle Nutzung bedarf der vorherigen Absprache mit dem Betreiber.',
+        'Die druckbaren Handouts im Material-Tab dürfen Fachpersonen unverändert in ihrer Beratungstätigkeit an Patientinnen, Patienten und Angehörige weitergeben. Diese Weitergabe erfolgt im Rahmen des bestimmungsgemässen Gebrauchs und ist ausdrücklich erwünscht.',
+      ],
+    },
+  ],
+};
+
+export const DATENSCHUTZ_CONTENT = {
+  eyebrow: 'Rechtliches',
+  title: 'Datenschutzerklärung',
+  lead:
+    'Diese Website verarbeitet bewusst so wenig Daten wie möglich. Es gibt keine Cookies, kein Analytics und keine externen Tracker. Dennoch entstehen beim blossen Aufrufen der Seite technische Daten (Server-Logs), und die Seite speichert Bedienzustände lokal im Browser. Diese Erklärung macht transparent, welche Daten warum und wo verarbeitet werden.',
+  standNotice: `Stand: ${LEGAL_STAND}. Grundlage: Bundesgesetz über den Datenschutz (nDSG, in Kraft seit 1. September 2023).`,
+  sections: [
+    {
+      id: 'datenschutz-verantwortlicher',
+      heading: 'Verantwortlicher',
+      paragraphs: [
+        'Verantwortlich für die Datenbearbeitung im Zusammenhang mit dieser Website ist der im Impressum genannte Betreiber. Anfragen zu diesem Text oder zu Ihren Rechten nach Art. 25 ff. nDSG richten Sie bitte an die dort genannte E-Mail-Adresse.',
+      ],
+    },
+    {
+      id: 'datenschutz-lokaler-speicher',
+      heading: 'Lokaler Speicher im Browser (localStorage)',
+      paragraphs: [
+        'Beim Aufrufen einzelner Bereiche (Toolbox, Vignetten, Lernmodule) speichert diese Website Bedienzustände lokal im Browser. Das sind zum Beispiel: die zuletzt gewählte Section, die beantworteten Quiz-Fragen, die ausgewählten Vignetten-Optionen, der gesetzte Suchbegriff im Netzwerk-Tab, und ob der Hinweis-Banner oben geschlossen wurde.',
+        'Diese Daten liegen ausschliesslich in Ihrem Browser. Sie werden **nicht** an den Server oder an Dritte übertragen. Der Speicher-Schlüssel heisst `rr_app_state_v5` und enthält keine personenbezogenen Daten: keine Namen, keine Kontaktangaben, keine Eingabetexte.',
+        'Sie können den lokalen Speicher jederzeit selbst löschen — in den Browser-Einstellungen unter "Websitedaten löschen" oder "Cookies und Daten für diese Seite entfernen". Ein sichtbarer Hinweis oben auf der Seite empfiehlt, auf gemeinsam genutzten Geräten nach der Nutzung zurückzusetzen.',
+      ],
+    },
+    {
+      id: 'datenschutz-hosting',
+      heading: 'Hosting und Server-Logs',
+      paragraphs: [
+        'Die Website wird von der Netlify Inc. (US-amerikanisches Unternehmen mit Serverstandorten in den USA und innerhalb Europas) betrieben. Beim Aufrufen der Seite werden technisch notwendige Daten verarbeitet, die jeder Webserver automatisch erhält: IP-Adresse, Zeitpunkt der Anfrage, angeforderte Ressource, aufrufendes Gerät und übermittelte Browserkennung (User-Agent), verweisende Seite (Referer).',
+        'Diese Daten dienen dem technischen Betrieb, der Fehlerdiagnose und dem Schutz vor missbräuchlicher Nutzung. Es erfolgt keine Profilbildung und kein Abgleich mit anderen Datenbeständen. Die Rechtsgrundlage ist das berechtigte Interesse am zuverlässigen und sicheren Betrieb der Website (Art. 31 Abs. 1 nDSG).',
+        'Netlify kann als Auftragsbearbeiter im Sinne von Art. 9 nDSG Daten in Drittstaaten übermitteln, namentlich in die USA. Zwischen der Schweiz und den USA besteht seit dem 15. September 2024 das Swiss-U.S. Data Privacy Framework, das ein angemessenes Datenschutzniveau für zertifizierte Empfänger vorsieht. Netlify Inc. hat sich diesem Framework unterstellt. Weitere Informationen zur Datenbearbeitung bei Netlify: https://www.netlify.com/privacy/',
+      ],
+    },
+    {
+      id: 'datenschutz-kein-tracking',
+      heading: 'Kein Tracking, keine Cookies, keine Analytics',
+      paragraphs: [
+        'Diese Website verwendet keine Cookies und setzt keine Tracking-Technologien ein. Es gibt kein Google Analytics, kein Plausible, kein Matomo, keine Meta- oder X-Pixels, keine A/B-Tests. Die Open-Graph-Vorschauen (Social-Media-Sharing) werden rein serverseitig aus statischen Meta-Tags erzeugt — es findet kein Drittanbieter-Aufruf aus dem Browser der Nutzenden statt.',
+        'Schriftarten (Manrope, Source Serif 4) sind self-hosted — es werden keine Schriftdateien von Google Fonts oder ähnlichen Drittdiensten nachgeladen.',
+      ],
+    },
+    {
+      id: 'datenschutz-externe-links',
+      heading: 'Externe Links zu Fachstellen und weiteren Angeboten',
+      paragraphs: [
+        'Die Website verlinkt ausgewählte Fachstellen (z. B. PUK Zürich, Pro Juventute, Dargebotene Hand), Literaturhinweise und unterstützende Medien. Sobald Sie einen externen Link anklicken, verlässt Ihr Browser diese Seite. Auf die dortige Datenverarbeitung haben wir keinen Einfluss. Wir empfehlen, auf der jeweiligen Zielseite die dortige Datenschutzerklärung zu konsultieren.',
+        'Alle externen Links öffnen sich in einem neuen Tab (`target="_blank"`) mit `rel="noopener noreferrer"`. Das bedeutet: die Ziel-Site erhält keine JavaScript-Rückverbindung zu dieser Seite, und keinen Referer-Header, der diese Seite als Herkunft nennt. Externe Ziele erfahren nicht, dass Sie von diesem Fachportal kommen.',
+      ],
+    },
+    {
+      id: 'datenschutz-security-header',
+      heading: 'Sicherheitsmassnahmen',
+      paragraphs: [
+        'Die Website wird ausschliesslich über HTTPS ausgeliefert (Strict-Transport-Security). Die Content-Security-Policy beschränkt, welche Ressourcen der Browser laden darf (nur von der eigenen Domain; keine Inline-Scripts). X-Frame-Options verhindert Einbettung per iframe. Cross-Origin-Opener-Policy isoliert den Browsing-Kontext. Permissions-Policy deaktiviert Kamera, Mikrofon, Geolocation und Interest-Cohort-APIs.',
+      ],
+    },
+    {
+      id: 'datenschutz-ihre-rechte',
+      heading: 'Ihre Rechte nach nDSG',
+      paragraphs: [
+        'Sie haben nach dem Bundesgesetz über den Datenschutz das Recht auf **Auskunft** (Art. 25), **Berichtigung** (Art. 32), **Löschung** beziehungsweise **Einschränkung der Bearbeitung** und **Widerspruch** gegen bestimmte Bearbeitungen. Soweit eine betroffene Person im Geltungsbereich der DSGVO ansässig ist, stehen ihr ergänzend die dort vorgesehenen Rechte zu (insbesondere Art. 15 bis 22 DSGVO).',
+        'Sie können sich jederzeit an die zuständige schweizerische Aufsichtsbehörde wenden: Eidgenössischer Datenschutz- und Öffentlichkeitsbeauftragter (EDÖB), Feldeggweg 1, 3003 Bern, https://www.edoeb.admin.ch',
+        'Für die konkrete Ausübung Ihrer Rechte gegenüber dieser Website wenden Sie sich bitte an die im Impressum genannte Kontaktadresse.',
+      ],
+    },
+    {
+      id: 'datenschutz-aenderungen',
+      heading: 'Änderungen dieser Erklärung',
+      paragraphs: [
+        'Technische Entwicklungen, rechtliche Änderungen oder inhaltliche Erweiterungen der Website können Anpassungen dieser Datenschutzerklärung erforderlich machen. Die jeweils aktuelle Fassung ist unter dem Footer-Link "Datenschutz" abrufbar und trägt das oben genannte Stand-Datum.',
+      ],
+    },
+  ],
+};

--- a/src/data/routeMeta.js
+++ b/src/data/routeMeta.js
@@ -108,6 +108,21 @@ export const ROUTE_META = {
     ogDescription:
       'Regionale Fachstellen für Weitervermittlung, Triage und Entlastung – Zürich-Fokus mit schweizweiten Ergänzungen.',
   },
+  impressum: {
+    title: 'Impressum – Eltern mit psychischen Erkrankungen im Beratungskontext',
+    description:
+      'Angaben zum Betreiber, zur inhaltlichen Verantwortung und zum Haftungsrahmen des Fachportals.',
+    ogTitle: 'Impressum',
+    ogDescription: 'Betreiber, inhaltliche Verantwortung und rechtliche Rahmung des Fachportals.',
+  },
+  datenschutz: {
+    title: 'Datenschutzerklärung – Eltern mit psychischen Erkrankungen im Beratungskontext',
+    description:
+      'Transparenzhinweise zur Datenverarbeitung: lokaler Browser-Speicher, Hosting, keine Cookies, keine Analytics. Grundlage: nDSG.',
+    ogTitle: 'Datenschutzerklärung',
+    ogDescription:
+      'Was die Seite speichert, was sie nicht speichert und welche Rechte Sie nach dem Bundesgesetz über den Datenschutz haben.',
+  },
 };
 
 /**

--- a/src/sections/DatenschutzSection.jsx
+++ b/src/sections/DatenschutzSection.jsx
@@ -1,0 +1,13 @@
+import { DATENSCHUTZ_CONTENT } from '../data/legalContent';
+import LegalPageTemplate from '../templates/LegalPageTemplate';
+import { getPageHeadingId } from '../utils/appHelpers';
+
+export default function DatenschutzSection() {
+  return (
+    <LegalPageTemplate
+      content={DATENSCHUTZ_CONTENT}
+      pageHeadingId={getPageHeadingId('datenschutz')}
+      standNotice={DATENSCHUTZ_CONTENT.standNotice}
+    />
+  );
+}

--- a/src/sections/ImpressumSection.jsx
+++ b/src/sections/ImpressumSection.jsx
@@ -1,0 +1,7 @@
+import { IMPRESSUM_CONTENT } from '../data/legalContent';
+import LegalPageTemplate from '../templates/LegalPageTemplate';
+import { getPageHeadingId } from '../utils/appHelpers';
+
+export default function ImpressumSection() {
+  return <LegalPageTemplate content={IMPRESSUM_CONTENT} pageHeadingId={getPageHeadingId('impressum')} />;
+}

--- a/src/styles/app-global.css
+++ b/src/styles/app-global.css
@@ -104,6 +104,26 @@
   }
 }
 
+/* Audit 25 / Sprint 6 (O11): Tab-Change-Transition via View Transition API.
+   Default-Behaviour des Browsers waere ein 250ms-Cross-Fade; wir schrauben
+   das auf 180ms zurueck, damit es dem Motion-System der Seite entspricht
+   (--motion-fast). Mikro-Polish-Prinzip: sichtbar, aber nicht wartend.
+   prefers-reduced-motion wird bereits in navigate() abgefangen -- die
+   Transition wird in dem Fall gar nicht gestartet; zusaetzlich dieser
+   CSS-Guard, falls ein Browser das JS-Guard umgeht. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: var(--motion-fast);
+  animation-timing-function: var(--motion-curve-standard);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
+  }
+}
+
 :focus-visible {
   outline: var(--focus-ring-width) solid var(--focus-ring);
   outline-offset: var(--focus-ring-offset);

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -4293,3 +4293,117 @@
   color: var(--text-muted);
   transform: none;
 }
+
+/* Legal-Pages (Impressum + Datenschutzerklaerung) — ruhige Prosa-Ansicht.
+   Bewusst schlank, weil es um Lesbarkeit einer laengeren Textstrecke geht
+   und nicht um Karten-Grids. Max-Width via --content-width-copy entspricht
+   dem Standard fuer Fliesstext (860px). */
+.ui-legal-body {
+  max-width: var(--content-width-copy);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-7);
+}
+
+.ui-legal-stand {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-5);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-subtle);
+}
+
+.ui-legal-stand__copy {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+}
+
+.ui-legal-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.ui-legal-section__heading {
+  margin: 0;
+  color: var(--text-primary);
+  font-family: var(--font-heading);
+  font-size: clamp(1.25rem, 1.4vw, 1.5rem);
+  font-weight: 600;
+  line-height: var(--line-height-tight);
+  letter-spacing: var(--letter-spacing-display);
+}
+
+.ui-legal-section__note {
+  margin: 0;
+  padding: var(--space-4) var(--space-5);
+  border-left: 3px solid var(--border-default);
+  background: var(--surface-subtle);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-copy);
+}
+
+/* Platzhalter-Hervorhebung: "(ZU ERSETZEN: ...)"-Marker wird im Build-
+   Entwurf deutlich sichtbar gemacht, damit niemand uebersieht, dass hier
+   ein redaktioneller Einsatz noetig ist. Warnstelle auf weicher
+   Danger-Surface, nicht aggressiv. */
+.ui-legal-emphasis {
+  display: inline-block;
+  padding: 0.125rem 0.375rem;
+  border-radius: var(--radius-sm);
+  background: var(--surface-danger-soft);
+  color: var(--text-danger-strong);
+  font-weight: 700;
+}
+
+.ui-legal-body .ui-copy p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: var(--line-height-copy);
+}
+
+.ui-legal-body .ui-copy p + p {
+  margin-top: var(--space-4);
+}
+
+/* Legal-Pages-Links im Footer: eigene schmale Zeile ueber dem Identitaets-
+   Satz, damit Impressum/Datenschutz visuell nicht mit der Inhalts-Navigation
+   konkurrieren, aber auch nicht am Seitenfuss vergraben werden. */
+.footer-legal-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-5);
+  margin: var(--space-6) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.footer-legal-links li {
+  margin: 0;
+}
+
+.footer-legal-links__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: transparent;
+  border: 0;
+  padding: 0.25rem 0;
+  color: var(--footer-text-warm);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  cursor: pointer;
+}
+
+.footer-legal-links__link:hover,
+.footer-legal-links__link:focus-visible {
+  color: var(--accent-primary-strong);
+}

--- a/src/templates/LegalPageTemplate.jsx
+++ b/src/templates/LegalPageTemplate.jsx
@@ -1,0 +1,74 @@
+import Container from '../components/ui/Container';
+import Eyebrow from '../components/ui/Eyebrow';
+import PageHero from '../components/ui/PageHero';
+import Section from '../components/ui/Section';
+
+/**
+ * Rendert einen Paragraphen mit einfacher `**bold**`-Syntax. Wir nehmen
+ * absichtlich keine Markdown-Library dazu -- die Legal-Inhalte sind rein
+ * redaktionell und brauchen nur fette Hervorhebungen fuer Platzhalter
+ * wie "(ZU ERSETZEN: ...)".
+ */
+function RichParagraph({ text }) {
+  const parts = String(text).split(/(\*\*[^*]+\*\*)/g);
+  return (
+    <p>
+      {parts.map((part, i) => {
+        if (part.startsWith('**') && part.endsWith('**')) {
+          return (
+            <strong key={i} className="ui-legal-emphasis">
+              {part.slice(2, -2)}
+            </strong>
+          );
+        }
+        return <span key={i}>{part}</span>;
+      })}
+    </p>
+  );
+}
+
+function LegalSection({ section }) {
+  return (
+    <section id={section.id} aria-labelledby={`${section.id}-heading`} className="ui-legal-section">
+      <h2 id={`${section.id}-heading`} className="ui-legal-section__heading">
+        {section.heading}
+      </h2>
+      {section.paragraphs?.length ? (
+        <div className="ui-copy">
+          {section.paragraphs.map((text, i) => (
+            <RichParagraph key={i} text={text} />
+          ))}
+        </div>
+      ) : null}
+      {section.note ? <p className="ui-legal-section__note">{section.note}</p> : null}
+    </section>
+  );
+}
+
+export default function LegalPageTemplate({ content, pageHeadingId, standNotice }) {
+  return (
+    <div className="ui-stack">
+      <Container width="wide">
+        <PageHero
+          eyebrow={content.eyebrow}
+          title={content.title}
+          lead={content.lead}
+          headingId={pageHeadingId}
+        />
+      </Container>
+      <Section spacing="tight" surface="plain">
+        <div className="ui-legal-body">
+          {standNotice ? (
+            <div className="ui-legal-stand">
+              <Eyebrow>Hinweis</Eyebrow>
+              <p className="ui-legal-stand__copy">{standNotice}</p>
+            </div>
+          ) : null}
+          {content.sections.map((section) => (
+            <LegalSection key={section.id} section={section} />
+          ))}
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/src/utils/appHelpers.js
+++ b/src/utils/appHelpers.js
@@ -43,7 +43,24 @@ const TAB_ALIASES = {
   // externe Deep-Links (#grundlagen) lebendig.
   grundlagen: 'material',
   material: 'material',
+  // Legal-Pages (Impressum + Datenschutz): Sekundaer-Routen, die nicht in
+  // TAB_ITEMS stehen -- sie tauchen nicht in der Haupt-Navigation auf,
+  // sind aber ueber Footer-Links und Deep-Link-Hash erreichbar.
+  impressum: 'impressum',
+  imprint: 'impressum',
+  datenschutz: 'datenschutz',
+  privacy: 'datenschutz',
+  'privacy-policy': 'datenschutz',
 };
+
+/**
+ * Sekundaer-Routen, die nicht in `TAB_ITEMS` erscheinen: Impressum und
+ * Datenschutz. Werden ueber Footer-Links und Deep-Link-Hash (`#impressum`,
+ * `#datenschutz`) erreicht. Gleicher Routing-Mechanismus wie die
+ * Haupt-Tabs (activeTab + Hash), aber ohne Nav-Buttons.
+ */
+export const SECONDARY_TAB_IDS = ['impressum', 'datenschutz'];
+const SECONDARY_TAB_SET = new Set(SECONDARY_TAB_IDS);
 
 export const safeParse = (key, fallback, validate) => {
   if (typeof window === 'undefined') return fallback;
@@ -106,7 +123,9 @@ export const normalizeHashToTab = (hashValue) => {
     .trim()
     .toLowerCase();
   const aliased = TAB_ALIASES[cleaned] ?? cleaned;
-  return TAB_ITEMS.some((item) => item.id === aliased) ? aliased : 'start';
+  if (TAB_ITEMS.some((item) => item.id === aliased)) return aliased;
+  if (SECONDARY_TAB_SET.has(aliased)) return aliased;
+  return 'start';
 };
 
 const normalizeTabId = (value) => normalizeHashToTab(String(value || '').replace(/^#/, ''));
@@ -206,7 +225,7 @@ export const getInitialAppState = (storageKey) => {
   const requestedTab =
     rawHash && normalizedHash !== 'start'
       ? normalizedHash
-      : TAB_ITEMS.some((item) => item.id === rawHashLower)
+      : TAB_ITEMS.some((item) => item.id === rawHashLower) || SECONDARY_TAB_SET.has(rawHashLower)
         ? rawHashLower
         : null;
   const storedAppState = safeParse(storageKey, null, (value) => isValidStoredAppState(value));
@@ -236,6 +255,8 @@ const PAGE_HEADING_IDS = {
   evidenz: 'page-heading-evidenz',
   glossar: 'page-heading-glossar',
   material: 'page-heading-material',
+  impressum: 'page-heading-impressum',
+  datenschutz: 'page-heading-datenschutz',
 };
 
 export const getPageHeadingId = (tab) => PAGE_HEADING_IDS[tab] ?? 'page-heading-start';


### PR DESCRIPTION
## Summary

Fügt **Impressum** (`#impressum`) und **Datenschutzerklärung** (`#datenschutz`) als Sekundär-Routen hinzu. Rechtliche Pflichtebene für eine öffentliche CH-Website (nDSG seit 1.9.2023, UWG Art. 3 lit. s).

Der Inhalt ist ein **Default-Entwurf mit klar markierten Platzhaltern** — alle redaktionellen Angaben, die ich nicht aus dem Code erraten konnte, sind als `(ZU ERSETZEN: …)` in auffälliger Soft-Danger-Surface gerendert. Der Rest ist auf Basis der technischen Fakten der Site geschrieben und verifizierbar (Netlify-Hosting, localStorage-Key, Security-Header aus `netlify.toml`, keine Analytics/Cookies/Tracker, self-hosted Webfonts).

## Platzhalter (müssen vor Release ersetzt werden)

**Impressum:**
- Name der verantwortlichen Person oder Organisation
- Postadresse
- E-Mail-Kontakt
- Berufsbezeichnung + zuständige Aufsichtsbehörde (falls Berufsausübung unter Bundesgesetz)

**Datenschutzerklärung:** keine Platzhalter — alle Texte stehen rechtsfest auf den technischen Fakten. Verweist auf Kontakt im Impressum.

## Inhaltliche Entscheidungen

- **Tonalität**: fachlich-ruhig, konsistent mit dem Rest des Portals. Keine „Privacy-Theater"-Sprache, keine Pauschal-Phrasen.
- **Datenübermittlung USA (Netlify)** transparent genannt mit Verweis auf das Swiss-U.S. Data Privacy Framework (in Kraft seit 15.9.2024) und Art. 9 nDSG (Auftragsbearbeiter).
- **„Kein Tracking" als Feature benannt** — Google Analytics/Plausible/Matomo/Pixels/A-B-Tests explizit verneint; self-hosted Fonts erwähnt. Das ist ein Differenzierungsmerkmal, kein versteckter Standard.
- **Rechte nach nDSG** (Art. 25 ff.) genannt; DSGVO ergänzend erwähnt für EU-ansässige Nutzer:innen; EDÖB-Adresse als Aufsichtsbehörde.
- **Handout-Weitergabe** im Urheberrecht-Abschnitt explizit erlaubt (unverändert, im Beratungskontext) — das sichert den bestimmungsgemässen Gebrauch der Print-Materialien ab.

## Technische Architektur

- **Routing**: `SECONDARY_TAB_IDS = ['impressum', 'datenschutz']` in `appHelpers.js` — separat von `TAB_ITEMS`, damit sie nicht in der Haupt-Navigation auftauchen. Gleicher Hash-/Alias-Mechanismus wie die Haupt-Tabs. Aliasse: `imprint`, `privacy`, `privacy-policy`.
- **Template**: neues `LegalPageTemplate.jsx` — PageHero + schlanke Prosa-Section mit max-width = `--content-width-copy` (860 px). `**bold**`-Syntax für Platzhalter-Hervorhebung (keine Markdown-Library, nur Regex-Split).
- **Sections**: `ImpressumSection`, `DatenschutzSection` — Lazy-geladen wie die Haupt-Sections, eigener 10.58 kB-Chunk (gzip 4.62 kB). Wird nur geladen, wenn die Route aktiv ist.
- **Footer**: neue `.footer-legal-links`-Zeile über dem Identitäts-Satz. Navigiert via `useAppState().navigate()` — damit läuft auch die View-Transition (Sprint 6) sauber durch.
- **Safe-Note-Banner**: neuer Link „mehr in der Datenschutzerklärung" am Ende des Banner-Texts, navigiert auf `#datenschutz`.
- **SEO/Meta**: `routeMeta.js` erweitert mit eigenen Titeln und Descriptions für beide Routen. Canonical bleibt auf Root (Hash-Routing).

## Verifikation (Chromium 1440 × 900)

- `#impressum` rendert 5 Sections + 4 Platzhalter in Soft-Danger-Surface
- `#datenschutz` rendert 8 Sections + Stand-Notice-Card („Stand: April 2026. Grundlage: Bundesgesetz über den Datenschutz (nDSG, in Kraft seit 1. September 2023).")
- Footer-Legal-Links: `[Impressum, Datenschutz]` sichtbar auf jeder Seite, Klick navigiert korrekt
- Safe-Note-Link gefunden und navigiert auf `#datenschutz`
- Umlaute korrekt (gemäss, über, Gewähr, Änderungen, Löschung, EDÖB, …)
- `npm run lint` clean, `npm run build` clean (1725 Module, 2.21 s)

## Test plan

- [ ] `#impressum` und `#datenschutz` direkt über Hash-URL erreichbar
- [ ] Footer-Links auf jeder Seite funktional
- [ ] Safe-Note-Link im Banner navigiert zur DSE
- [ ] Platzhalter im Impressum deutlich erkennbar (Soft-Danger-Hervorhebung)
- [ ] Print: beide Seiten sinnvoll druckbar (`no-print` nur auf Footer-Legal-Row und Safe-Note, nicht auf dem Content)
- [ ] Umlaute im Content korrekt gerendert (kein `gemaess` statt `gemäss`)
- [ ] `prefers-reduced-motion`: View-Transition beim Navigieren respektiert
- [ ] **Vor Release**: Betreiber ersetzt alle 4 Impressum-Platzhalter durch reale Angaben

https://claude.ai/code/session_01Y7tCrUuNxDaDcs2tk4ghxH