### PR TITLE
feat(nav): visuelle Tab-Gruppierung (Einstieg | Lernen | Anwenden)

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
 import { AlertTriangle, Check, Menu, Trash2, X } from 'lucide-react';
 import { TAB_ITEMS } from '../data/appShellContent';
 import Button from './ui/Button';
@@ -56,17 +56,19 @@ const Header = memo(function Header({
 
         <nav className="ui-nav ui-nav--desktop" aria-label="Hauptnavigation">
           {TAB_ITEMS.map((item) => (
-            <button
-              key={item.id}
-              type="button"
-              onClick={() => handleNavigate(item.id)}
-              className={`ui-nav__item haptic-btn ${activeTab === item.id ? 'is-active' : ''}`}
-              aria-current={activeTab === item.id ? 'page' : undefined}
-            >
-              <item.icon size={14} strokeWidth={2.1} aria-hidden="true" />
-              <span>{item.label}</span>
-              {item.audienceBadge ? <span className="ui-nav__badge">{item.audienceBadge}</span> : null}
-            </button>
+            <React.Fragment key={item.id}>
+              {item.navGroupStart ? <span className="ui-nav__separator" aria-hidden="true" /> : null}
+              <button
+                type="button"
+                onClick={() => handleNavigate(item.id)}
+                className={`ui-nav__item haptic-btn ${activeTab === item.id ? 'is-active' : ''}`}
+                aria-current={activeTab === item.id ? 'page' : undefined}
+              >
+                <item.icon size={14} strokeWidth={2.1} aria-hidden="true" />
+                <span>{item.label}</span>
+                {item.audienceBadge ? <span className="ui-nav__badge">{item.audienceBadge}</span> : null}
+              </button>
+            </React.Fragment>
           ))}
         </nav>
 
@@ -174,18 +176,20 @@ const Header = memo(function Header({
 
               <nav className="ui-nav ui-nav--mobile" aria-label="Mobile Navigation">
                 {TAB_ITEMS.map((item, index) => (
-                  <button
-                    key={item.id}
-                    ref={index === 0 ? firstMobileNavItemRef : undefined}
-                    type="button"
-                    onClick={() => handleNavigate(item.id)}
-                    className={`ui-nav__item haptic-btn ${activeTab === item.id ? 'is-active' : ''}`}
-                    aria-current={activeTab === item.id ? 'page' : undefined}
-                  >
-                    <item.icon size={18} strokeWidth={2.1} aria-hidden="true" />
-                    <span>{item.label}</span>
-                    {item.audienceBadge ? <span className="ui-nav__badge">{item.audienceBadge}</span> : null}
-                  </button>
+                  <React.Fragment key={item.id}>
+                    {item.navGroupStart ? <hr className="ui-nav__separator--mobile" aria-hidden="true" /> : null}
+                    <button
+                      ref={index === 0 ? firstMobileNavItemRef : undefined}
+                      type="button"
+                      onClick={() => handleNavigate(item.id)}
+                      className={`ui-nav__item haptic-btn ${activeTab === item.id ? 'is-active' : ''}`}
+                      aria-current={activeTab === item.id ? 'page' : undefined}
+                    >
+                      <item.icon size={18} strokeWidth={2.1} aria-hidden="true" />
+                      <span>{item.label}</span>
+                      {item.audienceBadge ? <span className="ui-nav__badge">{item.audienceBadge}</span> : null}
+                    </button>
+                  </React.Fragment>
                 ))}
               </nav>
             </div>

--- a/src/data/appShellContent.js
+++ b/src/data/appShellContent.js
@@ -74,6 +74,7 @@ export const TAB_ITEMS = [
   },
   {
     id: 'lernmodule',
+    navGroupStart: true,
     label: 'Lernmodule',
     icon: GraduationCap,
     footerNote: 'Kurzformate für Fachpraxis',
@@ -98,6 +99,7 @@ export const TAB_ITEMS = [
   },
   {
     id: 'material',
+    navGroupStart: true,
     label: 'Material',
     icon: CircleHelp,
     footerNote: 'Handouts für Patient:innen und Angehörige',

--- a/src/styles/primitives.css
+++ b/src/styles/primitives.css
@@ -1663,6 +1663,25 @@
     0 10px 24px rgba(76, 55, 39, 0.04);
 }
 
+/* Visueller Gruppentrenner zwischen Nav-Clustern (Einstieg | Lernen | Anwenden).
+   Desktop: vertikale 1px-Linie. Mobile-Drawer: horizontale Trennlinie. */
+.ui-nav__separator {
+  width: 1px;
+  height: 1.25rem;
+  margin-inline: 0.125rem;
+  background: color-mix(in srgb, var(--border-default) 60%, transparent 40%);
+  border-radius: 0.5px;
+  flex-shrink: 0;
+  align-self: center;
+}
+
+.ui-nav__separator--mobile {
+  border: none;
+  height: 1px;
+  margin: var(--space-2) var(--space-4);
+  background: color-mix(in srgb, var(--border-default) 40%, transparent 60%);
+}
+
 .ui-nav__item {
   min-height: var(--touch-target-min);
   border: 1px solid transparent;


### PR DESCRIPTION
## Summary
- **`navGroupStart`-Feld** auf TAB_ITEMS markiert Gruppenübergänge
- **3 Blöcke**: Einstieg (Start) | Lernen (Lernmodule, Training, Glossar) | Anwenden (Material, Evidenz, Toolbox, Netzwerk)
- **Mobile-Drawer**: horizontale Trennlinie zwischen den Gruppen sichtbar
- **Desktop-Nav**: vertikaler Separator vorbereitet (Desktop-Nav aktuell zugunsten Hamburger deaktiviert)
- Behebt Audit-Finding 4.1 (8 Tabs ohne Gruppierung schwer scanbar)

## Test plan
- [ ] Mobile: Menü öffnen → Trennlinie zwischen Glossar und Material sichtbar
- [ ] Mobile: Trennlinie zwischen Start und Lernmodule sichtbar
- [ ] Build erfolgreich

🤖 Generated with [Claude Code](https://claude.com/claude-code)