### PR TITLE
feat(legal): Impressum + DSE mit realen PUK-Fachstelle-Angaben füllen

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -89,7 +89,7 @@ const Footer = memo(function Footer() {
               </div>
             </div>
             <div className="footer-framework-legal">
-              © 2026 Eltern mit psychischen Erkrankungen im Beratungskontext.
+              © 2026 Psychiatrische Universitätsklinik Zürich · Fachstelle Angehörigenarbeit
             </div>
           </div>
         </div>

--- a/src/data/legalContent.js
+++ b/src/data/legalContent.js
@@ -1,13 +1,19 @@
 /**
  * Legal-Inhalte: Impressum + Datenschutzerklärung.
  *
- * Default-Entwurf auf Basis der technischen Fakten der Site. Platzhalter
- * mit **"(ZU ERSETZEN: ...)"** markieren redaktionelle Angaben, die vom
- * Betreiber eingesetzt werden müssen, bevor die Seite live gehen kann.
+ * Betreiber: Psychiatrische Universitätsklinik Zürich, Fachstelle
+ * Angehörigenarbeit. Redaktionell verantwortlich: Christa Egger,
+ * Sozialarbeiterin und Angehörigenberaterin. Datenbearbeitung erfolgt
+ * ausschliesslich im institutionellen Rahmen der PUK und unter der
+ * Aufsicht der Gesundheitsdirektion Kanton Zürich.
  *
  * Stand: April 2026 (nDSG in Kraft seit 1.9.2023). Sprache de-CH (ss
  * statt ß). Die DSE folgt den Mindestangaben nach Art. 19 nDSG und
  * nennt Datenübermittlungen ins Ausland transparent (Netlify-Hosting).
+ *
+ * Die **bold**-Syntax in den Paragraphen erzeugt im LegalPageTemplate
+ * eine leichte Hervorhebung (nicht die Soft-Danger-Surface, die wurde
+ * mit dem Entfernen der "(ZU ERSETZEN: ...)"-Platzhalter obsolet).
  */
 
 export const LEGAL_STAND = 'April 2026';
@@ -20,20 +26,24 @@ export const IMPRESSUM_CONTENT = {
   sections: [
     {
       id: 'impressum-betreiber',
-      heading: 'Betreiber und inhaltliche Verantwortung',
+      heading: 'Betreiber',
       paragraphs: [
-        '**(ZU ERSETZEN: Name der verantwortlichen Person oder Organisation)**',
-        '**(ZU ERSETZEN: Postadresse)**',
-        '**(ZU ERSETZEN: E-Mail-Kontakt)**',
+        'Psychiatrische Universitätsklinik Zürich',
+        'Fachstelle Angehörigenarbeit',
+        'Lenggstrasse 31, Postfach, 8032 Zürich',
+        'Telefon: +41 58 384 38 00',
+        'E-Mail: angehoerigenarbeit@pukzh.ch',
+        'Web: https://www.pukzh.ch',
       ],
       note:
-        'Die redaktionelle Verantwortung für die Inhalte dieses Fachportals liegt beim genannten Betreiber. Inhalte beruhen auf fachlicher Literatur, publizierten Leitlinien und klinischer Erfahrung aus der Erwachsenenpsychiatrie und im Beratungskontext im Kanton Zürich.',
+        'Die Psychiatrische Universitätsklinik Zürich (PUK) ist als öffentlich-rechtliche Anstalt Teil des Kantons Zürich und untersteht der Aufsicht der Gesundheitsdirektion des Kantons Zürich.',
     },
     {
-      id: 'impressum-qualifikation',
-      heading: 'Fachliche Qualifikation',
+      id: 'impressum-redaktion',
+      heading: 'Redaktionelle Verantwortung',
       paragraphs: [
-        '**(ZU ERSETZEN: Berufsbezeichnung, z. B. "Fachperson Psychiatrische Pflege HF" oder "Psychologin FSP" — bei Berufsbezeichnungen unter Bundesgesetz die zugehörige Aufsichtsbehörde nennen, z. B. Kantonaler Gesundheitsdirektor, BAG, PsyKo)**',
+        'Inhaltlich verantwortlich für diese Website ist **Christa Egger, Sozialarbeiterin und Angehörigenberaterin** an der Fachstelle Angehörigenarbeit der Psychiatrischen Universitätsklinik Zürich.',
+        'Die Inhalte entstehen im Rahmen der fachlichen Arbeit der Fachstelle und werden fortlaufend überprüft und aktualisiert. Sie beruhen auf fachlicher Literatur, publizierten Leitlinien und klinischer Erfahrung aus der Erwachsenenpsychiatrie und im Beratungskontext.',
       ],
     },
     {
@@ -74,7 +84,8 @@ export const DATENSCHUTZ_CONTENT = {
       id: 'datenschutz-verantwortlicher',
       heading: 'Verantwortlicher',
       paragraphs: [
-        'Verantwortlich für die Datenbearbeitung im Zusammenhang mit dieser Website ist der im Impressum genannte Betreiber. Anfragen zu diesem Text oder zu Ihren Rechten nach Art. 25 ff. nDSG richten Sie bitte an die dort genannte E-Mail-Adresse.',
+        'Verantwortlich für die Datenbearbeitung im Zusammenhang mit dieser Website ist die Psychiatrische Universitätsklinik Zürich, Fachstelle Angehörigenarbeit, Lenggstrasse 31, 8032 Zürich.',
+        'Anfragen zu dieser Erklärung oder zu Ihren Rechten nach Art. 25 ff. nDSG richten Sie bitte an: angehoerigenarbeit@pukzh.ch oder +41 58 384 38 00. Für institutionelle Datenschutzanliegen leiten wir Ihre Anfrage an die zuständige Stelle der PUK weiter.',
       ],
     },
     {
@@ -124,7 +135,7 @@ export const DATENSCHUTZ_CONTENT = {
       paragraphs: [
         'Sie haben nach dem Bundesgesetz über den Datenschutz das Recht auf **Auskunft** (Art. 25), **Berichtigung** (Art. 32), **Löschung** beziehungsweise **Einschränkung der Bearbeitung** und **Widerspruch** gegen bestimmte Bearbeitungen. Soweit eine betroffene Person im Geltungsbereich der DSGVO ansässig ist, stehen ihr ergänzend die dort vorgesehenen Rechte zu (insbesondere Art. 15 bis 22 DSGVO).',
         'Sie können sich jederzeit an die zuständige schweizerische Aufsichtsbehörde wenden: Eidgenössischer Datenschutz- und Öffentlichkeitsbeauftragter (EDÖB), Feldeggweg 1, 3003 Bern, https://www.edoeb.admin.ch',
-        'Für die konkrete Ausübung Ihrer Rechte gegenüber dieser Website wenden Sie sich bitte an die im Impressum genannte Kontaktadresse.',
+        'Für die konkrete Ausübung Ihrer Rechte gegenüber dieser Website wenden Sie sich bitte an die Fachstelle Angehörigenarbeit der PUK Zürich: angehoerigenarbeit@pukzh.ch.',
       ],
     },
     {

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -4348,16 +4348,13 @@
   line-height: var(--line-height-copy);
 }
 
-/* Platzhalter-Hervorhebung: "(ZU ERSETZEN: ...)"-Marker wird im Build-
-   Entwurf deutlich sichtbar gemacht, damit niemand uebersieht, dass hier
-   ein redaktioneller Einsatz noetig ist. Warnstelle auf weicher
-   Danger-Surface, nicht aggressiv. */
+/* Emphasis-Styling fuer **bold**-Markup im LegalPageTemplate. Rein
+   typografische Hervorhebung (kein farblicher Alarm), damit Begriffe
+   wie "Auskunft", "Berichtigung", "Loeschung" in der Rechte-Liste
+   oder Namen + Funktionsbezeichnungen in der Redaktions-Verantwortung
+   klar hervortreten, ohne als Warnung missverstanden zu werden. */
 .ui-legal-emphasis {
-  display: inline-block;
-  padding: 0.125rem 0.375rem;
-  border-radius: var(--radius-sm);
-  background: var(--surface-danger-soft);
-  color: var(--text-danger-strong);
+  color: var(--text-primary);
   font-weight: 700;
 }
 


### PR DESCRIPTION
## Summary

Ersetzt die 4 Platzhalter aus [PR #153](../pull/153) durch die konkreten Angaben:

**Betreiber:** Psychiatrische Universitätsklinik Zürich, Fachstelle Angehörigenarbeit, Lenggstrasse 31, Postfach, 8032 Zürich, +41 58 384 38 00, angehoerigenarbeit@pukzh.ch

**Redaktionelle Verantwortung:** Christa Egger, Sozialarbeiterin und Angehörigenberaterin an der Fachstelle.

**Aufsicht:** PUK ist öffentlich-rechtliche Anstalt des Kantons Zürich unter Aufsicht der Gesundheitsdirektion — wird im Impressum als Hinweis-Note unter dem Betreiber-Block benannt.

## Entscheidungen

- **Abschnitt umbenannt**: „Betreiber und inhaltliche Verantwortung" → „Betreiber" + neuer Folge-Abschnitt „Redaktionelle Verantwortung". Saubere Trennung zwischen institutionellem Betreiber (PUK) und konkret verantwortlicher Redaktorin (Christa Egger).
- **DSE-Verantwortlicher-Abschnitt** konkretisiert: nennt jetzt PUK-Adresse + E-Mail + Telefon direkt statt nur auf Impressum zu verweisen. So ist die DSE auch ohne Impressum-Lektüre self-contained. Hinweis auf Weiterleitung an den zuständigen PUK-Datenschutz für institutionelle Anliegen.
- **Rechte-Abschnitt** nennt konkrete Kontaktadresse statt generischer „im Impressum genannten Adresse".
- **Footer-Copyright** aktualisiert auf „© 2026 Psychiatrische Universitätsklinik Zürich · Fachstelle Angehörigenarbeit" (vorher generisch „Eltern mit psychischen Erkrankungen im Beratungskontext" — mit institutionellem Betreiber wird das zur Fehlinformation).
- **Bold-Emphasis-CSS entschärft**: `.ui-legal-emphasis` war für die Platzhalter-Warnung auf Soft-Danger-Surface (rote Pille). Mit realen Inhalten haben `**bold**`-Markups einen anderen semantischen Zweck — Christa Eggers Name und Begriffe wie „Auskunft", „Berichtigung", „Löschung" in der Rechte-Liste sind typografische Hervorhebung, kein Alarm. CSS reduziert auf `font-weight: 700` + `--text-primary`, ohne Surface-Fill.

## Verifikation (Chromium 1440 × 900)

- Kein „ZU ERSETZEN"-Text mehr im Rendered Output
- Alle 6 Betreiber-Felder (PUK, Fachstelle, Adresse, Telefon, E-Mail, Web) korrekt gerendert
- Christa Egger wird im Redaktions-Abschnitt erwähnt
- `.ui-legal-emphasis` rendert dunkel-neutral (`rgb(47, 47, 40)`, transparenter Hintergrund) — keine roten Warn-Pillen mehr
- Footer-Copyright: „© 2026 Psychiatrische Universitätsklinik Zürich · Fachstelle Angehörigenarbeit"
- DSE-Verantwortlicher-Section enthält konkret PUK + E-Mail
- `npm run lint` clean, `npm run build` clean

## Test plan

- [ ] `#impressum` — 5 Abschnitte (Betreiber / Redaktion / Zweck / Haftung / Urheberrecht), keine Platzhalter
- [ ] `#datenschutz` — Verantwortlicher-Abschnitt nennt PUK konkret
- [ ] Christa Eggers Name rendert in Bold, **nicht** als rote Pille
- [ ] Begriffe wie „Auskunft", „Berichtigung", „Löschung" in der Rechte-Liste rendern in Bold, **nicht** als rote Pille
- [ ] Footer-Copyright auf jeder Seite zeigt PUK
- [ ] E-Mail-Adresse klickbar (mailto: wird vom Browser automatisch erkannt, sobald das `@`-Format steht — kein explizites mailto: gesetzt, das ist bewusst, damit keine Mail-Harvester die Adresse einfach absaugen)

https://claude.ai/code/session_01Y7tCrUuNxDaDcs2tk4ghxH