### PR TITLE
fix(design): line-height-heading + tote Footer-Tokens + Hero min-height

### DIFF
--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -915,6 +915,7 @@
   background: var(--surface-hero);
   box-shadow: none;
   overflow: clip;
+  min-height: max(70vh, 28rem);
 }
 
 .ui-hero__inner {
@@ -3814,6 +3815,10 @@
 }
 
 @media (max-width: 64rem) {
+  .ui-hero-shell {
+    min-height: auto;
+  }
+
   .ui-hero__inner,
   .ui-split {
     grid-template-columns: 1fr;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -43,9 +43,7 @@
   --footer-badge-border: #e4d2c1;
   --footer-badge-text: #7a4c35;
   --footer-text-warm: #5a4a3f;
-  --footer-text-muted: #8a705f;
   --footer-text-inverse: #fff7ef;
-  --footer-text-inverse-soft: #d9cabb;
   --footer-text-inverse-strong: #332a24;
 
   /* Selection-Paar: warmer Highlight statt Browser-Default. */
@@ -101,6 +99,7 @@
   --font-size-5xl: 3rem;
 
   --line-height-tight: 1.2;
+  --line-height-heading: 1.3;
   --line-height-snug: 1.35;
   --line-height-copy: 1.7;
   --line-height-relaxed: 1.8;


### PR DESCRIPTION
## Summary
- **`--line-height-heading: 1.3`** in tokens.css definiert — war 7× referenziert aber nie deklariert
- **Tote Footer-Tokens entfernt**: `--footer-text-muted` + `--footer-text-inverse-soft` (unter WCAG AA, nirgends aktiv genutzt)
- **Hero min-height**: `max(70vh, 28rem)` auf Desktop für mehr Präsenz, `auto` auf Mobile

Behebt Audit-Findings 1.5 (Hero Whitespace), 2.2 (Footer-Kontrast) und technische Schuld (undefinierter Token).

## Test plan
- [ ] Desktop: Hero nimmt mindestens 70% Viewport-Höhe ein
- [ ] Mobile (≤64rem): Hero bleibt content-driven, kein erzwungenes Scrollen
- [ ] Headings mit `--line-height-heading` haben jetzt 1.3 statt Browser-Default 1.2
- [ ] Build erfolgreich

🤖 Generated with [Claude Code](https://claude.com/claude-code)