### PR TITLE
feat(design): Full-Bleed Sections + CSS-Decoratives

### DIFF
--- a/src/components/ui/Section.jsx
+++ b/src/components/ui/Section.jsx
@@ -50,6 +50,7 @@ const Section = forwardRef(function Section(
     width = 'default',
     spacing = 'standard',
     surface = 'plain',
+    bleed = false,
     inset = true,
     className = '',
     children,
@@ -75,15 +76,29 @@ const Section = forwardRef(function Section(
       : spacing === 'wide'
         ? 'ui-section ui-section--wide'
         : 'ui-section';
-  const surfaceClass =
-    surface === 'subtle' || surface === 'muted'
-      ? 'ui-section__surface ui-section__surface--subtle'
-      : surface === 'warm'
-        ? 'ui-section__surface ui-section__surface--warm'
-        : surface === 'accent'
-          ? 'ui-section__surface ui-section__surface--accent'
-          : 'ui-section__surface';
 
+  const surfaceVariant =
+    surface === 'subtle' || surface === 'muted'
+      ? '--subtle'
+      : surface === 'warm'
+        ? '--warm'
+        : surface === 'accent'
+          ? '--accent'
+          : '';
+
+  // Bleed-Modus: Hintergrund auf volle Viewport-Breite, Content im Container.
+  // Kein border-radius, kein border, kein box-shadow — wirkt als Band.
+  if (bleed) {
+    const bleedClass = `ui-section--bleed ui-section--bleed${surfaceVariant || '--plain'}`;
+    const sectionClasses = [spacingClass, bleedClass, 'reveal-on-scroll', className].filter(Boolean).join(' ');
+    return (
+      <Tag ref={combinedRef} className={sectionClasses} {...props}>
+        <Container width={width}>{children}</Container>
+      </Tag>
+    );
+  }
+
+  const surfaceClass = `ui-section__surface${surfaceVariant ? ` ui-section__surface${surfaceVariant}` : ''}`;
   const sectionClasses = [spacingClass, 'reveal-on-scroll', className].filter(Boolean).join(' ');
   const content = inset ? <div className={surfaceClass}>{children}</div> : children;
 

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -68,6 +68,48 @@
   border-color: var(--border-default);
 }
 
+/* Bleed-Modus: Hintergrund auf volle Viewport-Breite (kein border-radius,
+   kein border, kein box-shadow). Wirkt als horizontales Band, das den
+   visuellen Rhythmus bricht. Content bleibt im Container. */
+.ui-section--bleed {
+  padding-inline: var(--section-padding-inline);
+}
+
+.ui-section--bleed--plain {
+  background: var(--surface-app);
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.ui-section--bleed--subtle {
+  background: var(--surface-panel);
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.ui-section--bleed--warm {
+  background: color-mix(in srgb, var(--surface-app) 70%, var(--surface-muted) 30%);
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.ui-section--bleed--accent {
+  background: var(--surface-note);
+  border-top: 1px solid var(--border-default);
+  border-bottom: 1px solid var(--border-default);
+}
+
+/* Dekorativer Gradient-Akzent auf Bleed-Sections: sehr subtiler radialer
+   Gradient in der oberen Ecke, der Tiefe und Wärme erzeugt. */
+.ui-section--bleed--subtle,
+.ui-section--bleed--warm {
+  background-image: radial-gradient(
+    ellipse 60% 80% at 100% 0%,
+    color-mix(in srgb, var(--accent-primary-soft) 8%, transparent 92%),
+    transparent 70%
+  );
+}
+
 .ui-eyebrow {
   display: inline-flex;
   align-items: center;

--- a/src/templates/EvidencePageTemplate.jsx
+++ b/src/templates/EvidencePageTemplate.jsx
@@ -93,7 +93,7 @@ function ChapterOverview({ chapterOverview }) {
 
   return (
     <>
-      <Section spacing="tight" surface="subtle" className="no-print">
+      <Section spacing="tight" surface="subtle" bleed className="no-print">
         <div className="ui-stack ui-stack--loose">
           <SectionHeader
             eyebrow={chapterOverview.eyebrow}

--- a/src/templates/MaterialPageTemplate.jsx
+++ b/src/templates/MaterialPageTemplate.jsx
@@ -69,7 +69,7 @@ function MaterialCluster({ cluster, audienceBadge }) {
  */
 function MaterialClusterBlockHeader({ audience, surface = 'subtle' }) {
   return (
-    <Section spacing="tight" surface={surface}>
+    <Section spacing="tight" surface={surface} bleed>
       <div className="ui-stack ui-stack--tight ui-material-cluster-block__header">
         <div className="ui-badge-row">
           <span className="ui-badge ui-badge--soft" data-audience={audience.id}>

--- a/src/templates/ToolboxPageTemplate.jsx
+++ b/src/templates/ToolboxPageTemplate.jsx
@@ -14,7 +14,7 @@ function AssessmentPanel({ assessment, scoreStatusId }) {
   if (!assessment) return null;
 
   return (
-    <Section spacing="tight" surface="subtle" className="no-print">
+    <Section spacing="tight" surface="subtle" bleed className="no-print">
       <div className="ui-stack ui-stack--loose">
         <div className="ui-split">
           <div className="ui-stack ui-stack--tight">


### PR DESCRIPTION
## Summary
- **Neues `bleed`-Prop** auf Section.jsx: Hintergrund full-width, Content contained
- **3 Tabs** mit Bleed-Sections: Evidenz (ChapterOverview), Toolbox (Assessment), Material (Audience-Headers)
- **CSS Decoratives**: Subtiler radialer Gradient (8% accent-primary-soft) auf bleed-subtle/warm für Tiefe
- Behebt Audit-Findings 5.6 (Full-Width-Elemente) + 6.2 (dekorative CSS-Elemente)

## Test plan
- [ ] Evidenz: Kapitelübersicht erstreckt sich über volle Breite
- [ ] Toolbox: Assessment-Band full-bleed mit subtilen Borders
- [ ] Material: Audience-Trennbänder full-bleed
- [ ] Mobile: Bleed-Sections passen sich an (kein horizontaler Overflow)
- [ ] Build erfolgreich

🤖 Generated with [Claude Code](https://claude.com/claude-code)