### PR TITLE
fix(content): KESB-Selbstmeldung aus H-6 entfernt

### DIFF
--- a/src/data/materialContent.js
+++ b/src/data/materialContent.js
@@ -796,7 +796,6 @@ export const MATERIAL_HANDOUTS = [
         { action: 'Ansprechperson wechseln', detail: 'Fragen Sie nach einer anderen Fachperson im Team — das ist kein Affront, sondern Alltag.' },
         { action: 'Ombudsstelle kontaktieren', detail: 'Jede Klinik hat eine Beschwerde- oder Ombudsstelle. Dort können Sie neutral vermittelte Unterstützung bekommen.' },
         { action: 'Pro Mente Sana anrufen', detail: 'Kostenlose Rechtsberatung für Betroffene und Angehörige (0848 800 858).' },
-        { action: 'KESB-Selbstmeldung', detail: 'Wenn Sie sich Sorgen um Kinder machen und das Team nicht reagiert, können Sie sich direkt an die KESB (Kindes- und Erwachsenenschutzbehörde) wenden. Das ist kein Denunzieren — es ist Verantwortung.' },
       ],
     },
     disclaimer:


### PR DESCRIPTION
## Summary
- KESB-Selbstmeldung aus der Eskalations-Liste in H-6 (rights-overview) gestrichen
- Begründung: zu kritisch für ein Weitergabe-Handout ohne fachliche Begleitung — KESB-Pfade gehören in den Fachpersonen-Kontext

## Test plan
- [ ] Material-Tab → H-6 Eskalation zeigt nur 3 Items (Ansprechperson, Ombudsstelle, Pro Mente Sana)
- [ ] Build erfolgreich

🤖 Generated with [Claude Code](https://claude.com/claude-code)