### PR TITLE
feat(design): Surface-Variation für visuellen Sektions-Rhythmus

### DIFF
--- a/src/data/glossaryContent.js
+++ b/src/data/glossaryContent.js
@@ -22,6 +22,7 @@
 export const GLOSSARY_GROUPS = [
   {
     id: 'glossar-sprache',
+    surface: 'plain',
     eyebrow: 'Cluster 1',
     title: 'Sprache im Kontakt mit Eltern, Kindern und Bezugspersonen',
     description:
@@ -119,6 +120,7 @@ export const GLOSSARY_GROUPS = [
   },
   {
     id: 'glossar-schutz',
+    surface: 'subtle',
     eyebrow: 'Cluster 2',
     title: 'Schutz, Risiko und fachliche Schwellen',
     description:
@@ -226,6 +228,7 @@ export const GLOSSARY_GROUPS = [
   },
   {
     id: 'glossar-netzwerk',
+    surface: 'warm',
     eyebrow: 'Cluster 3',
     title: 'Netzwerk, Koordination und verbindliche Zusammenarbeit',
     description:

--- a/src/data/materialContent.js
+++ b/src/data/materialContent.js
@@ -838,6 +838,7 @@ export const MATERIAL_CLUSTERS = [
   {
     id: 'material-verstehen',
     audience: 'angehoerige',
+    surface: 'plain',
     eyebrow: 'Cluster 1',
     title: 'Belastung verstehen, ohne sich vorschnell schuldig zu machen',
     description:
@@ -874,6 +875,7 @@ export const MATERIAL_CLUSTERS = [
   {
     id: 'material-grenzen',
     audience: 'angehoerige',
+    surface: 'subtle',
     eyebrow: 'Cluster 2',
     title: 'Grenzen, Verantwortung und legitimer Selbstschutz',
     description:
@@ -910,6 +912,7 @@ export const MATERIAL_CLUSTERS = [
   {
     id: 'material-zusammenarbeit',
     audience: 'angehoerige',
+    surface: 'warm',
     legalDisclaimer: true,
     eyebrow: 'Cluster 3',
     title: 'Zusammenarbeit, Mitsprache und der nächste sinnvolle Schritt',
@@ -953,6 +956,7 @@ export const MATERIAL_CLUSTERS = [
     // (spezifische Schutzfaktoren: Krankheitswissen + offener Umgang).
     id: 'material-kinder',
     audience: 'eltern',
+    surface: 'plain',
     eyebrow: 'Cluster 4',
     title: 'Mit Kindern über die Erkrankung sprechen',
     description:
@@ -1012,6 +1016,7 @@ export const MATERIAL_CLUSTERS = [
     // an Cluster 4 an, das Grundlagen der Kinder-Aufklärung behandelt.
     id: 'material-altersgerecht',
     audience: 'eltern',
+    surface: 'subtle',
     eyebrow: 'Cluster 5',
     title: 'Altersgerecht erklären — was Kinder in welchem Alter brauchen',
     description:
@@ -1058,6 +1063,7 @@ export const MATERIAL_CLUSTERS = [
     // Eigenständig formuliert, keine wörtliche Übernahme.
     id: 'material-formulierungshilfen',
     audience: 'eltern',
+    surface: 'warm',
     eyebrow: 'Cluster 6',
     title: 'Formulierungshilfen — psychische Erkrankungen kindgerecht erklären',
     description:

--- a/src/sections/EvidenceSection.jsx
+++ b/src/sections/EvidenceSection.jsx
@@ -192,6 +192,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
   const zones = [
     {
       id: 'evidenz-verstehen',
+      surface: 'plain',
       eyebrow: 'Kapitel 1',
       title: 'Warum das Thema',
       accent: 'früh in die Behandlung gehört',
@@ -242,6 +243,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
     },
     {
       id: 'evidenz-mit-kindern-sprechen',
+      surface: 'subtle',
       eyebrow: 'Kapitel 2',
       title: 'Mit Kindern sprechen –',
       accent: 'klar, altersgerecht und entlastend',
@@ -290,6 +292,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
     },
     {
       id: 'evidenz-mit-eltern-arbeiten',
+      surface: 'warm',
       eyebrow: 'Kapitel 3',
       title: 'Mit Eltern arbeiten –',
       accent: 'respektvoll, transparent und alltagsnah',
@@ -343,6 +346,7 @@ export default function EvidenceSection({ downloadResources = [] }) {
     },
     {
       id: 'evidenz-handeln-und-vernetzen',
+      surface: 'subtle',
       eyebrow: 'Kapitel 4',
       title: 'Handeln und vernetzen –',
       accent: 'mit Schutzfaktoren, Angeboten und nächsten Schritten',

--- a/src/sections/ToolboxSection.jsx
+++ b/src/sections/ToolboxSection.jsx
@@ -359,6 +359,7 @@ export default function ToolboxSection({
     () => [
       {
         id: 'acute-crisis',
+        surface: 'plain',
         sectionRef: acuteCrisisSectionRef,
         eyebrow: 'Akute Krise',
         titlePrefix: 'Sofort handeln bei',
@@ -394,6 +395,7 @@ export default function ToolboxSection({
       },
       {
         id: 'safety-plan',
+        surface: 'subtle',
         sectionRef: safetyPlanSectionRef,
         eyebrow: 'Krisenvorsorge',
         titlePrefix: 'Ein kurzer',
@@ -448,6 +450,7 @@ export default function ToolboxSection({
       },
       {
         id: 'child-protection',
+        surface: 'warm',
         sectionRef: childProtectionSectionRef,
         legalDisclaimer: true,
         legalDisclaimerCantonal: true,
@@ -474,6 +477,7 @@ export default function ToolboxSection({
       },
       {
         id: 'addiction',
+        surface: 'subtle',
         sectionRef: addictionSectionRef,
         eyebrow: 'Sucht und Komorbidität',
         titlePrefix: 'Substanzkonsum und psychische Symptome',
@@ -496,6 +500,7 @@ export default function ToolboxSection({
       },
       {
         id: 'rights',
+        surface: 'plain',
         sectionRef: rightsSectionRef,
         legalDisclaimer: true,
         eyebrow: 'Rolle und Rechte',

--- a/src/templates/ToolboxPageTemplate.jsx
+++ b/src/templates/ToolboxPageTemplate.jsx
@@ -106,7 +106,7 @@ function PathwaySection({ pathway }) {
   if (!pathway) return null;
 
   return (
-    <Section spacing="tight" surface="subtle" className="no-print">
+    <Section spacing="tight" surface="warm" className="no-print">
       <div className="ui-stack ui-stack--loose">
         <SectionHeader
           eyebrow={pathway.eyebrow}
@@ -297,7 +297,7 @@ function PracticeBlocksSection({ practice }) {
   if (!practice) return null;
 
   return (
-    <Section spacing="tight" surface="subtle" className="no-print">
+    <Section spacing="tight" surface="warm" className="no-print">
       <div className="ui-stack ui-stack--loose">
         <SectionHeader
           eyebrow={practice.eyebrow}


### PR DESCRIPTION
## Summary
- **Alternating plain/subtle/warm** Hintergründe auf 4 Tabs (Evidenz, Glossar, Material, Toolbox)
- Behebt Audit-Finding 2.5 (Dunkel/Hell-Wechsel) + 5.1 (visueller Rhythmus)
- Section.jsx `surface`-Prop war bereits vorhanden — nur `surface`-Werte in Daten/Sections ergänzt
- Toolbox: Pathway + Practice von `subtle` → `warm` geändert, um 3× subtle-Clumping aufzubrechen

## Test plan
- [ ] Evidenz: Kapitel alternieren sichtbar (plain → subtle → warm → subtle)
- [ ] Glossar: 3 Cluster mit unterschiedlichen Hintergründen
- [ ] Material: 6 Cluster alternierend
- [ ] Toolbox: Kein 3× subtle hintereinander mehr
- [ ] Build: `npm run build` erfolgreich

🤖 Generated with [Claude Code](https://claude.com/claude-code)