### PR TITLE
docs(tokens): breakpoint-konvention + typografie-dokumentation (issue #122)

### DIFF
--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -134,6 +134,16 @@
   --radius-pill: 999px;
 
   /* Shadow tokens */
+  /* Breakpoints (dokumentiert, nicht als CSS-Variablen nutzbar in @media).
+     CSS Custom Properties funktionieren nicht in @media-Queries.
+     Die Werte hier dienen als Single Source of Truth — alle @media-
+     Literale im Projekt MUESSEN diese Werte verwenden.
+     --breakpoint-sm: 30rem    (480px — selten, nur Netzwerk-Grid)
+     --breakpoint-md: 48rem    (768px — Haupt-Breakpoint Mobile→Tablet)
+     --breakpoint-lg: 64rem    (1024px — Haupt-Breakpoint Tablet→Desktop)
+     --breakpoint-xl: 80rem    (1280px — breit, nur Netzwerk-Karte)
+  */
+
   /* Overlay */
   --overlay-scrim: rgba(47, 47, 40, 0.32);
 


### PR DESCRIPTION
## Summary

Issue #122, Punkte 2+3:
- **Breakpoints**: als dokumentierte Konstanten in tokens.css (CSS-Variablen in @media nicht nutzbar)
- **Typografie-Skala**: implizite Skala (~20 Literale) dokumentiert statt mechanisch refactored

Punkt 1 (Kontrast-Audit) als separates Follow-up.

## Test plan
- [x] Lint + Build sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)