### PR TITLE
qa: Link-Health-Check + Lighthouse-Baseline als Skripte + CI-Workflow

### DIFF
--- a/.github/workflows/qa-baseline.yml
+++ b/.github/workflows/qa-baseline.yml
@@ -1,0 +1,99 @@
+# QA-Baseline-Workflow fuer Relational Recovery.
+#
+# Fuehrt zwei Pruefungen aus, die lokales Sandboxing aus CI heraus
+# nicht brauchen (beide reden mit externen Hosts):
+#
+# 1. Link-Health-Check: scannt src/ + public/ + index.html nach
+#    externen URLs und prueft jeden mit HEAD/GET. Report als
+#    Artefakt + optional Auto-Commit.
+# 2. Lighthouse-Baseline: Performance / A11y / Best-Practices / SEO
+#    in Mobile + Desktop gegen die Produktions-URL. Report als
+#    Artefakt.
+#
+# Beide Jobs sind nur per `workflow_dispatch` (manueller Button im
+# Actions-Tab) oder im Monatsrhythmus scheduliert triggerbar --
+# absichtlich NICHT auf jedem PR, weil:
+# - Lighthouse rechnet ~1 Minute pro Run und ist flaky genug, dass
+#   es kein Merge-Gate sein sollte.
+# - Link-Health ist ein Content-Anliegen, kein Code-Anliegen --
+#   broken Links sollen einen Content-Fix triggern, keinen
+#   blockierten PR.
+#
+# Scheduled: 1. Mittwoch im Monat, 06:15 UTC (direkt nach dem
+# Monday-06:00-audit-Gate, damit die Jobs nicht um dieselben
+# Runner kaempfen).
+
+name: QA Baseline
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: 'Ziel-URL fuer Lighthouse (default: Produktion)'
+        required: false
+        default: 'https://eltern-angehoerige-fa.netlify.app/'
+  schedule:
+    - cron: '15 6 1-7 * 3' # 1. Mittwoch im Monat, 06:15 UTC
+
+concurrency:
+  group: qa-baseline-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  link-health:
+    name: Link-Health-Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run link-health-check
+        run: node qa/scripts/link-health-check.mjs
+
+      - name: Upload link-health report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: link-health-report
+          path: qa/link-health-check-report.md
+          retention-days: 90
+
+  lighthouse:
+    name: Lighthouse Baseline (Mobile + Desktop)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Lighthouse
+        run: node qa/scripts/lighthouse-baseline.mjs ${{ github.event.inputs.target_url || 'https://eltern-angehoerige-fa.netlify.app/' }}
+
+      - name: Upload Lighthouse report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-baseline-report
+          path: qa/lighthouse-baseline.md
+          retention-days: 90

--- a/qa/scripts/README.md
+++ b/qa/scripts/README.md
@@ -1,9 +1,14 @@
-# QA Test-Scripts — Interaktions-Integritaet
+# QA Test-Scripts — Interaktions-Integritaet + Baseline-Checks
 
-Diese vier headless-browser-basierten Scripts bilden die permanente Verifikations-
-Infrastruktur fuer Interaktions-Integritaet, entstanden aus Audit 14. Sie laufen
-gegen eine laufende Preview-Instanz der Site (`npm run preview` bzw. gegen eine
-beliebige Base-URL).
+Dieser Ordner sammelt permanente Verifikations-Scripts. Sie zerfallen in
+zwei Kategorien:
+
+1. **Interaktions-Integritaet** (Audit 14) — laufen gegen eine Preview-
+   Instanz (`interaction-overlap`, `click-reachability`, `z-stack`,
+   `click-diagnose`). Bewertung: Pflicht vor jedem Release.
+2. **QA-Baseline** (Audit-Nachfolge) — laufen gegen die Produktions-URL
+   (`link-health-check`, `lighthouse-baseline`). Bewertung: Monatlich via
+   GitHub-Actions-Workflow `qa-baseline.yml` oder manuell vor Release.
 
 ## Voraussetzungen
 
@@ -60,12 +65,49 @@ position, padding und pointer-events aus.
 node qa/scripts/click-diagnose.mjs [base-url]
 ```
 
+### `link-health-check.mjs`
+
+Scannt `src/`, `public/` und `index.html` nach externen http(s)-URLs und
+prueft jeden via HEAD (GET-Fallback) mit 15s-Timeout. Timeout, 4xx und
+5xx werden nach Kategorie gebuendelt, Quellen-Dateien referenziert.
+Report nach `qa/link-health-check-report.md`.
+
+```
+node qa/scripts/link-health-check.mjs
+```
+
+Braucht outbound HTTPS (wird in Sandbox-Umgebungen typischerweise
+blockiert). Aus CI heraus via `qa-baseline.yml` triggerbar.
+
+### `lighthouse-baseline.mjs`
+
+Laeuft Lighthouse 13 via `npx` in Mobile + Desktop gegen die Produktions-
+URL (oder eine uebergebene Base-URL). Erfasst die vier Category-Scores
+(Performance, Accessibility, Best Practices, SEO) + Core Web Vitals
+(LCP, TBT, CLS, FCP, Speed Index). Report nach
+`qa/lighthouse-baseline.md`.
+
+```
+node qa/scripts/lighthouse-baseline.mjs                               # Produktion
+node qa/scripts/lighthouse-baseline.mjs https://staging.example.com   # Staging
+```
+
+Braucht lokales Chrome/Chromium (Lighthouse bringt sein eigenes via
+`chrome-launcher` mit) + outbound HTTPS. Aus CI heraus via
+`qa-baseline.yml` triggerbar.
+
 ## Wann ausfuehren?
 
 **Pflicht vor jedem Release:**
 
 - `interaction-overlap.mjs` + `click-reachability.mjs` beide mit Exit-Code 0
 - `z-stack.mjs` ohne neue Anomalien
+
+**Empfohlen monatlich (oder via `qa-baseline.yml`-Workflow):**
+
+- `link-health-check.mjs` — broken External-Links erkennen, bevor sie
+  auffallen
+- `lighthouse-baseline.mjs` — Score-Regressions sichtbar machen
 
 **Nach allen Aenderungen an:**
 

--- a/qa/scripts/lighthouse-baseline.mjs
+++ b/qa/scripts/lighthouse-baseline.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Lighthouse-Baseline-Runner fuer das Fachportal.
+ *
+ * Laeuft Lighthouse via npx gegen die Produktions-URL (oder eine
+ * alternative Base-URL als Argument) in beiden Form-Factors (mobile
+ * + desktop) und schreibt eine kompakte Markdown-Zusammenfassung
+ * nach qa/lighthouse-baseline.md.
+ *
+ * Lighthouse selbst wird ueber `npx lighthouse@13` geladen -- nicht als
+ * Dev-Dependency, weil die Binary gross ist (~300 MB mit Chrome) und
+ * der Check nicht bei jedem Build laufen soll. Einsatz: manuell pro
+ * Release, automatisiert via workflow_dispatch.
+ *
+ * Ausgabe enthaelt die vier Top-Scores (Performance, Accessibility,
+ * Best Practices, SEO) + die Core-Web-Vitals (LCP, TBT, CLS). Das
+ * Markdown-Format ist bewusst grep-freundlich, damit Scores zwischen
+ * Runs diff-bar sind.
+ *
+ * Nutzung:
+ *   node qa/scripts/lighthouse-baseline.mjs
+ *   node qa/scripts/lighthouse-baseline.mjs https://staging.example.com
+ */
+
+import { execSync } from 'node:child_process';
+import { mkdirSync, writeFileSync, readFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+const REPORT_PATH = join(REPO_ROOT, 'qa', 'lighthouse-baseline.md');
+
+const DEFAULT_URL = 'https://eltern-angehoerige-fa.netlify.app/';
+const targetUrl = process.argv[2] || DEFAULT_URL;
+
+const FORM_FACTORS = [
+  { name: 'mobile', preset: 'mobile' },
+  { name: 'desktop', preset: 'desktop' },
+];
+
+const CHROME_FLAGS = ['--headless=new', '--no-sandbox', '--disable-gpu'];
+
+function runLighthouse(preset) {
+  const outputFile = join(tmpdir(), `lh-${preset}-${Date.now()}.json`);
+  const args = [
+    targetUrl,
+    `--preset=${preset}`,
+    `--chrome-flags="${CHROME_FLAGS.join(' ')}"`,
+    '--output=json',
+    `--output-path=${outputFile}`,
+    '--quiet',
+    '--only-categories=performance,accessibility,best-practices,seo',
+  ];
+  console.log(`[lighthouse] Starte ${preset} gegen ${targetUrl}`);
+  execSync(`npx --yes lighthouse@13 ${args.join(' ')}`, { stdio: 'inherit' });
+  const raw = readFileSync(outputFile, 'utf8');
+  unlinkSync(outputFile);
+  return JSON.parse(raw);
+}
+
+function pickScore(report, category) {
+  const cat = report.categories?.[category];
+  return cat ? Math.round(cat.score * 100) : null;
+}
+
+function pickAuditValue(report, auditId) {
+  const audit = report.audits?.[auditId];
+  if (!audit) return null;
+  return {
+    displayValue: audit.displayValue || '—',
+    numericValue: audit.numericValue ?? null,
+    score: audit.score ?? null,
+  };
+}
+
+function formatScore(score) {
+  if (score === null) return '—';
+  const emoji = score >= 90 ? '🟢' : score >= 50 ? '🟡' : '🔴';
+  return `${emoji} ${score}`;
+}
+
+function renderReport(results) {
+  const lines = [];
+  lines.push('# Lighthouse-Baseline');
+  lines.push('');
+  lines.push(`**Stand:** ${new Date().toISOString().slice(0, 19).replace('T', ' ')} UTC`);
+  lines.push(`**Ziel-URL:** ${targetUrl}`);
+  lines.push(`**Skript:** \`qa/scripts/lighthouse-baseline.mjs\``);
+  lines.push('');
+  lines.push('Scores sind das Ergebnis eines einzelnen Runs — Lighthouse-Werte schwanken');
+  lines.push('im Bereich ±3 zwischen Runs (Netzwerk, Throttling-Jitter, CPU-Variation).');
+  lines.push('Als Baseline reicht ein Run; fuer Regressions-Tracking am selben Commit');
+  lines.push('empfiehlt sich Medianbildung ueber 3–5 Runs.');
+  lines.push('');
+
+  lines.push('## Scores');
+  lines.push('');
+  lines.push('| Kategorie | Mobile | Desktop |');
+  lines.push('| --- | :---: | :---: |');
+  for (const cat of ['performance', 'accessibility', 'best-practices', 'seo']) {
+    const label = cat === 'best-practices' ? 'Best Practices' : cat[0].toUpperCase() + cat.slice(1);
+    const mobile = formatScore(pickScore(results.mobile, cat));
+    const desktop = formatScore(pickScore(results.desktop, cat));
+    lines.push(`| ${label} | ${mobile} | ${desktop} |`);
+  }
+  lines.push('');
+
+  lines.push('## Core Web Vitals');
+  lines.push('');
+  lines.push('| Metric | Mobile | Desktop | Schwelle gruen |');
+  lines.push('| --- | ---: | ---: | --- |');
+  const vitals = [
+    { id: 'largest-contentful-paint', label: 'LCP', green: '≤ 2.5 s' },
+    { id: 'total-blocking-time', label: 'TBT', green: '≤ 200 ms' },
+    { id: 'cumulative-layout-shift', label: 'CLS', green: '≤ 0.1' },
+    { id: 'first-contentful-paint', label: 'FCP', green: '≤ 1.8 s' },
+    { id: 'speed-index', label: 'Speed Index', green: '≤ 3.4 s' },
+  ];
+  for (const v of vitals) {
+    const m = pickAuditValue(results.mobile, v.id);
+    const d = pickAuditValue(results.desktop, v.id);
+    lines.push(`| ${v.label} | ${m?.displayValue ?? '—'} | ${d?.displayValue ?? '—'} | ${v.green} |`);
+  }
+  lines.push('');
+
+  lines.push('## Hinweis zur Reproduktion');
+  lines.push('');
+  lines.push('```bash');
+  lines.push(`node qa/scripts/lighthouse-baseline.mjs${targetUrl === DEFAULT_URL ? '' : ' ' + targetUrl}`);
+  lines.push('```');
+  lines.push('');
+  lines.push('Benoetigt outbound HTTPS + lokales Chrome/Chromium (Lighthouse bringt seines');
+  lines.push('via `chrome-launcher` mit). Fuer Sandbox-Umgebungen ohne Internet: via');
+  lines.push('GitHub-Actions-Workflow `qa-baseline.yml` (workflow_dispatch-Trigger).');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+async function main() {
+  const results = {};
+  for (const ff of FORM_FACTORS) {
+    results[ff.name] = runLighthouse(ff.preset);
+  }
+
+  mkdirSync(join(REPO_ROOT, 'qa'), { recursive: true });
+  writeFileSync(REPORT_PATH, renderReport(results), 'utf8');
+  console.log(`[lighthouse] Report geschrieben: ${REPORT_PATH}`);
+}
+
+main().catch((err) => {
+  console.error('[lighthouse] Fehler:', err.message || err);
+  process.exit(2);
+});

--- a/qa/scripts/link-health-check.mjs
+++ b/qa/scripts/link-health-check.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+/**
+ * Link-Health-Check fuer externe URLs im Fachportal.
+ *
+ * Scannt `src/`, `public/` und `index.html` nach http(s)-URLs, filtert
+ * interne, XML-Schema-Namespaces und SVG-Namespaces raus und pruefts
+ * den Rest via HEAD-Request (mit GET-Fallback). Timeouts: 15s pro URL.
+ * Parallelitaet: 5 concurrent, rate-limited damit wir externe Hosts
+ * nicht ueberrennen.
+ *
+ * Ergebnis landet auf stdout als Markdown + wird nach
+ * qa/link-health-check-report.md geschrieben. Das Skript ist idempotent
+ * und sollte regelmaessig (z. B. monatlich manuell) gelaufen werden,
+ * um URL-Rot fuer externe Quellen fruehzeitig zu erkennen.
+ *
+ * User-Agent ist bewusst ein echter Browser-String -- Node-Default
+ * faengt von vielen Hosts 403.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+const REPORT_PATH = join(REPO_ROOT, 'qa', 'link-health-check-report.md');
+
+const SCAN_DIRS = [join(REPO_ROOT, 'src'), join(REPO_ROOT, 'public')];
+const SCAN_FILES = [join(REPO_ROOT, 'index.html')];
+const INCLUDE_EXT = new Set(['.js', '.jsx', '.css', '.html', '.xml', '.txt', '.json', '.svg']);
+
+const EXCLUDE_HOSTS = new Set([
+  'eltern-angehoerige-fa.netlify.app',
+  'schema.org',
+  'www.sitemaps.org',
+  'www.w3.org',
+  'localhost',
+]);
+
+const URL_REGEX = /https?:\/\/[^\s"'`<>)\]]+/g;
+const CONCURRENCY = 5;
+const TIMEOUT_MS = 15_000;
+const USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36 qa-link-health-check/1.0';
+
+function walkFiles(startPath) {
+  const result = [];
+  const stack = [startPath];
+  while (stack.length) {
+    const current = stack.pop();
+    const st = statSync(current, { throwIfNoEntry: false });
+    if (!st) continue;
+    if (st.isDirectory()) {
+      for (const entry of readdirSync(current)) stack.push(join(current, entry));
+    } else if (st.isFile() && INCLUDE_EXT.has(extname(current))) {
+      result.push(current);
+    }
+  }
+  return result;
+}
+
+function cleanUrl(raw) {
+  // Strip trailing punctuation that was never part of the URL (z. B. Komma am
+  // Satzende, schliessende Klammer, Punkt am Satzende).
+  return raw.replace(/[.,;:!?)\]]+$/, '');
+}
+
+function collectUrls() {
+  const files = [...SCAN_FILES, ...SCAN_DIRS.flatMap((dir) => walkFiles(dir))];
+  const byUrl = new Map();
+  for (const file of files) {
+    let content;
+    try {
+      content = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const match of content.matchAll(URL_REGEX)) {
+      const url = cleanUrl(match[0]);
+      let host;
+      try {
+        host = new URL(url).hostname;
+      } catch {
+        continue;
+      }
+      if (EXCLUDE_HOSTS.has(host)) continue;
+      const rel = file.replace(REPO_ROOT + '/', '');
+      if (!byUrl.has(url)) byUrl.set(url, new Set());
+      byUrl.get(url).add(rel);
+    }
+  }
+  return byUrl;
+}
+
+async function checkOne(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  const started = Date.now();
+  const tryOnce = async (method) => {
+    const response = await fetch(url, {
+      method,
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'text/html,application/xhtml+xml,application/pdf,*/*;q=0.8',
+      },
+    });
+    return {
+      status: response.status,
+      finalUrl: response.url,
+      redirected: response.redirected,
+    };
+  };
+
+  try {
+    let result;
+    try {
+      result = await tryOnce('HEAD');
+      // Einige Hosts (insbesondere Cloudflare hinter PDFs) liefern 403/405/501
+      // auf HEAD, obwohl GET sauber geht. Fallback.
+      if ([403, 405, 501, 503].includes(result.status)) {
+        result = await tryOnce('GET');
+      }
+    } catch (headErr) {
+      // HEAD komplett abgewiesen -> GET-Retry
+      result = await tryOnce('GET');
+    }
+    clearTimeout(timer);
+    return {
+      url,
+      status: result.status,
+      finalUrl: result.finalUrl,
+      redirected: result.redirected,
+      elapsed: Date.now() - started,
+      error: null,
+    };
+  } catch (err) {
+    clearTimeout(timer);
+    return {
+      url,
+      status: null,
+      finalUrl: null,
+      redirected: false,
+      elapsed: Date.now() - started,
+      error: err.name === 'AbortError' ? `timeout nach ${TIMEOUT_MS}ms` : err.message,
+    };
+  }
+}
+
+async function runInPool(items, concurrency, worker) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: concurrency }, async () => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= items.length) return;
+      results[idx] = await worker(items[idx], idx);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+function categorize(result) {
+  if (result.error) return 'network-error';
+  if (result.status >= 200 && result.status < 300) return result.redirected ? 'ok-redirected' : 'ok';
+  if (result.status >= 300 && result.status < 400) return '3xx';
+  if (result.status >= 400 && result.status < 500) return `4xx-${result.status}`;
+  if (result.status >= 500) return `5xx-${result.status}`;
+  return 'unknown';
+}
+
+function renderReport(urlToSources, results, startedAt) {
+  const elapsed = Date.now() - startedAt;
+  const buckets = {
+    ok: [],
+    'ok-redirected': [],
+    '3xx': [],
+    '4xx-404': [],
+    '4xx-other': [],
+    '5xx': [],
+    'network-error': [],
+  };
+  for (const r of results) {
+    const cat = categorize(r);
+    if (cat === 'ok') buckets.ok.push(r);
+    else if (cat === 'ok-redirected') buckets['ok-redirected'].push(r);
+    else if (cat === '3xx') buckets['3xx'].push(r);
+    else if (cat === '4xx-404') buckets['4xx-404'].push(r);
+    else if (cat.startsWith('4xx-')) buckets['4xx-other'].push(r);
+    else if (cat.startsWith('5xx-')) buckets['5xx'].push(r);
+    else buckets['network-error'].push(r);
+  }
+
+  const lines = [];
+  lines.push('# Link-Health-Check Report');
+  lines.push('');
+  lines.push(`**Stand:** ${new Date().toISOString().slice(0, 19).replace('T', ' ')} UTC`);
+  lines.push(`**Pruefzeit:** ${(elapsed / 1000).toFixed(1)}s`);
+  lines.push(`**URLs geprueft:** ${results.length}`);
+  lines.push(`**Skript:** \`qa/scripts/link-health-check.mjs\``);
+  lines.push('');
+  lines.push('## Zusammenfassung');
+  lines.push('');
+  lines.push('| Kategorie | Count |');
+  lines.push('| --- | ---: |');
+  lines.push(`| OK (2xx direkt) | ${buckets.ok.length} |`);
+  lines.push(`| OK nach Redirect | ${buckets['ok-redirected'].length} |`);
+  lines.push(`| 3xx (unaufgeloest) | ${buckets['3xx'].length} |`);
+  lines.push(`| 404 | ${buckets['4xx-404'].length} |`);
+  lines.push(`| 4xx (andere) | ${buckets['4xx-other'].length} |`);
+  lines.push(`| 5xx | ${buckets['5xx'].length} |`);
+  lines.push(`| Netzwerk-Fehler / Timeout | ${buckets['network-error'].length} |`);
+  lines.push('');
+
+  const needsAttention = buckets['4xx-404'].length + buckets['4xx-other'].length + buckets['5xx'].length + buckets['network-error'].length;
+  if (needsAttention > 0) {
+    lines.push(`## Handlungsbedarf (${needsAttention} URL(s))`);
+    lines.push('');
+  } else {
+    lines.push('## Handlungsbedarf');
+    lines.push('');
+    lines.push('Keine broken Links gefunden.');
+    lines.push('');
+  }
+
+  const renderBucket = (title, bucket, showSources = false) => {
+    if (!bucket.length) return;
+    lines.push(`### ${title} (${bucket.length})`);
+    lines.push('');
+    for (const r of bucket) {
+      const status = r.error ? `FEHLER: ${r.error}` : `HTTP ${r.status}`;
+      const finalNote = r.redirected && r.finalUrl && r.finalUrl !== r.url ? ` -> ${r.finalUrl}` : '';
+      lines.push(`- ${status} (${r.elapsed}ms): ${r.url}${finalNote}`);
+      if (showSources) {
+        const sources = [...(urlToSources.get(r.url) || [])].sort();
+        for (const s of sources) lines.push(`  - \`${s}\``);
+      }
+    }
+    lines.push('');
+  };
+
+  renderBucket('404 Not Found', buckets['4xx-404'], true);
+  renderBucket('5xx Server-Fehler', buckets['5xx'], true);
+  renderBucket('4xx andere', buckets['4xx-other'], true);
+  renderBucket('Netzwerk-Fehler / Timeout', buckets['network-error'], true);
+  renderBucket('3xx unaufgeloest', buckets['3xx'], true);
+
+  lines.push('## Detailprotokoll');
+  lines.push('');
+  lines.push('| Status | URL | Finaler URL | Quelle(n) |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const r of results.slice().sort((a, b) => a.url.localeCompare(b.url))) {
+    const status = r.error ? `ERR` : String(r.status);
+    const final = r.redirected && r.finalUrl && r.finalUrl !== r.url ? r.finalUrl : '—';
+    const sources = [...(urlToSources.get(r.url) || [])].sort();
+    const firstSrc = sources[0] || '';
+    const moreCount = sources.length > 1 ? ` (+${sources.length - 1})` : '';
+    lines.push(`| ${status} | ${r.url} | ${final} | \`${firstSrc}\`${moreCount} |`);
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+async function main() {
+  const startedAt = Date.now();
+  const urlToSources = collectUrls();
+  const urls = [...urlToSources.keys()].sort();
+  console.log(`[link-health] ${urls.length} einzigartige URLs gefunden, ${CONCURRENCY} parallel, Timeout ${TIMEOUT_MS}ms.`);
+
+  const results = await runInPool(urls, CONCURRENCY, async (url, idx) => {
+    const r = await checkOne(url);
+    const status = r.error ? `ERR (${r.error})` : r.status;
+    console.log(`[${String(idx + 1).padStart(3, ' ')}/${urls.length}] ${status}  ${r.url}`);
+    return r;
+  });
+
+  const report = renderReport(urlToSources, results, startedAt);
+  mkdirSync(join(REPO_ROOT, 'qa'), { recursive: true });
+  writeFileSync(REPORT_PATH, report, 'utf8');
+  console.log(`[link-health] Report geschrieben: ${REPORT_PATH}`);
+
+  const broken = results.filter((r) => r.error || (r.status && r.status >= 400)).length;
+  if (broken > 0) {
+    console.log(`[link-health] ${broken} URL(s) brauchen Aufmerksamkeit -- siehe Report.`);
+    process.exit(0); // absichtlich 0: Report existiert, broken links sind Content-Anliegen, kein Build-Fail
+  }
+}
+
+main().catch((err) => {
+  console.error('[link-health] unerwarteter Fehler:', err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Zwei QA-Baseline-Skripte + CI-Workflow. Kein One-Shot-Report, sondern reusable Infrastruktur — weil die Sandbox, in der dieser Branch gebaut wurde, outbound HTTP blockiert (alle externen URLs liefern 403 auf Proxy-Ebene, sowohl via Node-`fetch` als auch via `curl`). Ein in dieser Umgebung erzeugter Report wäre Fake-Data; aus GitHub Actions funktioniert das Netz.

## Deliverables

### `qa/scripts/link-health-check.mjs`
- Scannt `src/`, `public/`, `index.html` nach http(s)-URLs
- Filtert interne + XML-Namespace-URLs raus
- Prüft jeden Rest via HEAD (GET-Fallback bei 403/405/501/503)
- Kategorisiert: ok / ok-redirected / 3xx / 404 / 4xx-other / 5xx / network-error
- Report nach `qa/link-health-check-report.md` mit Zusammenfassung, Handlungsbedarf-Block und Detailprotokoll
- Parallelität 5, Timeout 15 s, echter Browser-User-Agent
- Exit-Code immer 0 (broken Links sind Content-Anliegen, kein Build-Fail)

### `qa/scripts/lighthouse-baseline.mjs`
- Lighthouse 13 via `npx` (keine Dev-Dependency — Chrome ist gross, nicht bei jedem Build nötig)
- Mobile + Desktop
- Categories: Performance, Accessibility, Best Practices, SEO
- Core Web Vitals: LCP, TBT, CLS, FCP, Speed Index
- Report nach `qa/lighthouse-baseline.md` mit Score-Tabelle + Vitals-Tabelle + Reproduktionshinweis
- Default-URL: Produktion, per Argument überschreibbar (Staging)

### `.github/workflows/qa-baseline.yml`
- Zwei Jobs (link-health + lighthouse)
- Trigger: `workflow_dispatch` (manueller Button im Actions-Tab) + scheduled (1. Mittwoch im Monat, 06:15 UTC)
- Beide laden Reports als 90-Tage-Artefakte hoch
- Bewusst **nicht** auf PR-Trigger: Lighthouse ist flaky genug für ±3-Punkt-Jitter; Link-Health ist Content-Anliegen, kein Merge-Gate

### `qa/scripts/README.md`
Erweitert um Beschreibung beider neuer Skripte + Hinweis auf CI-Fallback für Sandbox-Umgebungen.

## Entscheidungen

- **Kein Initial-Report committen**: aus der Sandbox wäre es Fake-Data. Der erste echte Run kommt, sobald du im Actions-Tab „QA Baseline → Run workflow" drückst. Artefakte sind 90 Tage downloadbar.
- **Lighthouse via `npx`, nicht als Dependency**: Binary mit Chrome ist ~300 MB. Keine fünf Punkte Runtime-Kosten pro CI-Run, wenn wir es nicht ständig brauchen.
- **Workflow monatlich, nicht wöchentlich**: Link-Health ändert sich langsam; Lighthouse-Scores sind volatil genug, dass häufigeres Sampling keinen zusätzlichen Erkenntnisgewinn bringt. Ad-hoc-Runs via `workflow_dispatch` bleiben jederzeit möglich.
- **Exit-Code 0 auch bei broken Links**: ein Link-Fail soll keinen Workflow rot färben, sondern einen Content-Fix triggern.

## Verifikation

- `npm run lint` clean
- `npm run format:check` clean (Prettier-Regel für neue `.mjs`/`.yml` nicht konfiguriert — bewusst so, die QA-Scripts sind ausserhalb der Source-Pattern)
- `npm run build` clean

## Test plan

- [ ] Nach Merge: Actions-Tab → „QA Baseline" → „Run workflow" (Dropdown „Run workflow")
- [ ] Link-Health-Job läuft durch, Artefakt `link-health-report` erscheint
- [ ] Lighthouse-Job läuft durch, Artefakt `lighthouse-baseline-report` erscheint
- [ ] Artefakte runterladen, sichten
- [ ] Falls Link-Health 404s meldet: separate Content-Issues anlegen (nicht als Build-Fail behandeln)
- [ ] Falls Lighthouse-Score unerwartet niedrig: Audit 16 re-runnen

https://claude.ai/code/session_01Y7tCrUuNxDaDcs2tk4ghxH