### PR TITLE
ux(print+css): handout print-header/footer + ausfüllbare felder

### DIFF
--- a/src/styles/app-global.css
+++ b/src/styles/app-global.css
@@ -614,7 +614,52 @@
     font-size: 9.5pt;
   }
 
-  /* 10. Vignetten-Print-Hinweis (V1 aus Audit 11) ------------------------ *
+  /* 10. Handout Print-Header/Footer ---------------------------------------- *
+   * Titel oben links, Seitenzahl unten rechts auf jeder gedruckten Seite.
+   * Nutzt @page-Margin-Boxen (CSS Paged Media Level 3). Browser-Support:
+   * Chromium + Safari mit Einschränkungen; als Enhancement, nicht als
+   * harte Abhängigkeit.
+   */
+  @page {
+    margin: 15mm;
+    @top-left {
+      content: 'Eltern im Beratungskontext';
+      font-size: 7pt;
+      color: #999;
+    }
+    @bottom-right {
+      content: counter(page);
+      font-size: 7pt;
+      color: #999;
+    }
+  }
+
+  /* 11. Ausfüllbare Felder visuell markieren ------------------------------ *
+   * Felder in Handouts (H-1 Notfallplan, H-5 Schule) bekommen eine
+   * gestrichelte Linie, damit auf Papier klar ist: hier reinschreiben.
+   */
+  .ui-material-handout__field-box {
+    border: 1pt dashed #999 !important;
+    background: #fff !important;
+    min-height: 18mm;
+    padding: 3mm 4mm !important;
+  }
+  .ui-material-handout__field-box--large {
+    min-height: 30mm;
+  }
+  .ui-material-handout__placeholder {
+    color: #bbb !important;
+    font-style: italic;
+    font-size: 9pt;
+  }
+  .ui-material-handout__checkbox {
+    font-size: 14pt;
+  }
+  .ui-material-handout__check-item {
+    page-break-inside: avoid;
+  }
+
+  /* 12. Vignetten-Print-Hinweis (V1 aus Audit 11) ------------------------ *
    * Die Vignetten-Seite ist bewusst nicht druckbar. Der Hinweis erscheint
    * zentral und ruhig auf der ansonsten leeren Druckseite.
    */

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -2432,6 +2432,93 @@
   line-height: var(--line-height-copy);
 }
 
+/* Ausfüllbare Felder (H-5 Schule, ggf. H-1 Notfallplan) */
+.ui-material-handout__field-box {
+  border: 1px dashed var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+  min-height: 3rem;
+  background: var(--surface-app);
+}
+
+.ui-material-handout__field-box--large {
+  min-height: 5rem;
+}
+
+.ui-material-handout__placeholder {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  font-style: italic;
+  line-height: var(--line-height-copy);
+}
+
+/* Checkliste (H-5 Schule: Support-Items) */
+.ui-material-handout__checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.ui-material-handout__check-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  line-height: var(--line-height-copy);
+}
+
+.ui-material-handout__checkbox {
+  flex: none;
+  font-size: 1.1rem;
+  color: var(--text-muted);
+}
+
+/* Callout-Box (H-5: Boundary-Hinweis) */
+.ui-material-handout__callout {
+  background: var(--surface-note);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  border-left: 3px solid var(--accent-primary);
+}
+
+/* Kontaktliste (H-5 Schule, H-6 Behandlungsteam) */
+.ui-material-handout__contacts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.ui-material-handout__contact {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-app);
+}
+
+.ui-material-handout__contact-name {
+  margin: 0;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.ui-material-handout__contact-detail {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.ui-material-handout__contact-number {
+  font-weight: 700;
+  color: var(--accent-primary-strong);
+}
+
 .ui-material-handout__lines {
   display: grid;
   gap: var(--space-3);


### PR DESCRIPTION
## Summary

Drei Quick-Wins für Handout-Qualität:

1. **Print-Header/Footer** via \`@page\`: Titel oben links, Seitenzahl unten rechts
2. **Ausfüllbare Felder** im Print-CSS: gestrichelte Linien, kursive Platzhalter, grössere Checkboxen
3. **Bildschirm-Styling** für H-5 (Schule) + H-6 (Behandlungsteam): field-box, checklist, callout, contacts

## Test plan
- [x] Lint + Build sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)