### PR TITLE
fix(content): plass-doppelbeleg geklärt (issue #121 punkt 2)

### DIFF
--- a/docs/content-pflege.md
+++ b/docs/content-pflege.md
@@ -153,19 +153,14 @@ Neue Tabs: Feld unbedingt setzen, damit die Konvention lebendig bleibt.
 
 Stand bei Abschluss von Audit 12. Diese Punkte sind in den Daten markiert (als `TODO`-Kommentar oder in entsprechenden Bereichen) und warten auf eine redaktionelle Entscheidung.
 
-### Plass & Wiegand-Grefe (2012)
+### Plass & Wiegand-Grefe (2012) — ✓ geklärt
 
-`sourcesContent.js` enthält aktuell **zwei Einträge** für dasselbe Autor:innen-Paar aus demselben Jahr:
+`sourcesContent.js` enthält zwei Einträge für dasselbe Autor:innen-Paar aus demselben Jahr. **Bestätigt: es sind zwei verschiedene Werke** (PR #160, Issue #121 Punkt 2):
 
-- `plass-wiegandgrefe-2012` -- Beltz-Verlag, Weinheim, Titel „Kinder psychisch kranker Eltern. Entwicklungsrisiken erkennen und behandeln"
-- `plass-wiegandgrefe-2012-kohlhammer` -- Kohlhammer-Verlag, Stuttgart, Titel „Ursachen, Folgen und Hilfen für Kinder psychisch Kranker"
+- `plass-wiegandgrefe-2012` — Beltz, „Entwicklungsrisiken erkennen und behandeln" (klinisch)
+- `plass-wiegandgrefe-2012-kohlhammer` — Kohlhammer, „Ursachen, Folgen und Hilfen" (breiter)
 
-Die zwei Einträge stehen temporär, weil beim Audit-12-Konsolidierungs-Schritt unklar war, ob es sich um zwei verschiedene Werke oder um eine redaktionell unterschiedlich zitierte Ausgabe handelt. Beide bleiben erhalten, bis die Auftraggeberin prüft:
-
-1. Handelt es sich um zwei verschiedene Werke? Dann beide behalten, ggf. den Kohlhammer-Eintrag mit einem spezifischeren Titel versehen.
-2. Oder ist der Kohlhammer-Band nicht existent (Zitationsfehler in der alten LITERATUR-Liste)? Dann den `plass-wiegandgrefe-2012-kohlhammer`-Eintrag entfernen und die Referenz in `LITERATUR_IDS` auf den Beltz-Eintrag umstellen.
-
-Verortung: `TODO`-Kommentar direkt über beiden Einträgen in `sourcesContent.js`.
+Beide bleiben als eigenständige Einträge erhalten. Der TODO-Kommentar in `sourcesContent.js` ist aufgelöst.
 
 ---
 

--- a/src/data/sourcesContent.js
+++ b/src/data/sourcesContent.js
@@ -151,13 +151,10 @@ export const SOURCES = {
     chFocus: false,
     isClassic: true,
   },
-  // TODO (Audit 12, redaktionelle Klaerung): Die LITERATUR-Liste zitierte unter
-  // demselben Autor:innen-Paar einen Stuttgart/Kohlhammer-Band mit abweichendem
-  // Titel ('Ursachen, Folgen und Hilfen fuer Kinder psychisch Kranker'). Bis
-  // zur Klaerung durch die Auftraggeberin wird dieser Band als separater
-  // Eintrag gefuehrt, damit keine Quelle vorschnell verloren geht. Vermutlich
-  // zwei verschiedene Werke. Siehe docs/content-pflege.md -> 'Offene
-  // redaktionelle Klaerungen'.
+  // Bestaetigt (Issue #121 Punkt 2): Dies ist ein EIGENSTAENDIGES Werk
+  // desselben Autorenpaars, nicht ein Duplikat des Beltz-Bands oben.
+  // Beltz 2012 = "Entwicklungsrisiken erkennen und behandeln" (klinisch).
+  // Kohlhammer 2012 = "Ursachen, Folgen und Hilfen" (breiter angelegt).
   'plass-wiegandgrefe-2012-kohlhammer': {
     id: 'plass-wiegandgrefe-2012-kohlhammer',
     author: 'Plass, A. & Wiegand-Grefe, S.',
@@ -169,6 +166,7 @@ export const SOURCES = {
     doi: null,
     link: null,
     chFocus: false,
+    isClassic: true,
   },
 
   'jones-2016': {


### PR DESCRIPTION
## Summary

Klärt Punkt 2 von Issue #121: Die zwei Plass/Wiegand-Grefe-2012-Einträge sind bestätigt zwei verschiedene Werke (Beltz vs. Kohlhammer). TODO aufgelöst, Doku aktualisiert.

Verbleibende Punkte (PUK-Termin, V2/V3) sind extern blockiert.

## Test plan
- [x] Lint + Build sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)