### PR TITLE
feat(design): Sektions-Trenner + Warm-Gradient + ClosingSections für 3 Tabs

### DIFF
--- a/src/sections/ElearningSection.jsx
+++ b/src/sections/ElearningSection.jsx
@@ -4,6 +4,7 @@ import heroIllustration from '../assets/illustration-learning.webp';
 import { E_MODULES } from '../data/learningContent';
 import LearningPageTemplate from '../templates/LearningPageTemplate';
 import { getPageHeadingId } from '../utils/appHelpers';
+import { createClosingSectionModel } from '../utils/closingModel';
 import { useAppState } from '../context/useAppState';
 
 export default function ElearningSection() {
@@ -117,12 +118,32 @@ export default function ElearningSection() {
     items: moduleItems,
   };
 
+  const closingSection = createClosingSectionModel({
+    id: 'lernmodule-weiter',
+    eyebrow: 'Weiterarbeit',
+    title: 'Vom Modul',
+    accent: 'in die Praxis.',
+    paragraphs: [
+      'Die Lernmodule geben Orientierung — der Transfer passiert im Gespräch, in der Fallbesprechung und im Alltag mit belasteten Familien.',
+    ],
+    relatedLinks: {
+      eyebrow: 'Nächste Schritte',
+      title: 'Direkt weiterarbeiten',
+      items: [
+        { label: 'Vignetten: Trainingsfälle durchspielen', target: 'vignetten' },
+        { label: 'Toolbox: Orientierung und Triage', target: 'toolbox' },
+        { label: 'Glossar: Begriffe nachschlagen', target: 'glossar' },
+      ],
+    },
+  });
+
   return (
     <LearningPageTemplate
       hero={hero}
       pageHeadingId={getPageHeadingId('lernmodule')}
       sequence={sequence}
       modulesSection={modulesSection}
+      closingSection={closingSection}
     />
   );
 }

--- a/src/sections/GlossarSection.jsx
+++ b/src/sections/GlossarSection.jsx
@@ -3,8 +3,28 @@ import glossarIllustration from '../assets/illustration-glossar.webp';
 import { GLOSSARY_GROUPS, GLOSSARY_HERO, GLOSSARY_INTRO } from '../data/glossaryContent';
 import GlossarPageTemplate from '../templates/GlossarPageTemplate';
 import { getPageHeadingId } from '../utils/appHelpers';
+import { createClosingSectionModel } from '../utils/closingModel';
 
 export default function GlossarSection() {
+  const closingSection = createClosingSectionModel({
+    id: 'glossar-weiter',
+    eyebrow: 'Weiterarbeit',
+    title: 'Begriffe klären,',
+    accent: 'dann anwenden.',
+    paragraphs: [
+      'Das Glossar ist als Nachschlagewerk gedacht — nicht als Leseliste. Wenn ein Begriff klar ist, liegt der nächste Schritt in der Praxis: im Gespräch, in der Einschätzung, in der Vernetzung.',
+    ],
+    relatedLinks: {
+      eyebrow: 'Nächste Schritte',
+      title: 'Direkt weiterarbeiten',
+      items: [
+        { label: 'Toolbox: Orientierung und Triage', target: 'toolbox' },
+        { label: 'Evidenz: Fachliche Grundlagen', target: 'evidenz' },
+        { label: 'Material: Handouts für das Gespräch', target: 'material' },
+      ],
+    },
+  });
+
   return (
     <GlossarPageTemplate
       hero={{
@@ -18,6 +38,7 @@ export default function GlossarSection() {
       pageHeadingId={getPageHeadingId('glossar')}
       intro={GLOSSARY_INTRO}
       groups={GLOSSARY_GROUPS}
+      closingSection={closingSection}
     />
   );
 }

--- a/src/sections/NetworkSection.jsx
+++ b/src/sections/NetworkSection.jsx
@@ -12,6 +12,7 @@ import {
 import { FACHSTELLEN } from '../data/fachstellenContent';
 import NetworkPageTemplate from '../templates/NetworkPageTemplate';
 import { getPageHeadingId } from '../utils/appHelpers';
+import { createClosingSectionModel } from '../utils/closingModel';
 import { useAppState } from '../context/useAppState';
 
 const LENS_SUMMARY = {
@@ -177,12 +178,32 @@ export default function NetworkSection() {
     nextStepText: LENS_NEXT_STEP[networkLens] ?? LENS_NEXT_STEP.all,
   };
 
+  const closingSection = createClosingSectionModel({
+    id: 'netzwerk-weiter',
+    eyebrow: 'Weiterarbeit',
+    title: 'Netzwerk lesen,',
+    accent: 'Lücken schliessen.',
+    paragraphs: [
+      'Die Netzwerkkarte und das Fachstellenverzeichnis geben Orientierung. Der nächste Schritt liegt darin, konkrete Kontakte aufzunehmen und Zuständigkeiten zu klären.',
+    ],
+    relatedLinks: {
+      eyebrow: 'Nächste Schritte',
+      title: 'Direkt weiterarbeiten',
+      items: [
+        { label: 'Toolbox: Orientierung und Triage', target: 'toolbox' },
+        { label: 'Material: Handouts für das Gespräch', target: 'material' },
+        { label: 'Evidenz: Fachliche Grundlagen', target: 'evidenz' },
+      ],
+    },
+  });
+
   return (
     <NetworkPageTemplate
       hero={hero}
       pageHeadingId={getPageHeadingId('netzwerk')}
       directory={directory}
       mapping={mapping}
+      closingSection={closingSection}
     />
   );
 }

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -46,6 +46,19 @@
   padding-bottom: var(--section-tight);
 }
 
+/* Dekorativer Sektions-Trenner: zentrierte Akzentlinie zwischen Sections.
+   Subtiler als ein border, staerker als reiner Whitespace. Erscheint nur
+   zwischen aufeinanderfolgenden Sections (nicht vor der ersten). */
+.ui-section + .ui-section::before {
+  content: '';
+  display: block;
+  width: 3rem;
+  height: 2px;
+  margin: 0 auto var(--section-tight);
+  background: color-mix(in srgb, var(--accent-primary-soft) 50%, transparent 50%);
+  border-radius: 1px;
+}
+
 .ui-section__surface {
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-2xl);
@@ -60,7 +73,13 @@
 }
 
 .ui-section__surface--warm {
-  background: color-mix(in srgb, var(--surface-app) 70%, var(--surface-muted) 30%);
+  background:
+    radial-gradient(
+      ellipse 50% 70% at 95% 10%,
+      color-mix(in srgb, var(--accent-primary-soft) 6%, transparent 94%),
+      transparent 60%
+    ),
+    color-mix(in srgb, var(--surface-app) 70%, var(--surface-muted) 30%);
 }
 
 .ui-section__surface--accent {

--- a/src/templates/GlossarPageTemplate.jsx
+++ b/src/templates/GlossarPageTemplate.jsx
@@ -1,3 +1,4 @@
+import ClosingSection from '../components/closing/ClosingSection';
 import EditorialIndex from '../components/ui/EditorialIndex';
 import EditorialIntro from '../components/ui/EditorialIntro';
 import Container from '../components/ui/Container';
@@ -51,7 +52,7 @@ function GlossarGroup({ group }) {
   );
 }
 
-export default function GlossarPageTemplate({ hero, pageHeadingId, intro, groups = [] }) {
+export default function GlossarPageTemplate({ hero, pageHeadingId, intro, groups = [], closingSection }) {
   const letterIndex = buildGlossarLetterIndex(groups);
 
   return (
@@ -73,6 +74,9 @@ export default function GlossarPageTemplate({ hero, pageHeadingId, intro, groups
       {groups.map((group) => (
         <GlossarGroup key={group.id} group={group} />
       ))}
+      {closingSection ? (
+        <ClosingSection section={closingSection} sectionId="glossar-weiter" surface="plain" />
+      ) : null}
     </div>
   );
 }

--- a/src/templates/LearningPageTemplate.jsx
+++ b/src/templates/LearningPageTemplate.jsx
@@ -1,4 +1,5 @@
 import { Brain, Check, Circle } from 'lucide-react';
+import ClosingSection from '../components/closing/ClosingSection';
 import Container from '../components/ui/Container';
 import PageHero from '../components/ui/PageHero';
 import Section from '../components/ui/Section';
@@ -146,7 +147,7 @@ function LearningModulesSection({ modulesSection }) {
   );
 }
 
-export default function LearningPageTemplate({ hero, pageHeadingId, sequence, modulesSection }) {
+export default function LearningPageTemplate({ hero, pageHeadingId, sequence, modulesSection, closingSection }) {
   return (
     <article className="ui-stack">
       <Container width="wide">
@@ -154,6 +155,9 @@ export default function LearningPageTemplate({ hero, pageHeadingId, sequence, mo
       </Container>
       <LearningFlowSection sequence={sequence} />
       <LearningModulesSection modulesSection={modulesSection} />
+      {closingSection ? (
+        <ClosingSection section={closingSection} sectionId="lernmodule-weiter" surface="plain" />
+      ) : null}
     </article>
   );
 }

--- a/src/templates/NetworkPageTemplate.jsx
+++ b/src/templates/NetworkPageTemplate.jsx
@@ -1,4 +1,5 @@
 import { ExternalLink, MapPin, Search, XCircle } from 'lucide-react';
+import ClosingSection from '../components/closing/ClosingSection';
 import Button from '../components/ui/Button';
 import Container from '../components/ui/Container';
 import Eyebrow from '../components/ui/Eyebrow';
@@ -485,7 +486,7 @@ function NetworkMapSection({ mapping }) {
   );
 }
 
-export default function NetworkPageTemplate({ hero, pageHeadingId, directory, mapping }) {
+export default function NetworkPageTemplate({ hero, pageHeadingId, directory, mapping, closingSection }) {
   return (
     <article className="ui-stack">
       <Container width="wide">
@@ -493,6 +494,9 @@ export default function NetworkPageTemplate({ hero, pageHeadingId, directory, ma
       </Container>
       <ResourceDirectorySection directory={directory} />
       <NetworkMapSection mapping={mapping} />
+      {closingSection ? (
+        <ClosingSection section={closingSection} sectionId="netzwerk-weiter" surface="plain" />
+      ) : null}
     </article>
   );
 }


### PR DESCRIPTION
## Summary
- **5.3 Sektions-Trennung**: Dekorativer Akzent-Trenner (3rem × 2px Blush-Linie) zwischen Sections via `::before`
- **6.2 + 6.4 Decoratives + Visual Weight**: Radialer Gradient-Akzent auf `warm`-Surface (nicht nur Bleed)
- **7.5 CTA-Platzierung**: ClosingSections mit relatedLinks für **Glossar**, **Lernmodule** und **Netzwerk** — vorher kein End-CTA

6 von 8 Tabs haben jetzt ClosingSections (vorher 3). Vignetten und Start bleiben bewusst ohne (Vignetten hat eigene Navigation, Start ist Landing).

## Test plan
- [ ] Glossar: ClosingSection am Ende mit 3 Anschlusswegen
- [ ] Lernmodule: ClosingSection am Ende mit Vignetten/Toolbox/Glossar-Links
- [ ] Netzwerk: ClosingSection am Ende mit Toolbox/Material/Evidenz-Links
- [ ] Sektions-Trenner: subtile Linie zwischen Sections sichtbar (z. B. Glossar-Cluster)
- [ ] Warm-Surface: leichter Gradient-Akzent in der oberen rechten Ecke
- [ ] Build erfolgreich

🤖 Generated with [Claude Code](https://claude.com/claude-code)