### PR TITLE
feat(glossar): inline-verlinkung mit [[glossar:id]]-parser (closes #123)

### DIFF
--- a/src/data/evidenceContent.js
+++ b/src/data/evidenceContent.js
@@ -280,7 +280,7 @@ export const CHILD_EXPERIENCE_POINTS = [
 ];
 
 export const CHILD_EXPERIENCE_PRACTICE_POINTS = [
-  'nach Mitverantwortung, Sorgeverhalten und stiller Anpassung von Kindern fragen',
+  'nach Mitverantwortung, Sorgeverhalten und stiller Anpassung ([[glossar:parentifizierung|Parentifizierung]]) von Kindern fragen',
   'Loyalitätskonflikte und Familiengeheimnisse aktiv ansprechbar machen',
   'zwischen altersangemessener Mithilfe und überfordernder Rollenumkehr unterscheiden',
   'kindliche Perspektive in Krisenplanung, Entlastung und Gesprächsführung mitdenken',
@@ -334,7 +334,7 @@ export const PSYCHOEDUCATION_PRACTICE_POINTS = [
   'einfach, ehrlich und entlastend sprechen – nicht beschönigen, aber auch nicht überfordern',
   'wichtige Sätze wiederholen: Du bist nicht schuld. Du bist nicht allein. Erwachsene kümmern sich.',
   'altersgerechte Sprache wählen und an vorhandene Fragen des Kindes anknüpfen',
-  'Psychoedukation als fortlaufendes Gespräch verstehen, nicht als einmalige Erklärung',
+  '[[glossar:psychoedukation|Psychoedukation]] als fortlaufendes Gespräch verstehen, nicht als einmalige Erklärung',
 ];
 
 export const PSYCHOEDUCATION_PREPARATION_POINTS = [
@@ -401,7 +401,7 @@ export const HELP_BARRIER_POINTS = [
 ];
 
 export const HELP_BARRIER_PRACTICE_POINTS = [
-  'Ängste vor KESB, Bewertung oder Sorgerechtsverlust ansprechbar machen statt zu bagatellisieren',
+  'Ängste vor [[glossar:kesb|KESB]], Bewertung oder Sorgerechtsverlust ansprechbar machen statt zu bagatellisieren',
   'Hilfen konkret, klein und nachvollziehbar erklären: Wer macht was, was passiert zuerst, was nicht?',
   'symptombedingte Hürden mitdenken und Unterstützung so organisieren, dass sie tatsächlich erreichbar bleibt',
   'mit Eltern auf Augenhöhe arbeiten und Selbstwirksamkeit stärken statt vorschnell zu moralisieren',
@@ -444,7 +444,7 @@ export const CLINICAL_PRACTICE_POINTS = [
 export const SOCIAL_RESOURCES_INTRO_POINTS = [
   'Eine Netzwerkkarte zeigt, wer im Umfeld einer Familie da ist. Wenn Bindungs- und Kontaktbedürfnisse durch die bestehenden Kontakte nicht ausreichend abgedeckt werden, ist der nächste Schritt, soziale Ressourcen gezielt zu aktivieren.',
   'Die drei Strategie-Familien — personenbezogen, kontextbezogen und gruppenbezogen — ergänzen sich. Welche im Vordergrund steht, hängt davon ab, ob bestehende Beziehungen mobilisiert, strukturelle Bedingungen verändert oder neue Schutzräume aufgebaut werden müssen.',
-  'Familiäre Tabuisierung und die Angst vor Stigmatisierung sind die häufigsten Hürden. Ohne Bearbeitung dieser inneren Erlaubnis bleiben auch sichtbare soziale Ressourcen ungenutzt.',
+  'Familiäre [[glossar:tabuisierung|Tabuisierung]] und die Angst vor Stigmatisierung sind die häufigsten Hürden. Ohne Bearbeitung dieser inneren Erlaubnis bleiben auch sichtbare soziale Ressourcen ungenutzt.',
 ];
 
 export const SOCIAL_RESOURCES_ACTIVATION = [

--- a/src/templates/EvidencePageTemplate.jsx
+++ b/src/templates/EvidencePageTemplate.jsx
@@ -4,6 +4,7 @@ import Section from '../components/ui/Section';
 import SectionHeader from '../components/ui/SectionHeader';
 import SurfaceCard from '../components/ui/SurfaceCard';
 import ClosingSection from '../components/closing/ClosingSection';
+import parseGlossarPlaceholders from '../utils/parseGlossarPlaceholders';
 
 function RichCopy({ paragraphs = [] }) {
   if (!paragraphs.length) return null;
@@ -11,7 +12,9 @@ function RichCopy({ paragraphs = [] }) {
   return (
     <div className="ui-copy">
       {paragraphs.map((paragraph) => (
-        <p key={paragraph}>{paragraph}</p>
+        <p key={typeof paragraph === 'string' ? paragraph : JSON.stringify(paragraph)}>
+          {parseGlossarPlaceholders(paragraph)}
+        </p>
       ))}
     </div>
   );
@@ -31,9 +34,9 @@ function BulletList({ items = [], tone = 'default', icon }) {
     <div className={toneClass}>
       <div className="ui-stack ui-stack--tight">
         {items.map((item) => (
-          <div key={item} className="ui-bullet-panel__item">
+          <div key={typeof item === 'string' ? item : JSON.stringify(item)} className="ui-bullet-panel__item">
             {icon ? <span className="ui-bullet-panel__marker">{icon}</span> : <span className="ui-bullet-panel__dot" />}
-            <p className="ui-bullet-panel__copy">{item}</p>
+            <p className="ui-bullet-panel__copy">{parseGlossarPlaceholders(item)}</p>
           </div>
         ))}
       </div>

--- a/src/utils/parseGlossarPlaceholders.jsx
+++ b/src/utils/parseGlossarPlaceholders.jsx
@@ -1,0 +1,55 @@
+import GlossarLink from '../components/ui/GlossarLink';
+
+/**
+ * Parst Strings mit `[[glossar:id]]`- oder `[[glossar:id|Label]]`-Markern
+ * und ersetzt sie durch `<GlossarLink>`-Komponenten.
+ *
+ * Konvention (Issue #123, Audit 12 W3b Teil 2):
+ * - `[[glossar:kesb]]` → <GlossarLink term="kesb">KESB</GlossarLink>
+ *   (Label = Term aus glossaryContent.js, erster Buchstabe gross)
+ * - `[[glossar:kesb|die KESB]]` → <GlossarLink term="kesb">die KESB</GlossarLink>
+ *   (explizites Label)
+ *
+ * Strings ohne Marker werden unverändert zurückgegeben (kein Array-Wrap).
+ *
+ * @param {string} text
+ * @returns {string | Array<string | import('react').ReactElement>}
+ */
+export default function parseGlossarPlaceholders(text) {
+  if (!text || typeof text !== 'string') return text;
+
+  const pattern = /\[\[glossar:([a-z0-9-]+)(?:\|([^\]]+))?\]\]/g;
+  if (!pattern.test(text)) return text;
+
+  // Reset lastIndex nach test()
+  pattern.lastIndex = 0;
+
+  const parts = [];
+  let lastIndex = 0;
+  let match;
+
+  while ((match = pattern.exec(text)) !== null) {
+    // Text vor dem Match
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+
+    const termId = match[1];
+    const label = match[2] || termId.charAt(0).toUpperCase() + termId.slice(1).replace(/-/g, ' ');
+
+    parts.push(
+      <GlossarLink key={`${termId}-${match.index}`} term={termId}>
+        {label}
+      </GlossarLink>
+    );
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Rest nach dem letzten Match
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return parts.length === 1 ? parts[0] : parts;
+}


### PR DESCRIPTION
## Summary

Glossar-Inline-Verlinkung (Issue #123, Audit 12 W3b Teil 2):

- **Parser** \`parseGlossarPlaceholders.jsx\`: erkennt \`[[glossar:id]]\` / \`[[glossar:id|Label]]\` in Strings
- **Integration**: EvidencePageTemplate (RichCopy + BulletList)
- **4 Begriffe markiert**: KESB, Tabuisierung, Psychoedukation, Parentifizierung

## Test plan
- [x] Lint + Build sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)