### PR TITLE
fix(print): ausfüllbare Felder als echte Schreibflächen

### DIFF
--- a/src/styles/app-global.css
+++ b/src/styles/app-global.css
@@ -382,7 +382,8 @@
     color: #000;
   }
   .ui-material-handout__line {
-    border-bottom: 1pt solid #333;
+    height: 7mm;
+    border-bottom: 0.5pt solid #333;
   }
   .ui-material-handout__section-title {
     font-size: 13pt;
@@ -657,12 +658,18 @@
    */
   .ui-material-handout__field-box {
     border: 1pt dashed #999 !important;
-    background: #fff !important;
-    min-height: 18mm;
+    background: #fff repeating-linear-gradient(
+      to bottom,
+      transparent,
+      transparent 6.5mm,
+      #ccc 6.5mm,
+      #ccc 7mm
+    ) !important;
+    min-height: 21mm;
     padding: 3mm 4mm !important;
   }
   .ui-material-handout__field-box--large {
-    min-height: 30mm;
+    min-height: 35mm;
   }
   .ui-material-handout__placeholder {
     color: #bbb !important;


### PR DESCRIPTION
## Summary
- **Linien-Hintergrund** in Field-Boxes via `repeating-linear-gradient` — gedruckt sehen die Felder aus wie liniertes Papier
- **Grössere Schreibflächen**: min-height 18→21mm (normal), 30→35mm (gross)
- **H-1 Notfallplan**: Linien auf 7mm Zeilenhöhe für Handschrift optimiert

Schritt 4 (letzter) des Handout-Qualitätsplans.

## Test plan
- [ ] Print H-1: Linien haben genug Platz für Handschrift
- [ ] Print H-5: Field-Boxes zeigen Linien-Hintergrund
- [ ] Build: `npm run build` erfolgreich

🤖 Generated with [Claude Code](https://claude.com/claude-code)