### PR TITLE
fix(css): audit 18 follow-ups — tote tokens + footer-tokens + scrim (closes #138)

### DIFF
--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -1692,7 +1692,7 @@
      > Persistenz-Banner 100 > Header 50. Aenderungen muessen diese Ordnung wahren,
      sonst werden Mobile-Nav-Klicks vom Banner ueberlagert (Audit-14-Phase-2). */
   z-index: 110;
-  background: rgba(47, 47, 40, 0.32);
+  background: var(--overlay-scrim);
   /* Button-Defaults zuruecksetzen, damit das Element rein als Backdrop wirkt. */
   appearance: none;
   border: 0;
@@ -3860,16 +3860,16 @@
 
 .footer-panel--brand {
   border-radius: 2.5rem;
-  background: linear-gradient(180deg, rgba(255, 252, 247, 0.92), rgba(248, 240, 231, 0.92));
+  background: var(--footer-gradient-brand);
   padding: var(--space-6);
-  box-shadow: 0 24px 60px rgba(93, 68, 51, 0.06);
+  box-shadow: var(--footer-shadow-medium);
 }
 
 .footer-panel--nav {
   border-radius: 2.25rem;
   background: color-mix(in srgb, white 65%, transparent 35%);
   padding: var(--space-6);
-  box-shadow: 0 18px 40px rgba(93, 68, 51, 0.04);
+  box-shadow: var(--footer-shadow-subtle);
 }
 
 /* Audit P2 #14: Vorher war das Arbeitsrahmen-Panel ein dunkelbrauner
@@ -3883,10 +3883,10 @@
 .footer-panel--framework {
   border-radius: 2.5rem;
   border-color: var(--footer-badge-border);
-  background: linear-gradient(180deg, #f0e1cf, #e8d5be);
+  background: var(--footer-gradient-framework);
   padding: var(--space-6);
   color: var(--footer-text-warm);
-  box-shadow: 0 18px 40px rgba(93, 68, 51, 0.06);
+  box-shadow: var(--footer-shadow-medium);
 }
 
 .footer-brand-badge {
@@ -4014,7 +4014,7 @@
   transform: translateY(-1px);
   border-color: var(--footer-badge-border);
   background: color-mix(in srgb, white 85%, transparent 15%);
-  box-shadow: 0 16px 34px rgba(93, 68, 51, 0.05);
+  box-shadow: var(--footer-shadow-card);
 }
 
 .footer-nav-link__body {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -67,7 +67,6 @@
   /* Border tokens */
   --border-subtle: #e6dacb;
   --border-default: #d5c9b1;
-  --border-strong: #bda894;
   --border-danger: #e8b8aa;
 
   /* Brand and interaction tokens */
@@ -82,7 +81,6 @@
 
   /* Focus tokens */
   --focus-ring: #8d3f32; /* intended for light surfaces; target visible AA-level contrast */
-  --focus-ring-contrast: #fff8f2; /* intended as halo on dense or dark accent surfaces */
   --focus-ring-width: 3px;
   --focus-ring-offset: 4px;
   --focus-outline-radius: 0.875rem;
@@ -119,7 +117,6 @@
   --space-5: 1.5rem;
   --space-6: 2rem;
   --space-7: 3rem;
-  --space-8: 4rem;
 
   /* Section-Spacing: grosszügiger gesetzt, damit Sektionen stärker
      voneinander getrennt wirken und die Seite mehr «atmet».
@@ -137,9 +134,18 @@
   --radius-pill: 999px;
 
   /* Shadow tokens */
+  /* Overlay */
+  --overlay-scrim: rgba(47, 47, 40, 0.32);
+
+  /* Footer-spezifische Tokens (eigene Farbwelt, Audit 18 #138) */
+  --footer-gradient-brand: linear-gradient(180deg, rgba(255, 252, 247, 0.92), rgba(248, 240, 231, 0.92));
+  --footer-gradient-framework: linear-gradient(180deg, #f0e1cf, #e8d5be);
+  --footer-shadow-subtle: 0 18px 40px rgba(93, 68, 51, 0.04);
+  --footer-shadow-medium: 0 24px 60px rgba(93, 68, 51, 0.06);
+  --footer-shadow-card: 0 16px 34px rgba(93, 68, 51, 0.05);
+
   --shadow-soft: 0 8px 24px rgba(76, 55, 39, 0.08);
   --shadow-card: 0 16px 36px rgba(76, 55, 39, 0.1);
-  --shadow-elevated: 0 24px 60px rgba(76, 55, 39, 0.12);
   --shadow-focus: 0 0 0 4px rgba(141, 63, 50, 0.14);
 
   /* Layout tokens */


### PR DESCRIPTION
## Summary

Schliesst Issue #138 (Audit 18 CSS-Hygiene Follow-ups).

- 4 tote Tokens gelöscht (0 Verwendungen verifiziert)
- 5 Footer-spezifische Tokens eingeführt (Gradients + Shadows)
- Overlay-Scrim als Token
- 6 Literal-Stellen in primitives.css auf Tokens migriert

Punkte 5 (Dead-CSS-Scan) und 6 (Token-Registry) als eigenständige Nice-to-haves verbleibend.

## Test plan
- [x] Lint + Build sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)